### PR TITLE
Add support for Spectating user state

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.410.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.410.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -42,6 +42,7 @@ namespace osu.Server.Spectator.Tests
         private readonly Mock<HubCallerContext> mockContextUser1;
         private readonly Mock<HubCallerContext> mockContextUser2;
 
+        private readonly Mock<IHubCallerClients<IMultiplayerClient>> mockClients;
         private readonly Mock<IGroupManager> mockGroups;
 
         public MultiplayerFlowTests()
@@ -56,6 +57,7 @@ namespace osu.Server.Spectator.Tests
 
             hub = new TestMultiplayerHub(cache, mockDatabaseFactory.Object);
 
+            mockClients = new Mock<IHubCallerClients<IMultiplayerClient>>();
             mockGroups = new Mock<IGroupManager>();
 
             mockContextUser1 = new Mock<HubCallerContext>();
@@ -65,8 +67,6 @@ namespace osu.Server.Spectator.Tests
             mockContextUser2 = new Mock<HubCallerContext>();
             mockContextUser2.Setup(context => context.UserIdentifier).Returns(user_id_2.ToString());
             mockContextUser2.Setup(context => context.ConnectionId).Returns(user_id_2.ToString());
-
-            Mock<IHubCallerClients<IMultiplayerClient>> mockClients = new Mock<IHubCallerClients<IMultiplayerClient>>();
 
             mockReceiver = new Mock<IMultiplayerClient>();
             mockClients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(room_id, false))).Returns(mockReceiver.Object);
@@ -820,6 +820,47 @@ namespace osu.Server.Spectator.Tests
             await hub.JoinRoom(room_id);
             await hub.ChangeSettings(testSettings);
             mockReceiver.Verify(r => r.SettingsChanged(testSettings), Times.Once);
+        }
+
+        #endregion
+
+        #region Spectating
+
+        [Fact]
+        public async Task SpectatingUserAddedAndRemovedFromGameplayGroup()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+
+            verifyAddedToGameplayGroup(mockContextUser1, room_id);
+
+            await hub.ChangeState(MultiplayerUserState.Idle);
+            verifyRemovedFromGameplayGroup(mockContextUser1, room_id);
+        }
+
+        [Fact]
+        public async Task SpectatingUserStateDoesNotChange()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Ready);
+
+            setUserContext(mockContextUser2);
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+
+            setUserContext(mockContextUser1);
+
+            await hub.StartMatch();
+            mockGameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+            mockClients.Verify(clients => clients.Client(mockContextUser2.Object.ConnectionId).UserStateChanged(user_id_2, MultiplayerUserState.WaitingForLoad), Times.Never);
+
+            await hub.ChangeState(MultiplayerUserState.Loaded);
+            mockReceiver.Verify(c => c.MatchStarted(), Times.Once);
+            mockClients.Verify(clients => clients.Client(mockContextUser2.Object.ConnectionId).UserStateChanged(user_id_2, MultiplayerUserState.Playing), Times.Never);
+
+            await hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            mockReceiver.Verify(c => c.ResultsReady(), Times.Once);
+            mockClients.Verify(clients => clients.Client(mockContextUser2.Object.ConnectionId).UserStateChanged(user_id_2, MultiplayerUserState.Results), Times.Never);
         }
 
         #endregion

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -919,6 +919,22 @@ namespace osu.Server.Spectator.Tests
         #region Spectating
 
         [Fact]
+        public async Task CanTransitionBetweenIdleAndSpectating()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+            await hub.ChangeState(MultiplayerUserState.Idle);
+        }
+
+        [Fact]
+        public async Task CanTransitionFromReadyToSpectating()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Ready);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+        }
+
+        [Fact]
         public async Task SpectatingUserStateDoesNotChange()
         {
             await hub.JoinRoom(room_id);
@@ -941,6 +957,21 @@ namespace osu.Server.Spectator.Tests
             await hub.ChangeState(MultiplayerUserState.FinishedPlay);
             mockReceiver.Verify(c => c.ResultsReady(), Times.Once);
             mockClients.Verify(clients => clients.Client(mockContextUser2.Object.ConnectionId).UserStateChanged(user_id_2, MultiplayerUserState.Results), Times.Never);
+        }
+
+        [Fact]
+        public async Task SpectatingHostCanStartMatch()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+
+            setUserContext(mockContextUser2);
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Ready);
+
+            setUserContext(mockContextUser1);
+            await hub.StartMatch();
+            mockGameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
         }
 
         #endregion

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -44,6 +44,7 @@ namespace osu.Server.Spectator.Tests
 
         private readonly Mock<IHubCallerClients<IMultiplayerClient>> mockClients;
         private readonly Mock<IGroupManager> mockGroups;
+        private readonly Mock<IMultiplayerClient> mockCaller;
 
         public MultiplayerFlowTests()
         {
@@ -76,6 +77,9 @@ namespace osu.Server.Spectator.Tests
 
             var mockReceiver2 = new Mock<IMultiplayerClient>();
             mockClients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(room_id_2, false))).Returns(mockReceiver2.Object);
