### PR TITLE
Avoid incorrect async usage inside `Thread`

### DIFF
--- a/osu.Server.Spectator.Tests/EntityStoreTests.cs
+++ b/osu.Server.Spectator.Tests/EntityStoreTests.cs
@@ -143,16 +143,16 @@ namespace osu.Server.Spectator.Tests
             var firstLockAchieved = new ManualResetEventSlim();
             var firstLockDelayComplete = new ManualResetEventSlim();
 
-            new Thread(async () =>
+            new Thread(() =>
             {
-                using (var firstGet = await store.GetForUse(1, true))
+                using (var firstGet = store.GetForUse(1, true).Result)
                 {
                     // signal the second fetch to start once the first lock has been achieved.
                     firstLockAchieved.Set();
 
                     firstGet.Item = new TestItem("test data");
 
-                    await Task.Delay(2000);
+                    Thread.Sleep(2000);
 
                     firstLockDelayComplete.Set();
                 }


### PR DESCRIPTION
Based on the new inspection, similar to fixes applied on osu side.

![20210722 161859 (JetBrains Rider-EAP)](https://user-images.githubusercontent.com/191335/126602593-b95ee3f2-800a-4f50-be80-b46977737717.png)