### PR TITLE
Fix contexts being left in an incorrect state after a failed JoinRoom

### DIFF
--- a/osu.Server.Spectator.Tests/EntityStoreTests.cs
+++ b/osu.Server.Spectator.Tests/EntityStoreTests.cs
@@ -93,6 +93,9 @@ namespace osu.Server.Spectator.Tests
 
             await store.Destroy(1);
 
+            // second call should be allowed (and run as a noop).
+            await store.Destroy(1);
+
             await Assert.ThrowsAsync<KeyNotFoundException>(() => store.GetForUse(1));
 
             using (var thirdGet = await store.GetForUse(1, true))

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -181,11 +181,23 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public async Task UserJoinFailureCleansUpRoom()
+        public async Task UserJoinPreJoinFailureCleansUpRoom()
         {
             hub.MarkRoomActiveShouldThrow = true;
             await Assert.ThrowsAnyAsync<Exception>(() => hub.JoinRoom(room_id));
+
             await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.RoomStore.GetForUse(room_id));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.UserStore.GetForUse(user_id));
+        }
+
+        [Fact]
+        public async Task UserJoinPostJoinFailureCleansUpRoomAndUser()
+        {
+            hub.UpdateDatabaseParticipantsShouldThrow = true;
+            await Assert.ThrowsAnyAsync<Exception>(() => hub.JoinRoom(room_id));
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.RoomStore.GetForUse(room_id));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.UserStore.GetForUse(user_id));
         }
 
         #endregion
