### PR TITLE
Fix state management mishaps in old connection cleanup

### DIFF
--- a/osu.Server.Spectator.Tests/StatefulUserHubTests.cs
+++ b/osu.Server.Spectator.Tests/StatefulUserHubTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Moq;
+using osu.Server.Spectator.Hubs;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class StatefulUserHubTests
+    {
+        private readonly TestStatefulHub hub;
+
+        private const int user_id = 1234;
+
+        private readonly Mock<HubCallerContext> mockContext;
+
+        public StatefulUserHubTests()
+        {
+            TestStatefulHub.Reset();
+
+            MemoryDistributedCache cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+            hub = new TestStatefulHub(cache);
+
+            mockContext = new Mock<HubCallerContext>();
+            mockContext.Setup(context => context.UserIdentifier).Returns(user_id.ToString());
+
+            setNewConnectionId();
+
+            hub.Context = mockContext.Object;
+        }
+
+        [Fact]
+        public async Task ConnectDisconnectStateCleanup()
+        {
+            await hub.OnConnectedAsync();
+
+            await hub.CreateUserState();
+
+            await hub.OnDisconnectedAsync(null);
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.UserStore.GetForUse(user_id));
+        }
+
+        [Fact]
+        public async Task SameUserConnectsTwiceDestroysPreviousState()
+        {
+            await hub.OnConnectedAsync();
+            await hub.CreateUserState();
+
+            using (var state = await hub.UserStore.GetForUse(user_id))
+            {
+                ClientState? firstState = state.Item;
+
+                Assert.NotNull(firstState);
+                Assert.Equal(mockContext.Object.ConnectionId, firstState?.ConnectionId);
+            }
+
+            // connect a second time as the same user without disconnecting the original connection.
+            setNewConnectionId();
+            await hub.OnConnectedAsync();
+
+            // original state should have been destroyed.
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.UserStore.GetForUse(user_id));
+        }
+
+        [Fact]
+        public async Task SameUserOldConnectionDoesntDestroyNewState()
+        {
+            await hub.OnConnectedAsync();
+            await hub.CreateUserState();
+
+            string originalConnectionId = mockContext.Object.ConnectionId;
+
+            // connect a second time as the same user without disconnecting the original connection.
+            setNewConnectionId();
+            await hub.OnConnectedAsync();
+
+            // original state should have been destroyed.
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => hub.UserStore.GetForUse(user_id));
+
+            // create a state using the second connection.
+            await hub.CreateUserState();
+            string lastConnectedConnectionId = mockContext.Object.ConnectionId;
+
+            // ensure disconnecting the original connection does nothing.
+            setNewConnectionId(originalConnectionId);
+            await hub.OnDisconnectedAsync(null);
+
+            using (var state = await hub.UserStore.GetForUse(user_id))
+                Assert.Equal(lastConnectedConnectionId, state.Item?.ConnectionId);
+        }
+
+        private void setNewConnectionId(string? connectionId = null) =>
+            mockContext.Setup(context => context.ConnectionId).Returns(connectionId ?? Guid.NewGuid().ToString());
+
+        private class TestStatefulHub : StatefulUserHub<object, ClientState>
+        {
+            public EntityStore<ClientState> UserStore => ACTIVE_STATES;
+
+            public TestStatefulHub([NotNull] IDistributedCache cache)
+                : base(cache)
+            {
+            }
+
+            public async Task CreateUserState()
+            {
+                using (var state = await GetOrCreateLocalUserState())
+                    state.Item = new ClientState(Context.ConnectionId, CurrentContextUserId);
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -75,30 +75,30 @@ namespace osu.Server.Spectator.Hubs
                 return;
             }
 
-            try
+            Log($"Cleaning up state on {(isDisconnect ? "disconnect" : "connect")}");
+
+            if (usage.Item != null)
             {
-                Log($"Cleaning up state on {(isDisconnect ? "disconnect" : "connect")}");
+                bool isOurState = usage.Item.ConnectionId == Context.ConnectionId;
 
-                if (usage.Item != null)
+                if (isDisconnect && !isOurState)
                 {
-                    bool isOurState = usage.Item.ConnectionId == Context.ConnectionId;
+                    // not our state, owned by a different connection.
+                    Log("Disconnect state cleanup aborted due to newer connection owning state");
+                    return;
+                }
 
-                    if (isDisconnect && !isOurState)
-                    {
-                        // not our state, owned by a different connection.
-                        Log("Disconnect state cleanup aborted due to newer connection owning state");
-                        return;
-                    }
-
+                try
+                {
                     await CleanUpState(usage.Item);
                 }
-            }
-            finally
-            {
-                usage.Destroy();
-                usage.Dispose();
+                finally
+                {
+                    usage.Destroy();
+                    usage.Dispose();
 
-                Log("State cleanup completed");
+                    Log("State cleanup completed");
+                }
             }
         }
 

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -54,7 +56,7 @@ namespace osu.Server.Spectator.Hubs
             await base.OnConnectedAsync();
         }
 
-        public sealed override async Task OnDisconnectedAsync(Exception exception)
+        public sealed override async Task OnDisconnectedAsync(Exception? exception)
         {
             Log("Disconnected");
 

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -79,28 +79,33 @@ namespace osu.Server.Spectator.Hubs
 
             Log($"Cleaning up state on {(isDisconnect ? "disconnect" : "connect")}");
 
-            if (usage.Item != null)
+            try
             {
-                bool isOurState = usage.Item.ConnectionId == Context.ConnectionId;
-
-                if (isDisconnect && !isOurState)
+                if (usage.Item != null)
                 {
-                    // not our state, owned by a different connection.
-                    Log("Disconnect state cleanup aborted due to newer connection owning state");
-                    return;
-                }
+                    bool isOurState = usage.Item.ConnectionId == Context.ConnectionId;
 
-                try
-                {
-                    await CleanUpState(usage.Item);
-                }
-                finally
-                {
-                    usage.Destroy();
-                    usage.Dispose();
+                    if (isDisconnect && !isOurState)
+                    {
+                        // not our state, owned by a different connection.
+                        Log("Disconnect state cleanup aborted due to newer connection owning state");
+                        return;
+                    }
 
-                    Log("State cleanup completed");
+                    try
+                    {
+                        await CleanUpState(usage.Item);
+                    }
+                    finally
+                    {
+                        usage.Destroy();
+                        Log("State cleanup completed");
+                    }
                 }
+            }
+            finally
+            {
+                usage.Dispose();
             }
         }
 


### PR DESCRIPTION
Due to yet another oversight, there was the potential for an old connection to unsafely destroy a user context (without running any clean up code).

The oversight here is that the early `return` will still run the `finally` code, which includes not just a `dispose` but also a `destroy`:

https://github.com/ppy/osu-server-spectator/blob/351e32ce8336a203445d82a5e53b498f21c46364/osu.Server.Spectator/Hubs/StatefulUserHub.cs#L89-L90

for the same user:
- Connection 1 connects and creates a state
- Connection 2 connects, cleans up previous state
- Connection 2 create a state
- Connection 1 disconnects, and DESTROYS THE NEW STATE

Added test coverage for the above and other connection cleanup expectations.