+
+            mockCaller = new Mock<IMultiplayerClient>();
+            mockClients.Setup(client => client.Caller).Returns(mockCaller.Object);
 
             hub.Groups = mockGroups.Object;
             hub.Clients = mockClients.Object;
@@ -861,6 +865,25 @@ namespace osu.Server.Spectator.Tests
             await hub.ChangeState(MultiplayerUserState.FinishedPlay);
             mockReceiver.Verify(c => c.ResultsReady(), Times.Once);
             mockClients.Verify(clients => clients.Client(mockContextUser2.Object.ConnectionId).UserStateChanged(user_id_2, MultiplayerUserState.Results), Times.Never);
+        }
+
+        [Fact]
+        public async Task SpectatingUserReceivesLoadRequestedAfterMatchStarted()
+        {
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Ready);
+            await hub.StartMatch();
+            mockReceiver.Verify(c => c.LoadRequested(), Times.Never);
+            mockGameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+
+            setUserContext(mockContextUser2);
+            await hub.JoinRoom(room_id);
+            await hub.ChangeState(MultiplayerUserState.Spectating);
+            mockCaller.Verify(c => c.LoadRequested(), Times.Once);
+
+            // Ensure no other clients received LoadRequested().
+            mockReceiver.Verify(c => c.LoadRequested(), Times.Never);
+            mockGameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
         }
 
         #endregion

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -601,7 +601,7 @@ namespace osu.Server.Spectator.Hubs
                     throw new InvalidStateChangeException(oldState, newState);
 
                 case MultiplayerUserState.Spectating:
-                    if (oldState != MultiplayerUserState.Idle)
+                    if (oldState != MultiplayerUserState.Idle && oldState != MultiplayerUserState.Ready)
                         throw new InvalidStateChangeException(oldState, newState);
 
                     break;

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -350,7 +350,7 @@ namespace osu.Server.Spectator.Hubs
                 if (readyUsers.Length == 0)
                     throw new InvalidStateException("Can't start match when no users are ready.");
 
-                if (room.Host != null && room.Host.State != MultiplayerUserState.Ready)
+                if (room.Host != null && room.Host.State != MultiplayerUserState.Spectating && room.Host.State != MultiplayerUserState.Ready)
                     throw new InvalidStateException("Can't start match when the host is not ready.");
 
                 foreach (var u in readyUsers)

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -595,7 +595,7 @@ namespace osu.Server.Spectator.Hubs
                     throw new InvalidStateChangeException(oldState, newState);
 
                 case MultiplayerUserState.Spectating:
-                    if (oldState > MultiplayerUserState.Ready)
+                    if (oldState != MultiplayerUserState.Idle)
                         throw new InvalidStateChangeException(oldState, newState);
 
                     break;

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -276,6 +276,13 @@ namespace osu.Server.Spectator.Hubs
                 await Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(CurrentContextUserId, newState);
 
                 await updateRoomStateIfRequired(room);
+
+                // If the user is spectating and the match has started, notify them to start loading.
+                if (newState == MultiplayerUserState.Spectating
+                    && room.State == MultiplayerRoomState.WaitingForLoad || room.State == MultiplayerRoomState.Playing)
+                {
+                    await Clients.Caller.LoadRequested();
+                }
             }
         }
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -268,6 +268,7 @@ namespace osu.Server.Spectator.Hubs
                         break;
 
                     case MultiplayerUserState.Ready:
+                    case MultiplayerUserState.Spectating:
                         await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
                         break;
                 }
@@ -592,6 +593,12 @@ namespace osu.Server.Spectator.Hubs
                 case MultiplayerUserState.Results:
                     // state is managed by the server.
                     throw new InvalidStateChangeException(oldState, newState);
+
+                case MultiplayerUserState.Spectating:
+                    if (oldState > MultiplayerUserState.Ready)
+                        throw new InvalidStateChangeException(oldState, newState);
+
+                    break;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(newState), newState, null);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -272,7 +272,6 @@ namespace osu.Server.Spectator.Hubs
                         break;
 
                     case MultiplayerUserState.Ready:
-                    case MultiplayerUserState.Spectating:
                         await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
                         break;
                 }
@@ -280,13 +279,6 @@ namespace osu.Server.Spectator.Hubs
                 await Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(CurrentContextUserId, newState);
 
                 await updateRoomStateIfRequired(room);
-
-                // If the user is spectating and the match has started, notify them to start loading.
-                if (newState == MultiplayerUserState.Spectating
-                    && room.State == MultiplayerRoomState.WaitingForLoad || room.State == MultiplayerRoomState.Playing)
-                {
-                    await Clients.Caller.LoadRequested();
-                }
             }
         }
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -9,12 +9,12 @@
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.78" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.410.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2021.119.0" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] New osu.Game nuget package.

In particular:
1. A spectating host should be able to start the match.
2. `Idle <-> Spectating` and `Ready -> Spectating` are the valid state transitions.