### PR TITLE
Insert new items into the playlist with each match start

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.205.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.205.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -106,6 +106,14 @@ namespace osu.Server.Spectator.Tests
                         });
             mockDatabase.Setup(db => db.GetBeatmapChecksumAsync(It.IsAny<int>()))
                         .ReturnsAsync("checksum"); // doesn't matter if bogus, just needs to be non-empty.
+
+            mockDatabase.Setup(db => db.GetPlaylistItemFromRoomAsync(It.IsAny<long>(), It.IsAny<long>()))
+                        .Returns<long, long>((roomId, playlistItemId) => Task.FromResult<multiplayer_playlist_item?>(new multiplayer_playlist_item
+                        {
+                            id = playlistItemId,
+                            room_id = roomId,
+                            beatmap_id = 1234,
+                        }));
         }
 
         [Fact]
@@ -119,6 +127,8 @@ namespace osu.Server.Spectator.Tests
 
             await hub.ChangeState(MultiplayerUserState.Ready);
             await hub.StartMatch();
+            await hub.ChangeState(MultiplayerUserState.Loaded);
+            await hub.ChangeState(MultiplayerUserState.FinishedPlay);
 
             using (var usage = hub.GetRoom(room_id))
             {
@@ -126,6 +136,30 @@ namespace osu.Server.Spectator.Tests
                 Debug.Assert(room != null);
 
                 Assert.Equal(expectedPlaylistItemId, room.Settings.PlaylistItemId);
+                mockReceiver.Verify(r => r.SettingsChanged(room.Settings), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task ServerDoesNotAcceptClientPlaylistItemId()
+        {
+            await hub.JoinRoom(room_id);
+
+            MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
+            {
+                Name = "bestest room ever",
+                BeatmapChecksum = "checksum",
+                PlaylistItemId = 1
+            };
+
+            await hub.ChangeSettings(testSettings);
+
+            using (var usage = hub.GetRoom(room_id))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(0, room.Settings.PlaylistItemId);
                 mockReceiver.Verify(r => r.SettingsChanged(room.Settings), Times.Once);
             }
         }

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -114,7 +114,7 @@ namespace osu.Server.Spectator.Tests
             long playlistItemId = (await hub.JoinRoom(room_id)).Settings.PlaylistItemId;
             long expectedPlaylistItemId = playlistItemId + 1;
 
-            mockDatabase.Setup(db => db.CreatePlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()))
+            mockDatabase.Setup(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()))
                         .ReturnsAsync(() => expectedPlaylistItemId);
 
             await hub.ChangeState(MultiplayerUserState.Ready);

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageReference Include="Moq" Version="4.16.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.1">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -160,6 +160,7 @@ namespace osu.Server.Spectator.Database
         {
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
 
+            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET played=1 WHERE id=@id", currentItem);
             await connection.ExecuteAsync(
                 "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
                 + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -171,9 +171,9 @@ namespace osu.Server.Spectator.Database
 
         public async Task EndMatchAsync(MultiplayerRoom room)
         {
-            // Remove all non-played items from the playlist. For now this is only the current item.
+            // Remove all non-expired items from the playlist as they have no scores.
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
-            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE id=@id", currentItem);
+            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE expired = 0");
 
             // Close the room.
             await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = NOW() WHERE id = @RoomID", new

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -183,7 +183,6 @@ namespace osu.Server.Spectator.Database
         public async Task EndMatchAsync(MultiplayerRoom room)
         {
             // Remove all non-expired items from the playlist as they have no scores.
-            var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
             await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE expired = 0");
 
             // Close the room.

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -156,7 +156,7 @@ namespace osu.Server.Spectator.Database
             }
         }
 
-        public async Task<multiplayer_playlist_item> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId)
+        public async Task<multiplayer_playlist_item?> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId)
         {
             return await connection.QueryFirstOrDefaultAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id AND room_id = @RoomId", new
             {

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -165,9 +165,14 @@ namespace osu.Server.Spectator.Database
                 currentItem);
         }
 
-        public Task EndMatchAsync(MultiplayerRoom room)
+        public async Task EndMatchAsync(MultiplayerRoom room)
         {
-            return connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = NOW() WHERE id = @RoomID", new
+            // Remove all non-played items from the playlist. For now this is only the current item.
+            var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
+            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE id=@id", currentItem);
+
+            // Close the room.
+            await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = NOW() WHERE id = @RoomID", new
             {
                 RoomID = room.RoomID
             });

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -163,13 +163,7 @@ namespace osu.Server.Spectator.Database
                 + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",
                 item);
 
