### PR TITLE
Ensure users are set to waiting for load state before game is started

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -284,10 +284,10 @@ namespace osu.Server.Spectator.Hubs
 
                 await ClearDatabaseScores(room);
 
-                await changeRoomState(room, MultiplayerRoomState.WaitingForLoad);
-
                 foreach (var u in readyUsers)
                     await changeAndBroadcastUserState(room, u, MultiplayerUserState.WaitingForLoad);
+
+                await changeRoomState(room, MultiplayerRoomState.WaitingForLoad);
 
                 await Clients.Group(GetGroupId(room.RoomID, true)).LoadRequested();
             }


### PR DESCRIPTION
This simplifies client-side state handling, by allowing us to make assumptions and access user states at the point the game's state is changed (ie. to find which players are in the current match).