### PR TITLE
Add sample client implementation for multiplayer

### DIFF
--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -10,7 +10,7 @@ using osu.Game.Online.RealtimeMultiplayer;
 
 namespace SampleMultiplayerClient
 {
-    public class MultiplayerClient : IMultiplayerClient
+    public class MultiplayerClient : IStatefulMultiplayerClient
     {
         private readonly HubConnection connection;
 
@@ -38,9 +38,9 @@ namespace SampleMultiplayerClient
 
         public MultiplayerRoom? Room { get; private set; }
 
-        public async Task JoinRoom(long roomId)
+        public async Task<MultiplayerRoom> JoinRoom(long roomId)
         {
-            Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
+            return Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
         }
 
         public async Task LeaveRoom()

--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -10,7 +10,7 @@ using osu.Game.Online.RealtimeMultiplayer;
 
 namespace SampleMultiplayerClient
 {
-    public class MultiplayerClient : IStatefulMultiplayerClient
+    public class MultiplayerClient : IMultiplayerClient, IMultiplayerServer
     {
         private readonly HubConnection connection;
 

--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -38,8 +38,10 @@ namespace SampleMultiplayerClient
 
         public MultiplayerRoom? Room { get; private set; }
 
-        public async Task<MultiplayerRoom> JoinRoom(long roomId) =>
+        public async Task JoinRoom(long roomId)
+        {
             Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
+        }
 
         public async Task LeaveRoom()
         {

--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -1,0 +1,128 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
+using osu.Game.Online.RealtimeMultiplayer;
+
+namespace SampleMultiplayerClient
+{
+    public class MultiplayerClient : IMultiplayerClient
+    {
+        private readonly HubConnection connection;
+
+        public readonly int UserID;
+
+        public MultiplayerClient(HubConnection connection, int userId)
+        {
+            this.connection = connection;
+            UserID = userId;
+
+            // this is kind of SILLY
+            // https://github.com/dotnet/aspnetcore/issues/15198
+            connection.On<MultiplayerRoomState>(nameof(IMultiplayerClient.RoomStateChanged), ((IMultiplayerClient)this).RoomStateChanged);
+            connection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserJoined), ((IMultiplayerClient)this).UserJoined);
+            connection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserLeft), ((IMultiplayerClient)this).UserLeft);
+            connection.On<long>(nameof(IMultiplayerClient.HostChanged), ((IMultiplayerClient)this).HostChanged);
+            connection.On<MultiplayerRoomSettings>(nameof(IMultiplayerClient.SettingsChanged), ((IMultiplayerClient)this).SettingsChanged);
+            connection.On<long, MultiplayerUserState>(nameof(IMultiplayerClient.UserStateChanged), ((IMultiplayerClient)this).UserStateChanged);
+            connection.On(nameof(IMultiplayerClient.LoadRequested), ((IMultiplayerClient)this).LoadRequested);
+            connection.On(nameof(IMultiplayerClient.MatchStarted), ((IMultiplayerClient)this).MatchStarted);
+            connection.On(nameof(IMultiplayerClient.ResultsReady), ((IMultiplayerClient)this).ResultsReady);
+        }
+
+        public MultiplayerUserState State { get; private set; }
+
+        public MultiplayerRoom? Room { get; private set; }
+
+        public async Task<MultiplayerRoom> JoinRoom(long roomId) =>
+            Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
+
+        public async Task LeaveRoom()
+        {
+            await connection.InvokeAsync(nameof(IMultiplayerServer.LeaveRoom));
+            Room = null;
+        }
+
+        public Task TransferHost(long userId) =>
+            connection.InvokeAsync(nameof(IMultiplayerServer.TransferHost), userId);
+
+        public Task ChangeSettings(MultiplayerRoomSettings settings) =>
+            connection.InvokeAsync(nameof(IMultiplayerServer.ChangeSettings), settings);
+
+        public Task ChangeState(MultiplayerUserState newState) =>
+            connection.InvokeAsync(nameof(IMultiplayerServer.ChangeState), newState);
+
+        public Task StartMatch() =>
+            connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
+
+        Task IMultiplayerClient.RoomStateChanged(MultiplayerRoomState state)
+        {
+            Debug.Assert(Room != null);
+            Room.State = state;
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.UserJoined(MultiplayerRoomUser user)
+        {
+            Debug.Assert(Room != null);
+            Room.Users.Add(user);
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user)
+        {
+            Debug.Assert(Room != null);
+            Room.Users.Remove(user);
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.HostChanged(long userId)
+        {
+            Debug.Assert(Room != null);
+            Room.Host = Room.Users.FirstOrDefault(u => u.UserID == userId);
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
+        {
+            Debug.Assert(Room != null);
+            Room.Settings = newSettings;
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.UserStateChanged(long userId, MultiplayerUserState state)
+        {
+            if (userId == this.UserID)
+                State = state;
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.LoadRequested()
+        {
+            Console.WriteLine($"User {UserID} was requested to load");
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.MatchStarted()
+        {
+            Console.WriteLine($"User {UserID} was informed the game started");
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.ResultsReady()
+        {
+            Console.WriteLine($"User {UserID} was informed the results are ready");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -73,7 +73,7 @@ namespace SampleMultiplayerClient
                             break;
 
                         case "changestate":
-                            await targetClient.ChangeState(Enum.Parse<MultiplayerUserState>(args[0]));
+                            await targetClient.ChangeState(Enum.Parse<MultiplayerUserState>(args[0], true));
                             break;
 
                         case "startmatch":

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using osu.Framework.Utils;
+using osu.Game.Online.RealtimeMultiplayer;
+
+namespace SampleMultiplayerClient
+{
+    internal static class Program
+    {
+        private const long room_id = 1234;
+
+        public static async Task Main()
+        {
+            // ReSharper disable once CollectionNeverQueried.Local
+            var clients = new List<MultiplayerClient>();
+
+            for (int i = 1; i < 6; i++)
+                clients.Add(getConnectedClient(i));
+
+            while (true)
+            {
+                Console.WriteLine();
+
+                foreach (var c in clients)
+                {
+                    Console.WriteLine($"Client {c.UserID}  state: {c.State} room: {c.Room}");
+                }
+
+                Console.WriteLine("Usage: <client_id> <command> [params]");
+                Console.WriteLine("Valid commands [ JoinRoom LeaveRoom TransferHost ChangeSettings ChangeState ]");
+
+                Console.Write(">");
+
+                string input = Console.ReadLine();
+
+                try
+                {
+                    var pieces = input.Split(' ');
+
+                    if (pieces.Length < 2)
+                        continue;
+
+                    var args = pieces.Skip(2).ToArray();
+
+                    MultiplayerClient targetClient = clients.First(c => c.UserID == int.Parse(pieces[0]));
+
+                    switch (pieces[1].ToLower())
+                    {
+                        case "joinroom":
+                            await targetClient.JoinRoom(long.Parse(args[0]));
+                            break;
+
+                        case "leaveroom":
+                            await targetClient.LeaveRoom();
+                            break;
+
+                        case "transferhost":
+                            await targetClient.TransferHost(long.Parse(args[0]));
+                            break;
+
+                        case "changesettings":
+                            await targetClient.ChangeSettings(new MultiplayerRoomSettings { BeatmapID = RNG.Next(0, 65536) });
+                            break;
+
+                        case "changestate":
+                            await targetClient.ChangeState(Enum.Parse<MultiplayerUserState>(args[0]));
+                            break;
+
+                        default:
+                            Console.WriteLine("Unknown command");
+                            break;
+                    }
+                }
+                catch (HubException e)
+                {
+                    Console.WriteLine($"Server returned error: {e.Message}");
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Error performing action: {e}");
+                }
+            }
+
+            // ReSharper disable once FunctionNeverReturns
+        }
+
+        private static MultiplayerClient getConnectedClient(int userId)
+        {
+            var connection = new HubConnectionBuilder()
+                             .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; })
+                             .WithUrl("http://localhost:80/multiplayer", http => http.Headers.Add("user_id", userId.ToString()))
+                             .ConfigureLogging(logging =>
+                             {
+                                 // logging.AddFilter("Microsoft.AspNetCore.SignalR", LogLevel.Debug);
+                                 // logging.AddConsole();
+                             })
+                             .Build();
+
+            var client = new MultiplayerClient(connection, userId);
+
+            connection.Closed += async error =>
+            {
+                Console.WriteLine($"Connection closed with error:{error}");
+
+                await connection.StartAsync();
+            };
+
+            connection.Reconnected += id =>
+            {
+                Console.WriteLine($"Connected with id:{id}");
+                return Task.CompletedTask;
+            };
+
+            while (true)
+            {
+                try
+                {
+                    connection.StartAsync().Wait();
+                    break;
+                }
+                catch
+                {
+                    // try until connected
+                }
+            }
+
+            Console.WriteLine($"client {connection.ConnectionId} connected!");
+
+            return client;
+        }
+    }
+}

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -88,6 +89,9 @@ namespace SampleMultiplayerClient
                 {
                     Console.WriteLine($"Error performing action: {e}");
                 }
+
+                Thread.Sleep(50);
+                Console.WriteLine("Success!");
             }
 
             // ReSharper disable once FunctionNeverReturns

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -37,7 +37,7 @@ namespace SampleMultiplayerClient
                 }
 
                 Console.WriteLine("Usage: <client_id> <command> [params]");
-                Console.WriteLine("Valid commands [ JoinRoom LeaveRoom TransferHost ChangeSettings ChangeState ]");
+                Console.WriteLine("Valid commands [ JoinRoom LeaveRoom TransferHost ChangeSettings ChangeState StartMatch ]");
 
                 Console.Write(">");
 
@@ -74,6 +74,10 @@ namespace SampleMultiplayerClient
 
                         case "changestate":
                             await targetClient.ChangeState(Enum.Parse<MultiplayerUserState>(args[0]));
+                            break;
+
+                        case "startmatch":
+                            await targetClient.StartMatch();
                             break;
 
                         default:

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -82,7 +82,7 @@ namespace SampleMultiplayerClient
 
                         default:
                             Console.WriteLine("Unknown command");
-                            break;
+                            continue;
                     }
                 }
                 catch (HubException e)

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\osu\osu.Game\osu.Game.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -10,10 +10,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.9" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\osu\osu.Game\osu.Game.csproj" />
+        <PackageReference Include="ppy.osu.Game" Version="2020.1216.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.sln
+++ b/osu.Server.Spectator.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Server.Spectator.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleSpectatorClient", "SampleSpectatorClient\SampleSpectatorClient.csproj", "{E126B79F-50B9-4448-8DE6-564BB820EE9D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleMultiplayerClient", "SampleMultiplayerClient\SampleMultiplayerClient.csproj", "{1F6CE8F8-1CF5-455B-9064-63CC12410B56}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{E126B79F-50B9-4448-8DE6-564BB820EE9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E126B79F-50B9-4448-8DE6-564BB820EE9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E126B79F-50B9-4448-8DE6-564BB820EE9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F6CE8F8-1CF5-455B-9064-63CC12410B56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F6CE8F8-1CF5-455B-9064-63CC12410B56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F6CE8F8-1CF5-455B-9064-63CC12410B56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F6CE8F8-1CF5-455B-9064-63CC12410B56}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/osu.Server.Spectator/Hubs/MultiplayerClientState.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerClientState.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Newtonsoft.Json;
+
+#nullable enable
+
+namespace osu.Server.Spectator.Hubs
+{
+    [Serializable]
+    public class MultiplayerClientState
+    {
+        public readonly long CurrentRoomID;
+
+        [JsonConstructor]
+        public MultiplayerClientState(in long currentRoomID)
+        {
+            CurrentRoomID = currentRoomID;
+        }
+    }
+}

--- a/osu.Server.Spectator/StartupDevelopment.cs
+++ b/osu.Server.Spectator/StartupDevelopment.cs
@@ -45,7 +45,8 @@ namespace osu.Server.Spectator
         /// </summary>
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            string userIdString = Interlocked.Increment(ref userIDCounter).ToString();
+            if (!Context.Request.Headers.TryGetValue("user_id", out var userIdString))
+                userIdString = Interlocked.Increment(ref userIDCounter).ToString();
 
             var claim = new Claim(ClaimTypes.NameIdentifier, userIdString);
 


### PR DESCRIPTION


- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/2

This is slightly different than the spectator sample client in that it allows interactive control of a set of multiplayer clients. Should allow for some good (manual) test coverage of edge case scenarios.

Of note: signalr replies are not instant. If you perform an action and the client states are not as you expect, hit enter once to allow them to refresh again. (I've added a `Thread.Sleep` to avoid this in most cases).

![2020-12-09 15 12 50](https://user-images.githubusercontent.com/191335/101592245-47f55100-3a31-11eb-83f6-405fa1216320.gif)