-            var lastItem = await connection.QuerySingleAsync<multiplayer_playlist_item>(
-                "SELECT * FROM multiplayer_playlist_items WHERE id = (SELECT MAX(id) FROM multiplayer_playlist_items WHERE room_id = @RoomId)", new
-                {
-                    RoomID = item.room_id
-                });
-
-            return lastItem.id;
+            return await connection.QuerySingleAsync<long>("SELECT max(id) FROM multiplayer_playlist_items WHERE room_id = @room_id", item);
         }
 
         public async Task ExpirePlaylistItemAsync(long playlistItemId)

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -156,13 +156,16 @@ namespace osu.Server.Spectator.Database
             }
         }
 
-        public async Task CommitPlaylistItem(MultiplayerRoom room)
+        public async Task<long> CommitPlaylistItem(MultiplayerRoom room)
         {
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
+
             await connection.ExecuteAsync(
                 "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
                 + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",
                 currentItem);
+
+            return (await GetCurrentPlaylistItemAsync(room.RoomID)).id;
         }
 
         public async Task EndMatchAsync(MultiplayerRoom room)

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -156,7 +156,7 @@ namespace osu.Server.Spectator.Database
             }
         }
 
-        public async Task<long> CreatePlaylistItemAsync(multiplayer_playlist_item item)
+        public async Task<long> AddPlaylistItemAsync(multiplayer_playlist_item item)
         {
             await connection.ExecuteAsync(
                 "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -156,6 +156,15 @@ namespace osu.Server.Spectator.Database
             }
         }
 
