### PR TITLE
Fix mods not applying when reading room settings from DB

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -135,7 +135,7 @@ namespace osu.Server.Spectator.Hubs
                         BeatmapID = playlistItem.beatmap_id,
                         RulesetID = playlistItem.ruleset_id,
                         Name = databaseRoom.name,
-                        Mods = playlistItem.allowed_mods != null ? JsonConvert.DeserializeObject<IEnumerable<APIMod>>(playlistItem.allowed_mods) : Array.Empty<APIMod>()
+                        Mods = playlistItem.required_mods != null ? JsonConvert.DeserializeObject<IEnumerable<APIMod>>(playlistItem.required_mods) : Array.Empty<APIMod>()
                     }
                 };
             }


### PR DESCRIPTION
[Client sends out `RequiredMods`.](https://github.com/ppy/osu/blob/60be1bedc9e61f77e153ae4809b9f09fb0495599/osu.Game/Screens/Select/MatchSongSelect.cs#L73-L80)