@@ -586,6 +598,7 @@ namespace osu.Server.Spectator.Tests
         public class TestMultiplayerHub : MultiplayerHub
         {
             public EntityStore<MultiplayerRoom> RoomStore => MultiplayerHub.ACTIVE_ROOMS;
+            public EntityStore<MultiplayerClientState> UserStore => MultiplayerHub.ACTIVE_STATES;
 
             public TestMultiplayerHub(MemoryDistributedCache cache)
                 : base(cache)

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -176,6 +178,14 @@ namespace osu.Server.Spectator.Tests
 
             await hub.LeaveRoom();
             mockReceiver.Verify(r => r.UserLeft(new MultiplayerRoomUser(user_id_2)), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task UserJoinFailureCleansUpRoom()
+        {
+            hub.MarkRoomActiveShouldThrow = true;
+            await Assert.ThrowsAnyAsync<Exception>(() => hub.JoinRoom(room_id));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.RoomStore.GetForUse(room_id));
         }
 
         #endregion
@@ -575,18 +585,33 @@ namespace osu.Server.Spectator.Tests
 
         public class TestMultiplayerHub : MultiplayerHub
         {
+            public EntityStore<MultiplayerRoom> RoomStore => MultiplayerHub.ACTIVE_ROOMS;
+
             public TestMultiplayerHub(MemoryDistributedCache cache)
                 : base(cache)
             {
             }
 
-            protected override Task ClearDatabaseScores(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task UpdateDatabaseParticipants(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task UpdateDatabaseSettings(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task UpdateDatabaseHost(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task EndDatabaseMatch(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task MarkRoomActive(MultiplayerRoom room) => Task.CompletedTask;
-            protected override Task<bool> CheckIsUserRestricted() => Task.FromResult(false);
+            public bool ClearDatabaseScoresShouldThrow;
+            protected override Task ClearDatabaseScores(MultiplayerRoom room) => ClearDatabaseScoresShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool UpdateDatabaseParticipantsShouldThrow;
+            protected override Task UpdateDatabaseParticipants(MultiplayerRoom room) => UpdateDatabaseParticipantsShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool UpdateDatabaseSettingsShouldThrow;
+            protected override Task UpdateDatabaseSettings(MultiplayerRoom room) => UpdateDatabaseSettingsShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool UpdateDatabaseHostShouldThrow;
+            protected override Task UpdateDatabaseHost(MultiplayerRoom room) => UpdateDatabaseHostShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool EndDatabaseMatchShouldThrow;
+            protected override Task EndDatabaseMatch(MultiplayerRoom room) => EndDatabaseMatchShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool MarkRoomActiveShouldThrow;
+            protected override Task MarkRoomActive(MultiplayerRoom room) => MarkRoomActiveShouldThrow ? throw new InvalidOperationException() : Task.CompletedTask;
+
+            public bool CheckIsUserRestrictedShouldThrow;
+            protected override Task<bool> CheckIsUserRestricted() => CheckIsUserRestrictedShouldThrow ? throw new InvalidOperationException() : Task.FromResult(false);
 
             protected override Task<MultiplayerRoom> RetrieveRoom(long roomId)
             {
@@ -597,13 +622,13 @@ namespace osu.Server.Spectator.Tests
                 });
             }
 
-            public ItemUsage<MultiplayerRoom> GetRoom(long roomId) => ACTIVE_ROOMS.GetForUse(roomId).Result;
+            public ItemUsage<MultiplayerRoom> GetRoom(long roomId) => RoomStore.GetForUse(roomId).Result;
 
             public bool CheckRoomExists(long roomId)
             {
                 try
                 {
-                    using (var usage = ACTIVE_ROOMS.GetForUse(roomId).Result)
+                    using (var usage = RoomStore.GetForUse(roomId).Result)
                         return usage.Item != null;
                 }
                 catch

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -609,8 +609,8 @@ namespace osu.Server.Spectator.Tests
 
         public class TestMultiplayerHub : MultiplayerHub
         {
-            public EntityStore<MultiplayerRoom> RoomStore => MultiplayerHub.ACTIVE_ROOMS;
-            public EntityStore<MultiplayerClientState> UserStore => MultiplayerHub.ACTIVE_STATES;
+            public EntityStore<MultiplayerRoom> RoomStore => ACTIVE_ROOMS;
+            public EntityStore<MultiplayerClientState> UserStore => ACTIVE_STATES;
 
             public TestMultiplayerHub(MemoryDistributedCache cache)
                 : base(cache)

--- a/osu.Server.Spectator/Hubs/EntityStore.cs
+++ b/osu.Server.Spectator/Hubs/EntityStore.cs
@@ -179,6 +179,9 @@ namespace osu.Server.Spectator.Hubs
             /// </summary>
             public void Destroy()
             {
+                if (isDestroyed)
+                    return;
+
                 // we should already have a lock when calling destroy.
                 checkValidForUse();
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -102,7 +102,7 @@ namespace osu.Server.Spectator.Hubs
                         {
                             if (userUsage.Item != null)
                             {
-                                // the user was joined to the room, so we can tun the standard leaveRoom method.
+                                // the user was joined to the room, so we can run the standard leaveRoom method.
                                 // this will handle closing the room if this was the only user.
                                 await leaveRoom(userUsage.Item, roomUsage);
                             }

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -58,8 +58,8 @@ namespace osu.Server.Spectator.Hubs
                 // add the user to the room.
                 var roomUser = new MultiplayerRoomUser(CurrentContextUserId);
 
-                // track whether a new room was fetched from the database and assigned to a usage.
-                bool newRoomFetched = false;
+                // track whether this join necessitated starting the process of fetching the room and adding it to the ACTIVE_ROOMS store.
+                bool newRoomFetchStarted = false;
 
                 MultiplayerRoom? room = null;
 
@@ -69,7 +69,7 @@ namespace osu.Server.Spectator.Hubs
                     {
                         if (roomUsage.Item == null)
                         {
-                            newRoomFetched = true;
+                            newRoomFetchStarted = true;
 
                             // the requested room is not yet tracked by this server.
                             room = await RetrieveRoom(roomId);
@@ -112,7 +112,7 @@ namespace osu.Server.Spectator.Hubs
                                 // this will handle closing the room if this was the only user.
                                 await leaveRoom(userUsage.Item, roomUsage);
                             }
-                            else if (newRoomFetched)
+                            else if (newRoomFetchStarted)
                             {
                                 if (room != null)
                                 {


### PR DESCRIPTION
There was no cleanup/rollback logic in the join process. This adds rollback and destruction of room/user contexts when a failure occurred.

It also adds a means to test database failures (paves a way to add more test coverage we don't currently have).

- [x] Depends on #34 for ease-of-merging.