### PR TITLE
Clear all playlist item scores on starting match for implementation simplicity

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -510,6 +510,7 @@ namespace osu.Server.Spectator.Tests
             {
             }
 
+            protected override Task ClearDatabaseScores(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task UpdateDatabaseParticipants(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task UpdateDatabaseSettings(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -255,6 +255,8 @@ namespace osu.Server.Spectator.Hubs
                 if (room.Host != null && room.Host.State != MultiplayerUserState.Ready)
                     throw new InvalidStateException("Can't start match when the host is not ready.");
 
+                await ClearDatabaseScores(room);
+
                 await changeRoomState(room, MultiplayerRoomState.WaitingForLoad);
 
                 foreach (var u in readyUsers)
@@ -297,6 +299,22 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="roomId">The databased room ID.</param>
         /// <param name="gameplay">Whether the group ID should be for active gameplay, or room control messages.</param>
         public static string GetGroupId(long roomId, bool gameplay = false) => $"room:{roomId}:{gameplay}";
+
+        protected virtual async Task ClearDatabaseScores(MultiplayerRoom room)
+        {
+            // for now, clear all existing scores out of the playlist item to ensure no duplicates.
+            // eventually we will want to increment to a new playlist item rather than reusing the same one.
+            using (var conn = Database.GetConnection())
+            {
+                long playlistItemId = await conn.QuerySingleAsync<long>("SELECT playlist_item_id FROM multiplayer_playlist_items WHERE room_id = @RoomID", new
+                {
+                    RoomID = room.RoomID,
+                });
+
+                await conn.ExecuteAsync("DELETE FROM multiplayer_scores WHERE playlist_item_id = @PlaylistItemID", new { PlaylistItemID = playlistItemId });
+                await conn.ExecuteAsync("DELETE FROM multiplayer_scores_high WHERE playlist_item_id = @PlaylistItemID", new { PlaylistItemID = playlistItemId });
+            }
+        }
 
         protected virtual async Task UpdateDatabaseSettings(MultiplayerRoom room)
         {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -306,7 +306,7 @@ namespace osu.Server.Spectator.Hubs
             // eventually we will want to increment to a new playlist item rather than reusing the same one.
             using (var conn = Database.GetConnection())
             {
-                long playlistItemId = await conn.QuerySingleAsync<long>("SELECT playlist_item_id FROM multiplayer_playlist_items WHERE room_id = @RoomID", new
+                long playlistItemId = await conn.QuerySingleAsync<long>("SELECT id FROM multiplayer_playlist_items WHERE room_id = @RoomID", new
                 {
                     RoomID = room.RoomID,
                 });


### PR DESCRIPTION
For the time being, the realtime multiplayer implementation reuses a single playlist items (which gets updated with settings changes etc.) rather than inserting a new one on each new beatmap/match.

We weren't considering that this means osu-web will treat it similar to timeshift for score submission, leaving scores from the same users on previous matches polluting the results display.

This change clears all scores when a match starts to avoid this from happening.