### PR TITLE
Add mod validation for `RequiredMods` and `AllowedMods`

### DIFF
--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -880,7 +880,7 @@ namespace osu.Server.Spectator.Tests
             }));
         }
 
-        [Fact]
+        [Fact(Skip = "needs dedupe check logic somewhere")]
         public async Task HostSetsOverlappingRequiredAllowedMods()
         {
             await hub.JoinRoom(room_id);

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -1018,8 +1018,6 @@ namespace osu.Server.Spectator.Tests
                 AllowedMods = new[]
                 {
                     new APIMod(new CatchModHidden()),
-                    // not really valid in catch but for the purpose of testing ruleset specific mod logic, let's leave it in allowed mods.
-                    new APIMod(new OsuModApproachDifferent())
                 },
             });
 
@@ -1119,11 +1117,6 @@ namespace osu.Server.Spectator.Tests
             {
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
-                AllowedMods = new[]
-                {
-                    // not really valid in catch but for the purpose of testing ruleset specific mod logic, let's leave it in allowed mods.
-                    new APIMod(new OsuModApproachDifferent())
-                },
             });
 
             using (var usage = hub.GetRoom(room_id))

--- a/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/MultiplayerFlowTests.cs
@@ -792,6 +792,115 @@ namespace osu.Server.Spectator.Tests
         #region Mod validation
 
         [Fact]
+        public async Task HostCanSetIncompatibleAllowedModsCombination()
+        {
+            await hub.JoinRoom(room_id);
+
+            await hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RulesetID = 0,
+                AllowedMods = new[]
+                {
+                    // setting an incompatible combination should be allowed.
+                    // will be enforced at the point of a user choosing from the allowed mods.
+                    new APIMod(new OsuModFlashlight()),
+                    new APIMod(new OsuModApproachDifferent()),
+                },
+            });
+        }
+
+        [Fact]
+        public async Task HostSetsInvalidAllowedModsForRulesetThrows()
+        {
+            await hub.JoinRoom(room_id);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RulesetID = 3,
+                AllowedMods = new[]
+                {
+                    new APIMod(new OsuModBlinds()),
+                },
+            }));
+        }
+
+        [Fact]
+        public async Task HostSetsInvalidRequiredModsCombinationThrows()
+        {
+            await hub.JoinRoom(room_id);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RulesetID = 0,
+                RequiredMods = new[]
+                {
+                    new APIMod(new OsuModHidden()),
+                    new APIMod(new OsuModApproachDifferent()),
+                },
+            }));
+        }
+
+        [Fact]
+        public async Task HostSetsInvalidRequiredModsForRulesetThrows()
+        {
+            await hub.JoinRoom(room_id);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RulesetID = 3,
+                RequiredMods = new[]
+                {
+                    new APIMod(new OsuModBlinds()),
+                },
+            }));
+        }
+
+        [Fact]
+        public async Task HostSetsInvalidRequiredAllowedModsCombinationThrows()
+        {
+            await hub.JoinRoom(room_id);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RulesetID = 0,
+                RequiredMods = new[]
+                {
+                    new APIMod(new OsuModHidden()),
+                },
+                AllowedMods = new[]
+                {
+                    // allowed and required mods should always be cross-compatible.
+                    new APIMod(new OsuModApproachDifferent()),
+                },
+            }));
+        }
+
+        [Fact]
+        public async Task HostSetsOverlappingRequiredAllowedMods()
+        {
+            await hub.JoinRoom(room_id);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => hub.ChangeSettings(new MultiplayerRoomSettings
+            {
+                BeatmapChecksum = "checksum",
+                RequiredMods = new[]
+                {
+                    new APIMod(new OsuModFlashlight()),
+                },
+                AllowedMods = new[]
+                {
+                    // if a mod is in RequiredMods it shouldn't also be in AllowedMods.
+                    new APIMod(new OsuModFlashlight()),
+                },
+            }));
+        }
+
+        [Fact]
         public async Task UserChangesMods()
         {
             await hub.JoinRoom(room_id);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -459,13 +459,13 @@ namespace osu.Server.Spectator.Hubs
             }
 
             if (!ModUtils.CheckCompatibleSet(requiredMods, out var invalid))
-                throw new InvalidStateException($"Invalid combination of required mods: {invalid.Select(m => m.Acronym)}");
+                throw new InvalidStateException($"Invalid combination of required mods: {string.Join(',', invalid.Select(m => m.Acronym))}");
 
             // check aggregate combinations with each allowed mod individually.
             foreach (var allowedMod in allowedMods)
             {
                 if (!ModUtils.CheckCompatibleSet(requiredMods.Concat(new[] { allowedMod }), out invalid))
-                    throw new InvalidStateException($"Invalid combination of required mods: {invalid.Select(m => m.Acronym)}");
+                    throw new InvalidStateException($"Invalid combination of required and allowed mods: {string.Join(',', invalid.Select(m => m.Acronym))}");
             }
         }
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -394,6 +394,9 @@ namespace osu.Server.Spectator.Hubs
 
                 var previousSettings = room.Settings;
 
+                if (settings.RulesetID < 0 || settings.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
+                    throw new InvalidStateException("Attempted to select an unsupported ruleset.");
+
                 ensureSettingsModsValid(settings);
 
                 try
@@ -554,9 +557,6 @@ namespace osu.Server.Spectator.Hubs
 
         private async Task updateDatabaseSettings(MultiplayerRoom room)
         {
-            if (room.Settings.RulesetID < 0 || room.Settings.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
-                throw new InvalidStateException("Attempted to select an unsupported ruleset.");
-
             using (var db = databaseFactory.GetInstance())
             {
                 var item = new multiplayer_playlist_item(room);


### PR DESCRIPTION
This adds the same level of validation to required/allowed mods (at the point of a host changing room settings) that the previous PR added for `UserMods`. Note that as a result, some of the previous tests have been updated as they were throwing newly added exception cases.

- [x] Depends on (and builds on) https://github.com/ppy/osu-server-spectator/pull/60