### PR TITLE
Add MessagePack support

### DIFF
--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using osu.Framework.Utils;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
@@ -128,7 +127,7 @@ namespace SampleMultiplayerClient
         private static MultiplayerClient getConnectedClient(int userId)
         {
             var connection = new HubConnectionBuilder()
-                             .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; })
+                             .AddMessagePackProtocol()
                              .WithUrl("http://localhost:80/multiplayer", http => http.Headers.Add("user_id", userId.ToString()))
                              .ConfigureLogging(logging =>
                              {

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,8 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />
     </ItemGroup>

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.127.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/Program.cs
+++ b/SampleSpectatorClient/Program.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using osu.Framework.Utils;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
@@ -58,7 +57,7 @@ namespace SampleSpectatorClient
         private static SpectatorClient getConnectedClient()
         {
             var connection = new HubConnectionBuilder()
-                             .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; })
+                             .AddMessagePackProtocol()
                              .WithUrl("http://localhost:80/spectator")
                              .ConfigureLogging(logging =>
                              {

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,8 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />
     </ItemGroup>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.127.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -21,6 +21,7 @@ namespace osu.Server.Spectator
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSignalR()
+                    .AddMessagePackProtocol()
                     .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; });
 
             services.AddDatabaseServices();

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.127.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2021.119.0" />
         <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
         <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -8,7 +8,8 @@
     <ItemGroup>
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.11" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2021.118.1" />


### PR DESCRIPTION
This adds MessagePack as a supported protocol, in addition to existing Newtonsoft.JSON.

- [x] Depends on https://github.com/ppy/osu/pull/11607 + game dll bump