### PR TITLE
Add some extra safeties against database failures

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -591,19 +591,19 @@ namespace osu.Server.Spectator.Hubs
                 if (user == null)
                     failWithInvalidState("User was not in the expected room.");
 
-                room.Users.Remove(user);
-
-                await UpdateDatabaseParticipants(room);
-
-                if (room.Users.Count == 0)
+                // handle closing the room if the only participant is the user which is leaving.
+                if (room.Users.Count == 1)
                 {
-                    Console.WriteLine($"Stopping tracking of room {room.RoomID} (all users left).");
-                    roomUsage.Destroy();
-
                     await EndDatabaseMatch(room);
 
+                    // only destroy the usage after the database operation succeeds.
+                    Console.WriteLine($"Stopping tracking of room {room.RoomID} (all users left).");
+                    roomUsage.Destroy();
                     return;
                 }
+
+                room.Users.Remove(user);
+                await UpdateDatabaseParticipants(room);
 
                 var clients = Clients.Group(GetGroupId(room.RoomID));
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -72,10 +72,12 @@ namespace osu.Server.Spectator.Hubs
 
                     room = roomUsage.Item;
 
+                    // mark the room active - and wait for confirmation of this operation from the database - before adding the user to the room.
+                    await MarkRoomActive(room);
+
                     room.Users.Add(roomUser);
 
                     await UpdateDatabaseParticipants(room);
-                    await MarkRoomActive(room);
                 }
 
                 await Clients.Group(GetGroupId(roomId)).UserJoined(roomUser);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -440,10 +440,11 @@ namespace osu.Server.Spectator.Hubs
         private async Task setNewHost(MultiplayerRoom room, MultiplayerRoomUser newHost)
         {
             room.Host = newHost;
-
-            await UpdateDatabaseHost(room);
-
             await Clients.Group(GetGroupId(room.RoomID)).HostChanged(newHost.UserID);
+
+
+            // don't care too much about failures here (is only for display), so run after local state is updated.
+            await UpdateDatabaseHost(room);
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -35,8 +35,18 @@ namespace osu.Server.Spectator.Hubs
         {
             Console.WriteLine($"User {CurrentContextUserId} connected!");
 
-            // if a previous connection is still present for the current user, we need to clean it up.
-            await cleanUpState(false);
+            try
+            {
+                // if a previous connection is still present for the current user, we need to clean it up.
+                await cleanUpState(false);
+            }
+            catch
+            {
+                // if any exception happened during clean-up, don't allow the user to reconnect.
+                // this limits damage to the user in a bad state if their clean-up cannot occur (they will not be able to reconnect until the issue is resolved).
+                Context.Abort();
+                throw;
+            }
 
             await base.OnConnectedAsync();
         }


### PR DESCRIPTION
This sees to multiple failures that could occur if a database execution was to fail for one reason or another. The common case I've seen come up is on the `updateParticipants`, which is now protected against all failures, but on the way I also noticed that due to no local exception handling, in combination with haphazard order of execution, this could result in a room or user state becoming inconsistent.

I've reordered all such operations to allow the database calls to occur first, and early-abort on error (allowing the client or server to retry the operation post-failure).

This also adds exception handling to the cleanup operation on new connection, to avoid the case where a previous connection's cleanup failure results in state being inconsistent (and never recovered). Now it will retry every time the user tries to reconnect to the server, and disallow a connection from the bad-state user if retries don't help.