### PR TITLE
Retrieve beatmap checksum from database for initial room population

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -120,10 +120,16 @@ namespace osu.Server.Spectator.Hubs
                     RoomID = roomId
                 });
 
+                var beatmapChecksum = await conn.QuerySingleAsync<string>("SELECT checksum from osu_beatmaps where beatmap_id = @BeatmapID", new
+                {
+                    BeatmapId = playlistItem.beatmap_id
+                });
+
                 return new MultiplayerRoom(roomId)
                 {
                     Settings = new MultiplayerRoomSettings
                     {
+                        BeatmapChecksum = beatmapChecksum,
                         BeatmapID = playlistItem.beatmap_id,
                         RulesetID = playlistItem.ruleset_id,
                         Name = databaseRoom.name,


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/11193

Beyond the initial room settings, it uses the given room settings for simplicity. I've tested this works locally.