### PR TITLE
Add an extra check to ensure two connections from the same user_id cannot join the same room

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -43,9 +43,7 @@ namespace osu.Server.Spectator.Hubs
             bool isRestricted = await CheckIsUserRestricted();
 
             if (isRestricted)
-            {
                 throw new InvalidStateException("Can't join a room when restricted.");
-            }
 
             using (var userUsage = await GetOrCreateLocalUserState())
             {
@@ -70,6 +68,11 @@ namespace osu.Server.Spectator.Hubs
                     }
 
                     room = roomUsage.Item;
+
+                    // this is a sanity check to keep *rooms* in a good state.
+                    // in theory the connection clean-up code should handle this correctly.
+                    if (room.Users.Any(u => u.UserID == roomUser.UserID))
+                        throw new InvalidOperationException($"User {roomUser.UserID} attempted to join a room they are already present in.");
 
                     room.Users.Add(roomUser);
 


### PR DESCRIPTION
As per the inline comments, this cannot happen in theory. If we are hitting this point, connection uniqueness has not been maintained (two connections / tracked states from the same user have been allowed on the server at once).

The addition of this check allows rooms to continue to remain in a good state even when the above occurs, at worst limiting the damage to the user (until their connections are lost).