### PR TITLE
Fix ability to update room settings with custom rulesets

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -770,7 +770,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ChangingSettingsToNonExistentBeatmapThrows()
         {
-            mockDatabase.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync((string)null!);
+            mockDatabase.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync((string?)null);
 
             MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
             {

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -65,9 +65,9 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public Task<string> GetBeatmapChecksumAsync(int beatmapId)
+        public Task<string?> GetBeatmapChecksumAsync(int beatmapId)
         {
-            return connection.QuerySingleAsync<string>("SELECT checksum from osu_beatmaps where beatmap_id = @BeatmapID", new
+            return connection.QuerySingleAsync<string?>("SELECT checksum from osu_beatmaps where beatmap_id = @BeatmapID", new
             {
                 BeatmapId = beatmapId
             });

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -36,7 +36,7 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Returns the checksum of the beatmap with the given <paramref name="beatmapId"/>.
         /// </summary>
-        Task<string> GetBeatmapChecksumAsync(int beatmapId);
+        Task<string?> GetBeatmapChecksumAsync(int beatmapId);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as active and accepting new players.

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
@@ -170,6 +171,8 @@ namespace osu.Server.Spectator.Hubs
 
                 var playlistItem = await db.GetCurrentPlaylistItemAsync(roomId);
                 var beatmapChecksum = await db.GetBeatmapChecksumAsync(playlistItem.beatmap_id);
+
+                Debug.Assert(beatmapChecksum != null);
 
                 return new MultiplayerRoom(roomId)
                 {
@@ -425,7 +428,7 @@ namespace osu.Server.Spectator.Hubs
             {
                 var dbPlaylistItem = new multiplayer_playlist_item(room);
 
-                string beatmapChecksum = await db.GetBeatmapChecksumAsync(dbPlaylistItem.beatmap_id);
+                string? beatmapChecksum = await db.GetBeatmapChecksumAsync(dbPlaylistItem.beatmap_id);
 
                 if (beatmapChecksum == null)
                     throw new InvalidStateException("Attempted to select a beatmap which does not exist online.");

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -422,7 +422,7 @@ namespace osu.Server.Spectator.Hubs
         private async Task updateDatabaseSettings(MultiplayerRoom room)
         {
             if (room.Settings.RulesetID < 0 || room.Settings.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
-                throw new InvalidStateException("Attempted to select a beatmap of a custom ruleset.");
+                throw new InvalidStateException("Attempted to select an unsupported ruleset.");
 
             using (var db = databaseFactory.GetInstance())
             {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
@@ -417,6 +418,9 @@ namespace osu.Server.Spectator.Hubs
 
         private async Task updateDatabaseSettings(MultiplayerRoom room)
         {
+            if (room.Settings.RulesetID < 0 || room.Settings.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
+                throw new InvalidStateException("Attempted to select a beatmap of a custom ruleset.");
+
             using (var db = databaseFactory.GetInstance())
             {
                 var dbPlaylistItem = new multiplayer_playlist_item(room);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
@@ -172,7 +171,8 @@ namespace osu.Server.Spectator.Hubs
                 var playlistItem = await db.GetCurrentPlaylistItemAsync(roomId);
                 var beatmapChecksum = await db.GetBeatmapChecksumAsync(playlistItem.beatmap_id);
 
-                Debug.Assert(beatmapChecksum != null);
+                if (beatmapChecksum == null)
+                    throw new InvalidOperationException($"Expected non-null checksum on beatmap ID {playlistItem.beatmap_id}");
 
                 return new MultiplayerRoom(roomId)
                 {


### PR DESCRIPTION
Can be reproduced by creating a room regularly in multiplayer, then updating room settings to select a beatmap of a custom ruleset.

**NOTE:** I haven't tested this yet, but it looks to be theoretically working given that the other guards there exist and are working properly.

Wasn't initially sure about just throwing in the number `3` as the maximum legacy ruleset ID (despite of remaining constant), so I went ahead and used `ILegacyRuleset.MAX_LEGACY_RULESET_ID` instead, feels nicer that way.

Also guarded against negative ruleset ID as that sounds like a possibility to happen (from the type of `ruleset_id` in `multiplayer_playlist_item` being signed short).

---

Added 100% code coverage of the whole `updateDatabaseSettings` method while at it.

---

EDIT: This could potentially be the reason why rooms with playlist items of custom rulesets were being received in multiplayer lounge somewhat, though I'm not sure how that could happen given that the user must set the filter to the right custom ruleset ID /shrug.