### PR TITLE
Don't throw exception when attempting to leave a room when not joined

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -118,9 +118,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task UserCantLeaveWhenNotAlreadyJoined()
+        public async Task LeaveWhenNotAlreadyJoinedIsNoop()
         {
-            await Assert.ThrowsAsync<NotJoinedRoomException>(() => Hub.LeaveRoom());
+            await Hub.LeaveRoom();
 
             // ensure no state was left behind.
             await Assert.ThrowsAsync<KeyNotFoundException>(() => UserStates.GetForUse(USER_ID));

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -227,7 +227,7 @@ namespace osu.Server.Spectator.Hubs
             using (var userUsage = await GetOrCreateLocalUserState())
             {
                 if (userUsage.Item == null)
-                    throw new NotJoinedRoomException();
+                    return;
 
                 try
                 {


### PR DESCRIPTION
This is already deployed to production. It was used to make client-side event flow simpler in the case of kick operations.
