### PR TITLE
Add datadog logging for entity store usages

### DIFF
--- a/osu.Server.Spectator/Hubs/EntityStore.cs
+++ b/osu.Server.Spectator/Hubs/EntityStore.cs
@@ -50,6 +50,7 @@ namespace osu.Server.Spectator.Hubs
                         }
 
                         entityMapping[id] = item = new TrackedEntity(id, this);
+                        DogStatsd.Gauge($"{statsDPrefix}.total-tracked", entityMapping.Count);
                         DogStatsd.Increment($"{statsDPrefix}.create");
                     }
                 }
@@ -132,8 +133,8 @@ namespace osu.Server.Spectator.Hubs
             {
                 entityMapping.Remove(id);
 
-                DogStatsd.Decrement($"{statsDPrefix}.change");
-                DogStatsd.Gauge($"{statsDPrefix}.total", entityMapping.Count);
+                DogStatsd.Increment($"{statsDPrefix}.removed");
+                DogStatsd.Gauge($"{statsDPrefix}.total-tracked", entityMapping.Count);
             }
         }
 

--- a/osu.Server.Spectator/Hubs/EntityStore.cs
+++ b/osu.Server.Spectator/Hubs/EntityStore.cs
@@ -126,7 +126,9 @@ namespace osu.Server.Spectator.Hubs
             lock (entityMapping)
             {
                 entityMapping.Remove(id);
-                DogStatsd.Decrement($"{statsDPrefix}.total");
+
+                DogStatsd.Decrement($"{statsDPrefix}.change");
+                DogStatsd.Gauge($"{statsDPrefix}.total", entityMapping.Count);
             }
         }
 

--- a/osu.Server.Spectator/Hubs/EntityStore.cs
+++ b/osu.Server.Spectator/Hubs/EntityStore.cs
@@ -67,6 +67,7 @@ namespace osu.Server.Spectator.Hubs
                         continue;
 
                     // if we're just looking to retrieve and instance, to an external consumer, this should just be handled as the item not being tracked.
+                    DogStatsd.Increment($"{statsDPrefix}.get-notfound");
                     throw new KeyNotFoundException($"Attempted to get untracked entity {typeof(T)} id {id}");
                 }
 

--- a/osu.Server.Spectator/Hubs/EntityStore.cs
+++ b/osu.Server.Spectator/Hubs/EntityStore.cs
@@ -44,10 +44,13 @@ namespace osu.Server.Spectator.Hubs
                     if (!entityMapping.TryGetValue(id, out item))
                     {
                         if (!createOnMissing)
+                        {
+                            DogStatsd.Increment($"{statsDPrefix}.get-notfound");
                             throw new KeyNotFoundException($"Attempted to get untracked entity {typeof(T)} id {id}");
+                        }
 
                         entityMapping[id] = item = new TrackedEntity(id, this);
-                        DogStatsd.Increment($"{statsDPrefix}.total");
+                        DogStatsd.Increment($"{statsDPrefix}.create");
                     }
                 }
 
@@ -66,6 +69,7 @@ namespace osu.Server.Spectator.Hubs
                     throw new KeyNotFoundException($"Attempted to get untracked entity {typeof(T)} id {id}");
                 }
 
+                DogStatsd.Increment($"{statsDPrefix}.get");
                 return new ItemUsage<T>(item);
             }
 
@@ -89,6 +93,7 @@ namespace osu.Server.Spectator.Hubs
 
                 // handles removal and disposal of the semaphore.
                 item.Destroy();
+                DogStatsd.Increment($"{statsDPrefix}.destroy");
             }
             catch (InvalidOperationException)
             {

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using StatsdClient;
 
 namespace osu.Server.Spectator
 {
@@ -10,6 +12,12 @@ namespace osu.Server.Spectator
     {
         public static void Main(string[] args)
         {
+            DogStatsd.Configure(new StatsdConfig
+            {
+                StatsdServerName = Environment.GetEnvironmentVariable("DD_AGENT_HOST") ?? "localhost",
+                Prefix = "osu.server.spectator",
+            });
+
             createHostBuilder(args).Build().Run();
         }
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="BouncyCastle" Version="1.8.6.1" />
+        <PackageReference Include="DogStatsD-CSharp-Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.9" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />


### PR DESCRIPTION
Bare minimum logging to track the usage of entity stores (and hopefully help track down issues)

This is already deployed live and has helped with some basic understanding. Have confirmed that everything is outputting as expected, but would appreciate a quick one-over on the calls from a correctness perspective.