### PR TITLE
Remove users finished play from gameplay group

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -218,6 +218,7 @@ namespace osu.Server.Spectator.Hubs
                 // handle whether this user should be receiving gameplay messages or not.
                 switch (newState)
                 {
+                    case MultiplayerUserState.FinishedPlay:
                     case MultiplayerUserState.Idle:
                         await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
                         break;


### PR DESCRIPTION
Tested to be working locally. Advise appreciated if you'd like a unit test, because I'm not sure how to write one - I don't think the `mockGameplayReceiver` can be used to test this because it will trigger but I want to test it didn't trigger on a particular user (the one in the `FinishedPlay` state).