### PR TITLE
Add a github action to run unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-latest
+    name: Unit testing
+    steps:
+      - uses: actions/checkout@v1
+      - run: dotnet test


### PR DESCRIPTION
We didn't have any CI until now, so this is the bare minimum. Using the windows build agent as it has been updated to net5.0 (unlike linux, which is [currently in rollout](https://github.com/actions/virtual-environments/issues/1891#issuecomment-744424035)).

Note that https://github.com/ppy/osu-server-spectator/pull/4 should be merged first to fix a compilation error.


A test run can be seen [here](https://github.com/peppy/osu-server-spectator/runs/1562514189?check_suite_focus=true).