### PR TITLE
Fix clients polluting the states of other client types

### DIFF
--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -90,6 +90,6 @@ namespace osu.Server.Spectator.Hubs
             return state;
         }
 
-        public static string GetStateId(int userId) => $"state-{nameof(TClient)}:{userId}";
+        public static string GetStateId(int userId) => $"state-{typeof(TClient)}:{userId}";
     }
 }


### PR DESCRIPTION
When leaving a multiplayer room, the spectator client (via EndPlaySession) would remove the multiplayer state from the cache, causing the multiplayer client actions to fail.