### PR TITLE
Disallow restricted users from joining a game

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -582,7 +582,7 @@ namespace osu.Server.Spectator.Tests
             protected override Task UpdateDatabaseHost(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task MarkRoomActive(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task<bool> CheckUserRestrictions() => Task.FromResult(false);
+            protected override Task<bool> CheckIsUserRestricted() => Task.FromResult(false);
 
             protected override Task<MultiplayerRoom> RetrieveRoom(long roomId)
             {

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -582,6 +582,7 @@ namespace osu.Server.Spectator.Tests
             protected override Task UpdateDatabaseHost(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;
             protected override Task MarkRoomActive(MultiplayerRoom room) => Task.CompletedTask;
+            protected override Task<bool> CheckUserRestrictions() => Task.FromResult(false);
 
             protected override Task<MultiplayerRoom> RetrieveRoom(long roomId)
             {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -52,7 +52,7 @@ namespace osu.Server.Spectator.Hubs
 
         public async Task<MultiplayerRoom> JoinRoom(long roomId)
         {
-            bool isRestricted = await CheckUserRestrictions();
+            bool isRestricted = await CheckIsUserRestricted();
 
             if (isRestricted)
             {
@@ -412,7 +412,7 @@ namespace osu.Server.Spectator.Hubs
             }
         }
 
-        protected virtual async Task<bool> CheckUserRestrictions()
+        protected virtual async Task<bool> CheckIsUserRestricted()
         {
             using (var conn = Database.GetConnection())
             {


### PR DESCRIPTION
This is not supported behaviour and currently causes client crashes as a result.