### PR TITLE
Fix dapper not correctly handling DateTimeOffset when local system is not UTC

### DIFF
--- a/osu.Server.Spectator/DapperExtensions.cs
+++ b/osu.Server.Spectator/DapperExtensions.cs
@@ -10,6 +10,7 @@ namespace osu.Server.Spectator
 {
     public static class DapperExtensions
     {
+        // see https://stackoverflow.com/questions/12510299/get-datetime-as-utc-with-dapper
         public class DateTimeOffsetTypeHandler : SqlMapper.TypeHandler<DateTimeOffset>
         {
             public override void SetValue(IDbDataParameter parameter, DateTimeOffset value)

--- a/osu.Server.Spectator/DapperExtensions.cs
+++ b/osu.Server.Spectator/DapperExtensions.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Data;
+using System.Threading;
+using Dapper;
+
+namespace osu.Server.Spectator
+{
+    public static class DapperExtensions
+    {
+        public class DateTimeOffsetTypeHandler : SqlMapper.TypeHandler<DateTimeOffset>
+        {
+            public override void SetValue(IDbDataParameter parameter, DateTimeOffset value)
+            {
+                switch (parameter.DbType)
+                {
+                    case DbType.DateTime:
+                    case DbType.DateTime2:
+                    case DbType.AnsiString: // Seems to be some MySQL type mapping here
+                        parameter.Value = value.UtcDateTime;
+                        break;
+
+                    case DbType.DateTimeOffset:
+                        parameter.Value = value;
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("DateTimeOffset must be assigned to a DbType.DateTime SQL field.");
+                }
+            }
+
+            public override DateTimeOffset Parse(object value)
+            {
+                switch (value)
+                {
+                    case DateTime time:
+                        return new DateTimeOffset(DateTime.SpecifyKind(time, DateTimeKind.Utc), TimeSpan.Zero);
+
+                    case DateTimeOffset dto:
+                        return dto;
+
+                    default:
+                        throw new InvalidOperationException("Must be DateTime or DateTimeOffset object to be mapped.");
+                }
+            }
+        }
+
+        private static int dateTimeOffsetMapperInstalled = 0;
+
+        public static void InstallDateTimeOffsetMapper()
+        {
+            // Assumes SqlMapper.ResetTypeHandlers() is never called.
+            if (Interlocked.CompareExchange(ref dateTimeOffsetMapperInstalled, 1, 0) == 0)
+            {
+                // First remove the default type map between typeof(DateTimeOffset) => DbType.DateTimeOffset (not valid for MySQL)
+                SqlMapper.RemoveTypeMap(typeof(DateTimeOffset));
+                SqlMapper.RemoveTypeMap(typeof(DateTimeOffset?));
+
+                // This handles nullable value types automatically e.g. DateTimeOffset?
+                SqlMapper.AddTypeHandler(typeof(DateTimeOffset), new DateTimeOffsetTypeHandler());
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Database.cs
+++ b/osu.Server.Spectator/Database.cs
@@ -13,6 +13,8 @@ namespace osu.Server.Spectator
             string host = (Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost");
             string user = (Environment.GetEnvironmentVariable("DB_USER") ?? "root");
 
+            DapperExtensions.InstallDateTimeOffsetMapper();
+
             var connection = new MySqlConnection($"Server={host};Database=osu;User ID={user};ConnectionTimeout=5;ConnectionReset=false;Pooling=true;");
             connection.Open();
             return connection;


### PR DESCRIPTION
As it turns out, dapper just doesn't handle the time zone portion of DateTimeOffset, full stop. Things have only been working until now because we are running our components on servers which are set to UTC.

This is the proposed fix to handle DateTimeOffset correctly, see https://stackoverflow.com/questions/12510299/get-datetime-as-utc-with-dapper for more details. We should probably deploy this to all other projects we have which user dapper to avoid similar issues, especially during local development.