### PR TITLE
Mark a room as joined by nulling ends_at in database

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -581,6 +581,7 @@ namespace osu.Server.Spectator.Tests
             protected override Task UpdateDatabaseSettings(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task UpdateDatabaseHost(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;
+            protected override Task MarkRoomActive(MultiplayerRoom room) => Task.CompletedTask;
 
             protected override Task<MultiplayerRoom> RetrieveRoom(long roomId)
             {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -88,6 +88,8 @@ namespace osu.Server.Spectator.Hubs
 
             await UpdateLocalUserState(new MultiplayerClientState(roomId));
 
+            await MarkRoomActive(room);
+
             return room;
         }
 
@@ -136,6 +138,20 @@ namespace osu.Server.Spectator.Hubs
                         Mods = playlistItem.allowed_mods != null ? JsonConvert.DeserializeObject<IEnumerable<APIMod>>(playlistItem.allowed_mods) : Array.Empty<APIMod>()
                     }
                 };
+            }
+        }
+
+        /// <summary>
+        /// Marks a room active at the database, implying the host has joined and this server is now in control of the room's lifetime.
+        /// </summary>
+        protected virtual async Task MarkRoomActive(MultiplayerRoom room)
+        {
+            using (var conn = Database.GetConnection())
+            {
+                await conn.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = null WHERE id = @RoomID", new
+                {
+                    RoomID = room.RoomID
+                });
             }
         }
 


### PR DESCRIPTION
As discovered during testing, it is possible for a client to open a game via an osu-web api call but never join it (due to client crash, for instance).

To address this, osu-web will now give a host 30 seconds to join the match before it is automatically closed. This is done via ends_at (see https://github.com/ppy/osu-web/pull/7013). We now need to resolve rooms as "joined" by setting this field to null.

This is deployed to live for testing purposes.