### PR TITLE
Split out user state implementation to abstract class for code share

### DIFF
--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -2,65 +2,54 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
-using Newtonsoft.Json;
 using osu.Game.Online.Spectator;
 
 namespace osu.Server.Spectator.Hubs
 {
     [UsedImplicitly]
     [Authorize]
-    public class SpectatorHub : Hub<ISpectatorClient>, ISpectatorServer
+    public class SpectatorHub : StatefulUserHub<ISpectatorClient, SpectatorState>, ISpectatorServer
     {
-        private readonly IDistributedCache cache;
-
-        private static readonly ConcurrentDictionary<int, SpectatorState> active_states = new ConcurrentDictionary<int, SpectatorState>();
-
-        public SpectatorHub(IDistributedCache cache)
+        public SpectatorHub([NotNull] IDistributedCache cache)
+            : base(cache)
         {
-            this.cache = cache;
         }
-
-        private int currentContextUserId => int.Parse(Context.UserIdentifier);
 
         public async Task BeginPlaySession(SpectatorState state)
         {
-            await updateUserState(state);
+            await UpdateLocalUserState(state);
 
-            Console.WriteLine($"User {currentContextUserId} beginning play session ({state})");
+            Console.WriteLine($"User {CurrentContextUserId} beginning play session ({state})");
 
             // let's broadcast to every player temporarily. probably won't stay this way.
-            await Clients.All.UserBeganPlaying(currentContextUserId, state);
+            await Clients.All.UserBeganPlaying(CurrentContextUserId, state);
         }
 
         public async Task SendFrameData(FrameDataBundle data)
         {
             Console.WriteLine($"Receiving frame data ({data.Frames.First()})..");
-            await Clients.Group(GetGroupId(currentContextUserId)).UserSentFrames(currentContextUserId, data);
+            await Clients.Group(GetGroupId(CurrentContextUserId)).UserSentFrames(CurrentContextUserId, data);
         }
 
         public async Task EndPlaySession(SpectatorState state)
         {
-            Console.WriteLine($"User {currentContextUserId} ending play session ({state})");
+            Console.WriteLine($"User {CurrentContextUserId} ending play session ({state})");
 
-            active_states.TryRemove(currentContextUserId, out var _);
-
-            await cache.RemoveAsync(GetStateId(currentContextUserId));
-            await Clients.All.UserFinishedPlaying(currentContextUserId, state);
+            await RemoveLocalUserState();
+            await Clients.All.UserFinishedPlaying(CurrentContextUserId, state);
         }
 
         public async Task StartWatchingUser(int userId)
         {
-            Console.WriteLine($"User {currentContextUserId} watching {userId}");
+            Console.WriteLine($"User {CurrentContextUserId} watching {userId}");
 
             // send the user's state if exists
-            var state = await getStateFromUser(userId);
+            var state = await GetStateFromUser(userId);
 
             if (state != null)
             {
@@ -77,53 +66,21 @@ namespace osu.Server.Spectator.Hubs
 
         public override async Task OnConnectedAsync()
         {
-            Console.WriteLine($"User {currentContextUserId} connected!");
-
             // for now, send *all* player states to users on connect.
             // we don't want this for long, but while the lazer user base is small it should be okay.
-            foreach (var kvp in active_states)
+            foreach (var kvp in ACTIVE_STATES)
                 await Clients.Caller.UserBeganPlaying(kvp.Key, kvp.Value);
 
             await base.OnConnectedAsync();
         }
 
-        public override async Task OnDisconnectedAsync(Exception exception)
+        protected override Task OnDisconnectedAsync(Exception exception, SpectatorState? state)
         {
-            Console.WriteLine($"User {currentContextUserId} disconnected!");
-
-            var state = await getStateFromUser(currentContextUserId);
-
             if (state != null)
-            {
-                // clean up user on disconnection
-                await EndPlaySession(state);
-            }
+                return EndPlaySession(state);
 
-            await base.OnDisconnectedAsync(exception);
+            return base.OnDisconnectedAsync(exception, state);
         }
-
-        private async Task updateUserState(SpectatorState state)
-        {
-            active_states.TryRemove(currentContextUserId, out var _);
-            active_states.TryAdd(currentContextUserId, state);
-
-            await cache.SetStringAsync(GetStateId(currentContextUserId), JsonConvert.SerializeObject(state));
-        }
-
-        private async Task<SpectatorState?> getStateFromUser(int userId)
-        {
-            var jsonString = await cache.GetStringAsync(GetStateId(userId));
-
-            if (jsonString == null)
-                return null;
-
-            // todo: error checking logic?
-            var state = JsonConvert.DeserializeObject<SpectatorState>(jsonString);
-
-            return state;
-        }
-
-        public static string GetStateId(int userId) => $"state:{userId}";
 
         public static string GetGroupId(int userId) => $"watch:{userId}";
     }

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -5,14 +5,11 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Caching.Distributed;
 using osu.Game.Online.Spectator;
 
 namespace osu.Server.Spectator.Hubs
 {
-    [UsedImplicitly]
-    [Authorize]
     public class SpectatorHub : StatefulUserHub<ISpectatorClient, SpectatorState>, ISpectatorServer
     {
         public SpectatorHub([NotNull] IDistributedCache cache)

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -4,12 +4,16 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Newtonsoft.Json;
 
 namespace osu.Server.Spectator.Hubs
 {
+    [UsedImplicitly]
+    [Authorize]
     public abstract class StatefulUserHub<TClient, TUserState> : Hub<TClient>
         where TUserState : class
         where TClient : class

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -50,7 +50,7 @@ namespace osu.Server.Spectator.Hubs
         {
             Console.WriteLine($"User {CurrentContextUserId} disconnected!");
 
-            var state = await GetStateFromUser(CurrentContextUserId);
+            var state = await GetLocalUserState();
 
             await OnDisconnectedAsync(exception, state);
 
@@ -67,6 +67,8 @@ namespace osu.Server.Spectator.Hubs
 
             await Cache.SetStringAsync(GetStateId(CurrentContextUserId), JsonConvert.SerializeObject(state));
         }
+
+        protected Task<TUserState?> GetLocalUserState() => GetStateFromUser(CurrentContextUserId);
 
         protected async Task RemoveLocalUserState()
         {

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+
+namespace osu.Server.Spectator.Hubs
+{
+    public abstract class StatefulUserHub<TClient, TUserState> : Hub<TClient>
+        where TUserState : class
+        where TClient : class
+    {
+        protected readonly IDistributedCache Cache;
+
+        protected static readonly ConcurrentDictionary<int, TUserState> ACTIVE_STATES = new ConcurrentDictionary<int, TUserState>();
+
+        protected StatefulUserHub(IDistributedCache cache)
+        {
+            this.Cache = cache;
+        }
+
+        /// <summary>
+        /// The osu! user id for the currently processing context.
+        /// </summary>
+        protected int CurrentContextUserId => int.Parse(Context.UserIdentifier);
+
+        public override Task OnConnectedAsync()
+        {
+            Console.WriteLine($"User {CurrentContextUserId} connected!");
+
+            return base.OnConnectedAsync();
+        }
+
+        /// <summary>
+        /// Called when a user disconnected, providing their last state.
+        /// </summary>
+        /// <param name="exception">A potential error which caused the disconnection.</param>
+        /// <param name="state">The last user state. May be null. This is automatically cleared on disconnection.</param>
+        protected virtual Task OnDisconnectedAsync(Exception exception, TUserState? state) => Task.CompletedTask;
+
+        public sealed override async Task OnDisconnectedAsync(Exception exception)
+        {
+            Console.WriteLine($"User {CurrentContextUserId} disconnected!");
+
+            var state = await GetStateFromUser(CurrentContextUserId);
+
+            await OnDisconnectedAsync(exception, state);
+
+            // clean up user on disconnection
+            if (state != null) await RemoveLocalUserState();
+
+            await base.OnDisconnectedAsync(exception);
+        }
+
+        protected async Task UpdateLocalUserState(TUserState state)
+        {
+            ACTIVE_STATES.TryRemove(CurrentContextUserId, out var _);
+            ACTIVE_STATES.TryAdd(CurrentContextUserId, state);
+
+            await Cache.SetStringAsync(GetStateId(CurrentContextUserId), JsonConvert.SerializeObject(state));
+        }
+
+        protected async Task RemoveLocalUserState()
+        {
+            ACTIVE_STATES.TryRemove(CurrentContextUserId, out var _);
+
+            await Cache.RemoveAsync(GetStateId(CurrentContextUserId));
+        }
+
+        protected async Task<TUserState?> GetStateFromUser(int userId)
+        {
+            var jsonString = await Cache.GetStringAsync(GetStateId(userId));
+
+            if (jsonString == null)
+                return null;
+
+            // todo: error checking logic?
+            var state = JsonConvert.DeserializeObject<TUserState>(jsonString);
+
+            return state;
+        }
+
+        public static string GetStateId(int userId) => $"state-{nameof(TClient)}:{userId}";
+    }
+}


### PR DESCRIPTION
Both multiplayer and spectators hubs can share the same underlying logic for managing user connection states. This splits that out so that can occur.