### PR TITLE
Update the host UserID in the database after transfer

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -512,6 +512,7 @@ namespace osu.Server.Spectator.Tests
 
             protected override Task UpdateDatabaseParticipants(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task UpdateDatabaseSettings(MultiplayerRoom room) => Task.CompletedTask;
+            protected override Task UpdateDatabaseHost(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;
 
             protected override Task<MultiplayerRoom> RetrieveRoom(long roomId)


### PR DESCRIPTION
This wasn't happening, causing a stale listing display and (potentially) incorrect client-side permissions if the information from the lobby is used for actual room display.