### PR TITLE
Clone the full MultiplayerRoom before returning to the user to avoid collection enumeration failures

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -139,7 +139,7 @@ namespace osu.Server.Spectator.Hubs
                     }
                 }
 
-                return room;
+                return JsonConvert.DeserializeObject<MultiplayerRoom>(JsonConvert.SerializeObject(room));
             }
         }
 


### PR DESCRIPTION
As seen in server logs, there are cases where `JoinRoom` operations fail to serialise the message to the end user due to collection modification during enumeration:

```
Microsoft.AspNetCore.SignalR.HubConnectionContext[6]
      Failed writing message. Aborting connection.
      System.InvalidOperationException: Collection was modified;
enumeration operation may not execute.
         at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
```

After this occurs, things seem to fall apart in terms of server consistency. I'm not quite sure why this is the case yet (since the serialisation failure should occur after the lock has been returned, and should not affect any transactional server operation) but figure it is best to fix this as a first step.

The "Aborting connection" part is a touch suspicious - maybe it is bypassing the cleanup logic in cases like this. Will require some further investigation.

Unfortunately, this makes the tests are bit uglier than before.

As a side note, I tried using AutoMapper for the cloning of the room, but ran into issues with reference types somewhere in the hierarchy.  While the json method is horribly inefficient, it is a very simple way to ensure serialization consistency (since we're using the same method for the SignalR level serialization). Also, as it's only happening in the `JoinRoom` method (which is quite rare in comparison to other operations) this should do fine for now.