### PR TITLE
Allow joining game if ends_at is in the future

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -111,7 +111,7 @@ namespace osu.Server.Spectator.Hubs
                 if (databaseRoom == null)
                     throw new InvalidStateException("Specified match does not exist.");
 
-                if (databaseRoom.ends_at != null)
+                if (databaseRoom.ends_at != null && databaseRoom.ends_at < DateTimeOffset.Now)
                     throw new InvalidStateException("Match has already ended.");
 
                 if (databaseRoom.user_id != CurrentContextUserId)


### PR DESCRIPTION
Required for the new server logic, which creates games with a limited 30
seconds to join them.