### PR TITLE
Use `osuweb` database user ID in run configurations

### DIFF
--- a/osu.Server.Spectator/Properties/launchSettings.json
+++ b/osu.Server.Spectator/Properties/launchSettings.json
@@ -9,15 +9,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": false,
-      "launchUrl": "ranklookup",
-      "environmentVariables": {
-        "DB_USER": "osuweb",
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "osu.Server.Spectator": {
       "commandName": "Project",
       "launchBrowser": false,

--- a/osu.Server.Spectator/Properties/launchSettings.json
+++ b/osu.Server.Spectator/Properties/launchSettings.json
@@ -14,6 +14,7 @@
       "launchBrowser": false,
       "launchUrl": "ranklookup",
       "environmentVariables": {
+        "DB_USER": "osuweb",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
@@ -23,6 +24,7 @@
       "launchUrl": "spectator",
       "applicationUrl": "http://localhost:5009",
       "environmentVariables": {
+        "DB_USER": "osuweb",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }


### PR DESCRIPTION
That's what an osu!web setup would use by default (see [`.env.example`](https://github.com/ppy/osu-web/blob/ff0dcdda9e421a21852146120dcb9ce49cff5d1d/.env.example#L17)).

The `launchSettings.json` would also be used when running using `dotnet run` which is a good thing for this.