### PR TITLE
Fix `UserModsChanged` incorrectly invoked with the current context ID

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -447,7 +447,7 @@ namespace osu.Server.Spectator.Hubs
 
             user.Mods = newModList;
 
-            await Clients.Group(GetGroupId(room.RoomID)).UserModsChanged(CurrentContextUserId, newModList);
+            await Clients.Group(GetGroupId(room.RoomID)).UserModsChanged(user.UserID, newModList);
         }
 
         private static void ensureSettingsModsValid(MultiplayerRoomSettings settings)


### PR DESCRIPTION
Theortically, this should be the solution to https://github.com/ppy/osu/issues/13956, as the server correctly updates `user.Mods` on changes to the allowed mods list, and the [existing logic osu!-side](https://github.com/ppy/osu/blob/abc96057b2cf50e02e0ec939645f6421684495d4/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs#L176-L178) should be a no-op in that case.

But I can't test with a local server currently, so will have to wait for this to be deployed first to confirm.