### PR TITLE
Mark all ready users as not ready (idle) on settings change

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -466,6 +466,28 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
+        public async Task ChangingSettingsMarksReadyUsersAsIdle()
+        {
+            MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
+            {
+                Name = "bestest room ever",
+            };
+
+            await hub.JoinRoom(room_id);
+
+            Assert.True(hub.TryGetRoom(room_id, out var room));
+            Debug.Assert(room != null);
+
+            await hub.ChangeState(MultiplayerUserState.Ready);
+            mockReceiver.Verify(r => r.UserStateChanged(user_id, MultiplayerUserState.Ready), Times.Once);
+            Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Ready, u.State));
+
+            await hub.ChangeSettings(testSettings);
+            mockReceiver.Verify(r => r.UserStateChanged(user_id, MultiplayerUserState.Idle), Times.Once);
+            Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
+        }
+
+        [Fact]
         public async Task UserCantChangeSettingsWhenNotJoinedRoom()
         {
             await Assert.ThrowsAsync<NotJoinedRoomException>(() => hub.ChangeSettings(new MultiplayerRoomSettings()));

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -274,7 +274,14 @@ namespace osu.Server.Spectator.Hubs
 
                 ensureIsHost(room);
 
+                if (room.Settings.Equals(settings))
+                    return;
+
                 room.Settings = settings;
+
+                // this should probably only happen for gameplay-related changes, but let's just keep things simple for now.
+                foreach (var u in room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray())
+                    await changeAndBroadcastUserState(room, u, MultiplayerUserState.Idle);
 
                 await UpdateDatabaseSettings(room);
 


### PR DESCRIPTION
Argued over whether to make this only when a beatmap/mod/ruleset change occurs, but this just seems simpler for now. We can iterate going forwards, probably adding a EqualsForGameplay method to the underlying model.