+        public async Task<multiplayer_playlist_item> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId)
+        {
+            return await connection.QueryFirstOrDefaultAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id AND room_id = @RoomId", new
+            {
+                Id = playlistItemId,
+                RoomId = roomId
+            });
+        }
+
         public async Task<long> AddPlaylistItemAsync(multiplayer_playlist_item item)
         {
             await connection.ExecuteAsync(

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -160,7 +160,7 @@ namespace osu.Server.Spectator.Database
         {
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
 
-            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET played = 1, updated_at = NOW() WHERE id=@id", currentItem);
+            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET expired = 1, updated_at = NOW() WHERE id=@id", currentItem);
             await connection.ExecuteAsync(
                 "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
                 + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -186,7 +186,10 @@ namespace osu.Server.Spectator.Database
         public async Task EndMatchAsync(MultiplayerRoom room)
         {
             // Remove all non-expired items from the playlist as they have no scores.
-            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE expired = 0");
+            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE room_id = @RoomID AND expired = 0", new
+            {
+                RoomID = room.RoomID
+            });
 
             // Close the room.
             await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = NOW() WHERE id = @RoomID", new

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -186,10 +186,12 @@ namespace osu.Server.Spectator.Database
         public async Task EndMatchAsync(MultiplayerRoom room)
         {
             // Remove all non-expired items from the playlist as they have no scores.
-            await connection.ExecuteAsync("DELETE FROM multiplayer_playlist_items WHERE room_id = @RoomID AND expired = 0", new
-            {
-                RoomID = room.RoomID
-            });
+            await connection.ExecuteAsync(
+                "DELETE FROM multiplayer_playlist_items p WHERE p.room_id = @RoomID AND p.expired = 0 AND (SELECT COUNT(*) FROM multiplayer_scores s WHERE s.playlist_item_id = p.id) = 0",
+                new
+                {
+                    RoomID = room.RoomID
+                });
 
             // Close the room.
             await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = NOW() WHERE id = @RoomID", new

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -59,11 +59,11 @@ namespace osu.Server.Spectator.Database
 
         public Task<multiplayer_playlist_item> GetCurrentPlaylistItemAsync(long roomId)
         {
-            return connection.QuerySingleAsync<multiplayer_playlist_item>(
-                "SELECT * FROM multiplayer_playlist_items WHERE id = (SELECT MAX(id) FROM multiplayer_playlist_items WHERE room_id = @RoomId)", new
-                {
-                    RoomID = roomId
-                });
+            // Todo: Add ordering.
+            return connection.QueryFirstAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE room_id = @RoomId AND expired = 0", new
+            {
+                RoomID = roomId
+            });
         }
 
         public Task<string> GetBeatmapChecksumAsync(int beatmapId)

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -160,7 +160,7 @@ namespace osu.Server.Spectator.Database
         {
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
 
-            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET played=1 WHERE id=@id", currentItem);
+            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET played = 1, updated_at = NOW() WHERE id=@id", currentItem);
             await connection.ExecuteAsync(
                 "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
                 + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -160,7 +160,8 @@ namespace osu.Server.Spectator.Database
         {
             var currentItem = await GetCurrentPlaylistItemAsync(room.RoomID);
             await connection.ExecuteAsync(
-                "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods) VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods)",
+                "INSERT INTO multiplayer_playlist_items (room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
+                + " VALUES (@room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",
                 currentItem);
         }
 

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -59,6 +59,12 @@ namespace osu.Server.Spectator.Database
         Task UpdateRoomParticipantsAsync(MultiplayerRoom room);
 
         /// <summary>
+        /// Retrieves a playlist item from the given room's playlist.
+        /// </summary>
+        /// <returns>The item if it's in the room's playlist, otherwise null.</returns>
+        Task<multiplayer_playlist_item> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId);
+
+        /// <summary>
         /// Creates a new playlist item.
         /// </summary>
         /// <returns>The playlist item ID.</returns>

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Spectator.Database
         /// Creates a new playlist item.
         /// </summary>
         /// <returns>The playlist item ID.</returns>
-        Task<long> CreatePlaylistItemAsync(multiplayer_playlist_item item);
+        Task<long> AddPlaylistItemAsync(multiplayer_playlist_item item);
 
         /// <summary>
         /// Marks a playlist item as expired.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Spectator.Database
         /// Retrieves a playlist item from the given room's playlist.
         /// </summary>
         /// <returns>The item if it's in the room's playlist, otherwise null.</returns>
-        Task<multiplayer_playlist_item> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId);
+        Task<multiplayer_playlist_item?> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId);
 
         /// <summary>
         /// Creates a new playlist item.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -59,9 +59,10 @@ namespace osu.Server.Spectator.Database
         Task UpdateRoomParticipantsAsync(MultiplayerRoom room);
 
         /// <summary>
-        /// Clears all user scores associated with the given <paramref name="room"/>.
+        /// Commits a playlist item, making it immutable in the database.
+        /// A new item is inserted with the existing settings for any new modifications.
         /// </summary>
-        Task ClearRoomScoresAsync(MultiplayerRoom room);
+        Task CommitPlaylistItem(MultiplayerRoom room);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as ended and no longer accepting new players or scores.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -62,7 +62,8 @@ namespace osu.Server.Spectator.Database
         /// Commits a playlist item, making it immutable in the database.
         /// A new item is inserted with the existing settings for any new modifications.
         /// </summary>
-        Task CommitPlaylistItem(MultiplayerRoom room);
+        /// <returns>The new playlist item id to be used for any future setting changes.</returns>
+        Task<long> CommitPlaylistItem(MultiplayerRoom room);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as ended and no longer accepting new players or scores.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -59,11 +59,15 @@ namespace osu.Server.Spectator.Database
         Task UpdateRoomParticipantsAsync(MultiplayerRoom room);
 
         /// <summary>
-        /// Commits a playlist item, making it immutable in the database.
-        /// A new item is inserted with the existing settings for any new modifications.
+        /// Creates a new playlist item.
         /// </summary>
-        /// <returns>The new playlist item id to be used for any future setting changes.</returns>
-        Task<long> CommitPlaylistItem(MultiplayerRoom room);
+        /// <returns>The playlist item ID.</returns>
+        Task<long> CreatePlaylistItemAsync(multiplayer_playlist_item item);
+
+        /// <summary>
+        /// Marks a playlist item as expired.
+        /// </summary>
+        Task ExpirePlaylistItemAsync(long playlistItemId);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as ended and no longer accepting new players or scores.

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -33,8 +33,8 @@ namespace osu.Server.Spectator.Database.Models
         /// <param name="room">The room to retrieve settings from.</param>
         public multiplayer_playlist_item(MultiplayerRoom room)
         {
+            id = room.Settings.PlaylistItemId;
             room_id = room.RoomID;
-
             beatmap_id = room.Settings.BeatmapID;
             ruleset_id = (short)room.Settings.RulesetID;
             required_mods = JsonConvert.SerializeObject(room.Settings.RequiredMods);

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -21,6 +21,7 @@ namespace osu.Server.Spectator.Database.Models
         public string? required_mods { get; set; }
         public DateTimeOffset? created_at { get; set; }
         public DateTimeOffset? updated_at { get; set; }
+        public bool expired { get; set; }
 
         // for deserialization
         public multiplayer_playlist_item()

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -425,7 +425,7 @@ namespace osu.Server.Spectator.Hubs
             // Todo: Only run the following code for non-host-rotate matches.
             long newPlaylistItemId;
             using (var db = databaseFactory.GetInstance())
-                newPlaylistItemId = await db.CreatePlaylistItemAsync(currentItem);
+                newPlaylistItemId = await db.AddPlaylistItemAsync(currentItem);
 
             // Distribute the new playlist item ID to clients. All future playlist changes will affect this new one.
             room.Settings.PlaylistItemId = newPlaylistItemId;

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -351,7 +351,7 @@ namespace osu.Server.Spectator.Hubs
                 if (room.Host != null && room.Host.State != MultiplayerUserState.Ready)
                     throw new InvalidStateException("Can't start match when the host is not ready.");
 
-                await clearDatabaseScores(room);
+                await commitPlaylistItem(room);
 
                 foreach (var u in readyUsers)
                     await changeAndBroadcastUserState(room, u, MultiplayerUserState.WaitingForLoad);
@@ -409,10 +409,10 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="gameplay">Whether the group ID should be for active gameplay, or room control messages.</param>
         public static string GetGroupId(long roomId, bool gameplay = false) => $"room:{roomId}:{gameplay}";
 
-        private async Task clearDatabaseScores(MultiplayerRoom room)
+        private async Task commitPlaylistItem(MultiplayerRoom room)
         {
             using (var db = databaseFactory.GetInstance())
-                await db.ClearRoomScoresAsync(room);
+                await db.CommitPlaylistItem(room);
         }
 
         private async Task updateDatabaseSettings(MultiplayerRoom room)

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -359,7 +359,7 @@ namespace osu.Server.Spectator.Hubs
 
                 await Clients.Group(GetGroupId(room.RoomID, true)).LoadRequested();
 
-                await commitPlaylistItem(room);
+                await selectNextPlaylistItem(room);
             }
         }
 
@@ -410,7 +410,7 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="gameplay">Whether the group ID should be for active gameplay, or room control messages.</param>
         public static string GetGroupId(long roomId, bool gameplay = false) => $"room:{roomId}:{gameplay}";
 
-        private async Task commitPlaylistItem(MultiplayerRoom room)
+        private async Task selectNextPlaylistItem(MultiplayerRoom room)
         {
             multiplayer_playlist_item currentItem;
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -376,6 +376,10 @@ namespace osu.Server.Spectator.Hubs
 
                 ensureIsHost(room);
 
+                // Server is authoritative over the playlist item ID.
+                // Todo: This needs to change for tournament mode.
+                settings.PlaylistItemId = room.Settings.PlaylistItemId;
+
                 if (room.Settings.Equals(settings))
                     return;
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -412,9 +412,9 @@ namespace osu.Server.Spectator.Hubs
         {
             long newPlaylistItemId;
 
-            // Expire the current playlist item.
             using (var db = databaseFactory.GetInstance())
             {
+                // Expire the current playlist item.
                 var currentItem = await db.GetCurrentPlaylistItemAsync(room.RoomID);
                 await db.ExpirePlaylistItemAsync(currentItem.id);
 
@@ -436,6 +436,9 @@ namespace osu.Server.Spectator.Hubs
 
                 if (dbItem == null)
                     throw new InvalidStateException("Attempted to select a playlist item not contained by the room.");
+
+                if (dbItem.expired)
+                    throw new InvalidStateException("Attempted to select an expired playlist item.");
 
                 string beatmapChecksum = await db.GetBeatmapChecksumAsync(item.beatmap_id);
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -9,12 +9,12 @@
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.78" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.205.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2021.119.0" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-web/pull/7223
- [x] https://github.com/ppy/osu/pull/11808

On match end:
1. The current playlist item is duplicated.
2. `expired = 1` is set on the old playlist item.
3. The duplicate item is propagated to clients via `SettingsChanged`.

Here's how it looks at a database level: https://drive.google.com/file/d/1xDLePId0IIVdqU3Qce437A9CRYSH0v95/view?usp=sharing

Compatibility between old and new clients:
- Old clients can join rooms from the new clients that are on their first playlist item. Any more than that and they die on a `Playlist.SingleOrDefault()` call somewhere.
- Old clients can play the first playlist item, but then die on an added osu-web exception (https://github.com/ppy/osu-web/blob/d92c83fb80467796da3b892647fa426842f868e6/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php#L196) otherwise they'd submit to an older playlist_item_id.
- Old clients can't change beatmaps - they don't populate `PlaylistItemId` and die on an added exception (https://github.com/ppy/osu-server-spectator/compare/master...smoogipoo:multiplayer-no-playlist-mangling?expand=1#diff-90658690a1d84ef42d78f75a985211e9140da7fdadbcb3b5562eee9c5d894fd7R437-R438)