### PR TITLE
Disallow creating or changing rooms to "playlists" type

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using Xunit;
@@ -24,6 +25,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 0,
                 AllowedMods = new[]
                 {
@@ -43,6 +45,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 3,
                 AllowedMods = new[]
                 {
@@ -59,6 +62,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 0,
                 RequiredMods = new[]
                 {
@@ -76,6 +80,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 3,
                 RequiredMods = new[]
                 {
@@ -92,6 +97,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 0,
                 RequiredMods = new[]
                 {
@@ -113,6 +119,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RequiredMods = new[]
                 {
                     new APIMod(new OsuModFlashlight()),
@@ -133,6 +140,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new OsuModFlashlight()),
@@ -169,6 +177,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new OsuModHidden()),
@@ -209,6 +218,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new CatchModHidden()),
@@ -240,6 +250,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new CatchModHidden()),
@@ -282,6 +293,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new OsuModApproachDifferent()),
@@ -301,6 +313,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new OsuModFlashlight()),
@@ -336,6 +349,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             var roomSettings = new MultiplayerRoomSettings
             {
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 AllowedMods = new[]
                 {
                     new APIMod(new OsuModApproachDifferent())
@@ -357,6 +371,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
             });
 
             using (var usage = Hub.GetRoom(ROOM_ID))

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomPlaylistTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomPlaylistTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database.Models;
 using Xunit;
 
@@ -45,6 +46,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 Name = "bestest room ever",
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 PlaylistItemId = 1
             };
 

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using Xunit;
 
@@ -18,7 +19,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
             {
                 Name = "bestest room ever",
-                BeatmapChecksum = "checksum"
+                BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead
             };
 
             await Hub.JoinRoom(ROOM_ID);
@@ -39,7 +41,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
             {
                 Name = "bestest room ever",
-                BeatmapChecksum = "checksum"
+                BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead
             };
 
             await Hub.JoinRoom(ROOM_ID);
@@ -88,6 +91,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 BeatmapID = 1234567,
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.HeadToHead,
                 RulesetID = 2
             };
 
@@ -104,6 +108,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
             {
                 BeatmapID = 3333,
+                MatchType = MatchType.Playlists,
                 BeatmapChecksum = "checksum",
             };
 
@@ -119,6 +124,23 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
             {
                 BeatmapID = 9999,
+                MatchType = MatchType.HeadToHead,
+                BeatmapChecksum = "incorrect checksum",
+            };
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeSettings(testSettings));
+        }
+
+        [Fact]
+        public async Task ChangingSettingsToUnsupportedMatchTypeThrows()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(9999)).ReturnsAsync("correct checksum");
+
+            MultiplayerRoomSettings testSettings = new MultiplayerRoomSettings
+            {
+                BeatmapID = 9999,
+                MatchType = MatchType.Playlists,
                 BeatmapChecksum = "incorrect checksum",
             };
 
@@ -135,6 +157,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 BeatmapID = 1234,
                 BeatmapChecksum = "checksum",
+                MatchType = MatchType.Playlists,
                 RulesetID = rulesetID,
             };
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -447,6 +447,9 @@ namespace osu.Server.Spectator.Hubs
 
                 ensureSettingsModsValid(settings);
 
+                if (settings.MatchType == MatchType.Playlists)
+                    throw new InvalidStateException($"Invalid match type selected");
+
                 try
                 {
                     room.Settings = settings;


### PR DESCRIPTION
This is only in the enum for legacy purposes. For now let's just ensure that a room can't be set to it.
