### PR TITLE
Add UseLocalOsu scripts

### DIFF
--- a/UseLocalOsu.ps1
+++ b/UseLocalOsu.ps1
@@ -1,0 +1,30 @@
+# Run this script to use a local copy of osu rather than fetching it from nuget.
+# It expects the osu directory to be at the same level as the osu-tools directory
+
+
+$CSPROJ="osu.Server.Spectator/osu.Server.Spectator.csproj"
+$SLN="osu.Server.Spectator.sln"
+
+$DEPENDENCIES=@(
+    "..\osu\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj"
+    "..\osu\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj"
+    "..\osu\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj"
+    "..\osu\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj"
+    "..\osu\osu.Game\osu.Game.csproj"
+)
+
+
+dotnet remove $CSPROJ package ppy.osu.Game
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Osu
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Taiko
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Catch
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Mania
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES
+
+dotnet remove "SampleMultiplayerClient\SampleMultiplayerClient.csproj" package ppy.osu.Game
+dotnet add "SampleMultiplayerClient\SampleMultiplayerClient.csproj" reference "..\osu\osu.Game\osu.Game.csproj"
+
+dotnet remove "SampleSpectatorClient\SampleSpectatorClient.csproj" package ppy.osu.Game
+dotnet add "SampleSpectatorClient\SampleSpectatorClient.csproj" reference "..\osu\osu.Game\osu.Game.csproj"

--- a/UseLocalOsu.sh
+++ b/UseLocalOsu.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Run this script to use a local copy of osu rather than fetching it from nuget.
+# It expects the osu directory to be at the same level as the osu-tools directory
+
+
+CSPROJ="osu.Server.Spectator/osu.Server.Spectator.csproj"
+SLN="osu.Server.Spectator.sln"
+
+DEPENDENCIES="../osu/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+    ../osu/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+    ../osu/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+    ../osu/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+    ../osu/osu.Game/osu.Game.csproj"
+
+
+dotnet remove $CSPROJ package ppy.osu.Game
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Osu
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Taiko
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Catch
+dotnet remove $CSPROJ package ppy.osu.Game.Rulesets.Mania
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES
+
+dotnet remove "SampleMultiplayerClient/SampleMultiplayerClient.csproj" package ppy.osu.Game
+dotnet add "SampleMultiplayerClient/SampleMultiplayerClient.csproj" reference "../osu/osu.Game/osu.Game.csproj"
+
+dotnet remove "SampleSpectatorClient/SampleSpectatorClient.csproj" package ppy.osu.Game
+dotnet add "SampleSpectatorClient/SampleSpectatorClient.csproj" reference "../osu/osu.Game/osu.Game.csproj"


### PR DESCRIPTION
I have found this useful when testing a local deploy. Basically a copy of the same script that exists in osu-difficulty-calculator/osu-tools.
Especially since https://github.com/ppy/osu-server-spectator/pull/65 had an uncaught compile error because local osu! wasn't tested with all contained projects.