### PR TITLE
Fix user's joined state not being updated as part of room transaction

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -80,12 +80,12 @@ namespace osu.Server.Spectator.Hubs
                     room.Users.Add(roomUser);
 
                     await UpdateDatabaseParticipants(room);
+
+                    await Clients.Group(GetGroupId(roomId)).UserJoined(roomUser);
+                    await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
+
+                    userUsage.Item = new MultiplayerClientState(Context.ConnectionId, CurrentContextUserId, roomId);
                 }
-
-                await Clients.Group(GetGroupId(roomId)).UserJoined(roomUser);
-                await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
-
-                userUsage.Item = new MultiplayerClientState(Context.ConnectionId, CurrentContextUserId, roomId);
 
                 return room;
             }


### PR DESCRIPTION
This shouldn't cause any issues with the current scope of this server,
but may in the future (for instance, if a user is kicked from a room).