### PR TITLE
Rework multiplayer queue to expose item ordering to clients

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.1122.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.1204.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.1122.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.1204.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -36,7 +36,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.Equal(playlistItemId, room.Settings.PlaylistItemId);
-                Database.Verify(db => db.UpdatePlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()), Times.Never);
                 Database.Verify(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()), Times.Once);
                 Receiver.Verify(r => r.PlaylistItemAdded(newItem), Times.Once);
                 Receiver.Verify(r => r.SettingsChanged(It.IsAny<MultiplayerRoomSettings>()), Times.Exactly(2));

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -44,47 +44,16 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "5555"
             });
 
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // Item 1 selected (user 1)
-                Assert.Equal(1, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(1);
 
             await runGameplay();
-
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // Item 4 selected (user 2)
-                Assert.Equal(4, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(4);
 
             await runGameplay();
-
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // Item 2 selected (user 1)
-                Assert.Equal(2, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(2);
 
             await runGameplay();
-
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // Item 3 selected (user 1). User 2 has no more items available.
-                Assert.Equal(3, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(3);
         }
 
         [Fact]
@@ -112,37 +81,57 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             });
 
             await runGameplay();
-
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // After playing the first item, the second item (by player 1) is selected.
-                Assert.Equal(2, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(2);
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
-
-            using (var usage = Hub.GetRoom(ROOM_ID))
-            {
-                var room = usage.Item;
-                Debug.Assert(room != null);
-
-                // After changing to fair-play mode, we expect the third item (by player 2) to be selected.
-                Assert.Equal(3, room.Settings.PlaylistItemId);
-            }
+            checkCurrentItem(3);
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+            checkCurrentItem(2);
+        }
 
-            using (var usage = Hub.GetRoom(ROOM_ID))
+        [Fact]
+        public async Task CurrentItemOrderedByPlayedAt()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser);
+
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
-                var room = usage.Item;
-                Debug.Assert(room != null);
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
 
-                // After changing back to free-for-all mode, we expect the second item (by player 1) to be selected.
-                Assert.Equal(2, room.Settings.PlaylistItemId);
-            }
+            await runGameplay();
+            await runGameplay();
+
+            // Item 3: Now the only non-expired item in the room.
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
+
+            SetUserContext(ContextUser2);
+
+            // Item 4: Because this user hasn't had any items played, this item will be moved to the start.
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
+
+            await runGameplay();
+            await runGameplay();
+
+            // Item 3 should be the "current" item, as it is in order of play rather than order of addition.
+            checkCurrentItem(3);
         }
 
         private async Task runGameplay()
@@ -167,6 +156,18 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             SetUserContext(ContextUser);
+        }
+
+        private void checkCurrentItem(long expectedItemId)
+        {
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                // After changing back to free-for-all mode, we expect the second item (by player 1) to be selected.
+                Assert.Equal(expectedItemId, room.Settings.PlaylistItemId);
+            }
         }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -165,7 +165,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                // After changing back to free-for-all mode, we expect the second item (by player 1) to be selected.
                 Assert.Equal(expectedItemId, room.Settings.PlaylistItemId);
             }
         }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -86,8 +86,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == newItem.ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)), Times.Once);
-                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(2));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)));
+                Receiver.Verify(r => r.SettingsChanged(room.Settings));
             }
 
             // And a second time...
@@ -116,8 +116,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == newItem.ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)), Times.Once);
-                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(3));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)));
+                Receiver.Verify(r => r.SettingsChanged(room.Settings));
             }
         }
 
@@ -153,9 +153,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.Equal(room.Playlist[1].ID, room.Settings.PlaylistItemId);
                 Assert.True(room.Playlist[0].Expired);
 
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[0].ID && i.Expired)), Times.Once);
                 Receiver.Verify(r => r.PlaylistItemAdded(It.IsAny<MultiplayerPlaylistItem>()), Times.Once);
-                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(2));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[0].ID && i.Expired)));
+                Receiver.Verify(r => r.SettingsChanged(room.Settings));
             }
 
             // Play the second item in host-only mode.
@@ -178,8 +178,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[2].ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[1].ID && i.Expired)), Times.Once);
-                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(3));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[1].ID && i.Expired)));
+                Receiver.Verify(r => r.SettingsChanged(room.Settings));
             }
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -86,8 +86,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == newItem.ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)));
-                Receiver.Verify(r => r.SettingsChanged(room.Settings));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)), Times.Once);
+                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(2));
             }
 
             // And a second time...
@@ -116,8 +116,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == newItem.ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)));
-                Receiver.Verify(r => r.SettingsChanged(room.Settings));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == oldItem.ID && i.Expired)), Times.Once);
+                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(3));
             }
         }
 
@@ -153,9 +153,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.Equal(room.Playlist[1].ID, room.Settings.PlaylistItemId);
                 Assert.True(room.Playlist[0].Expired);
 
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[0].ID && i.Expired)), Times.Once);
                 Receiver.Verify(r => r.PlaylistItemAdded(It.IsAny<MultiplayerPlaylistItem>()), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[0].ID && i.Expired)));
-                Receiver.Verify(r => r.SettingsChanged(room.Settings));
+                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(2));
             }
 
             // Play the second item in host-only mode.
@@ -178,8 +178,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 // Players received callbacks.
                 Receiver.Verify(r => r.PlaylistItemAdded(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[2].ID)), Times.Once);
-                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[1].ID && i.Expired)));
-                Receiver.Verify(r => r.SettingsChanged(room.Settings));
+                Receiver.Verify(r => r.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == room.Playlist[1].ID && i.Expired)), Times.Once);
+                Receiver.Verify(r => r.SettingsChanged(room.Settings), Times.Exactly(3));
             }
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -150,6 +150,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Database.Setup(db => db.GetBeatmapChecksumAsync(It.IsAny<int>()))
                     .ReturnsAsync("checksum"); // doesn't matter if bogus, just needs to be non-empty.
 
+            Database.Setup(db => db.GetPlaylistItemAsync(It.IsAny<long>()))
+                    .Returns<long>(playlistItemId => Task.FromResult(playlistItems.Single(i => i.id == playlistItemId).Clone()));
+
             Database.Setup(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()))
                     .Callback<multiplayer_playlist_item>(item =>
                     {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -150,8 +150,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Database.Setup(db => db.GetBeatmapChecksumAsync(It.IsAny<int>()))
                     .ReturnsAsync("checksum"); // doesn't matter if bogus, just needs to be non-empty.
 
-            Database.Setup(db => db.GetPlaylistItemAsync(It.IsAny<long>()))
-                    .Returns<long>(playlistItemId => Task.FromResult(playlistItems.Single(i => i.id == playlistItemId).Clone()));
+            Database.Setup(db => db.GetPlaylistItemAsync(It.IsAny<long>(), It.IsAny<long>()))
+                    .Returns<long, long>((roomId, playlistItemId) => Task.FromResult(playlistItems.Single(i => i.id == playlistItemId && i.room_id == roomId).Clone()));
 
             Database.Setup(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()))
                     .Callback<multiplayer_playlist_item>(item =>
@@ -170,10 +170,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                         playlistItems[index] = item.Clone();
                     });
 
-            Database.Setup(db => db.MarkPlaylistItemAsPlayedAsync(It.IsAny<long>()))
-                    .Callback<long>(playlistItemId =>
+            Database.Setup(db => db.MarkPlaylistItemAsPlayedAsync(It.IsAny<long>(), It.IsAny<long>()))
+                    .Callback<long, long>((roomId, playlistItemId) =>
                     {
-                        int index = playlistItems.FindIndex(i => i.id == playlistItemId);
+                        int index = playlistItems.FindIndex(i => i.id == playlistItemId && i.room_id == roomId);
                         var copy = playlistItems[index].Clone();
                         copy.expired = true;
                         copy.played_at = DateTimeOffset.Now;

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -167,12 +167,13 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                         playlistItems[index] = item.Clone();
                     });
 
-            Database.Setup(db => db.ExpirePlaylistItemAsync(It.IsAny<long>()))
+            Database.Setup(db => db.MarkPlaylistItemAsPlayedAsync(It.IsAny<long>()))
                     .Callback<long>(playlistItemId =>
                     {
                         int index = playlistItems.FindIndex(i => i.id == playlistItemId);
                         var copy = playlistItems[index].Clone();
                         copy.expired = true;
+                        copy.played_at = DateTimeOffset.Now;
                         playlistItems[index] = copy;
                     });
 

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -168,11 +168,12 @@ namespace osu.Server.Spectator.Database
             }
         }
 
-        public async Task<multiplayer_playlist_item> GetPlaylistItemAsync(long playlistItemId)
+        public async Task<multiplayer_playlist_item> GetPlaylistItemAsync(long roomId, long playlistItemId)
         {
-            return await connection.QueryFirstOrDefaultAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id", new
+            return await connection.QuerySingleAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id AND room_id = @RoomId", new
             {
                 Id = playlistItemId,
+                RoomId = roomId
             });
         }
 
@@ -208,11 +209,12 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task MarkPlaylistItemAsPlayedAsync(long playlistItemId)
+        public async Task MarkPlaylistItemAsPlayedAsync(long roomId, long playlistItemId)
         {
-            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET expired = 1, played_at = NOW(), updated_at = NOW() WHERE id = @PlaylistItemId", new
+            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET expired = 1, played_at = NOW(), updated_at = NOW() WHERE id = @PlaylistItemId AND room_id = @RoomId", new
             {
-                PlaylistItemId = playlistItemId
+                PlaylistItemId = playlistItemId,
+                RoomId = roomId
             });
         }
 

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -180,8 +180,8 @@ namespace osu.Server.Spectator.Database
         public async Task<long> AddPlaylistItemAsync(multiplayer_playlist_item item)
         {
             await connection.ExecuteAsync(
-                "INSERT INTO multiplayer_playlist_items (owner_id, room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, gameplay_order, created_at, updated_at)"
-                + " VALUES (@owner_id, @room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, @gameplay_order, NOW(), NOW())",
+                "INSERT INTO multiplayer_playlist_items (owner_id, room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, playlist_order, created_at, updated_at)"
+                + " VALUES (@owner_id, @room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, @playlist_order, NOW(), NOW())",
                 item);
 
             return await connection.QuerySingleAsync<long>("SELECT max(id) FROM multiplayer_playlist_items WHERE room_id = @room_id", item);
@@ -195,7 +195,7 @@ namespace osu.Server.Spectator.Database
                 + " ruleset_id = @ruleset_id,"
                 + " required_mods = @required_mods,"
                 + " allowed_mods = @allowed_mods,"
-                + " gameplay_order = @gameplay_order,"
+                + " playlist_order = @playlist_order,"
                 + " updated_at = NOW()"
                 + " WHERE id = @id", item);
         }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -180,8 +180,8 @@ namespace osu.Server.Spectator.Database
         public async Task<long> AddPlaylistItemAsync(multiplayer_playlist_item item)
         {
             await connection.ExecuteAsync(
-                "INSERT INTO multiplayer_playlist_items (owner_id, room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, created_at, updated_at)"
-                + " VALUES (@owner_id, @room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, NOW(), NOW())",
+                "INSERT INTO multiplayer_playlist_items (owner_id, room_id, beatmap_id, ruleset_id, allowed_mods, required_mods, gameplay_order, created_at, updated_at)"
+                + " VALUES (@owner_id, @room_id, @beatmap_id, @ruleset_id, @allowed_mods, @required_mods, @gameplay_order, NOW(), NOW())",
                 item);
 
             return await connection.QuerySingleAsync<long>("SELECT max(id) FROM multiplayer_playlist_items WHERE room_id = @room_id", item);
@@ -195,6 +195,7 @@ namespace osu.Server.Spectator.Database
                 + " ruleset_id = @ruleset_id,"
                 + " required_mods = @required_mods,"
                 + " allowed_mods = @allowed_mods,"
+                + " gameplay_order = @gameplay_order,"
                 + " updated_at = NOW()"
                 + " WHERE id = @id", item);
         }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -168,12 +168,11 @@ namespace osu.Server.Spectator.Database
             }
         }
 
-        public async Task<multiplayer_playlist_item?> GetPlaylistItemFromRoomAsync(long roomId, long playlistItemId)
+        public async Task<multiplayer_playlist_item> GetPlaylistItemAsync(long playlistItemId)
         {
-            return await connection.QueryFirstOrDefaultAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id AND room_id = @RoomId", new
+            return await connection.QueryFirstOrDefaultAsync<multiplayer_playlist_item>("SELECT * FROM multiplayer_playlist_items WHERE id = @Id", new
             {
                 Id = playlistItemId,
-                RoomId = roomId
             });
         }
 

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -209,9 +209,9 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task ExpirePlaylistItemAsync(long playlistItemId)
+        public async Task MarkPlaylistItemAsPlayedAsync(long playlistItemId)
         {
-            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET expired = 1, updated_at = NOW() WHERE id = @PlaylistItemId", new
+            await connection.ExecuteAsync("UPDATE multiplayer_playlist_items SET expired = 1, played_at = NOW(), updated_at = NOW() WHERE id = @PlaylistItemId", new
             {
                 PlaylistItemId = playlistItemId
             });

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -58,6 +58,12 @@ namespace osu.Server.Spectator.Database
         Task RemoveRoomParticipantAsync(MultiplayerRoom room, MultiplayerRoomUser user);
 
         /// <summary>
+        /// Retrieves a playlist item.
+        /// </summary>
+        /// <param name="playlistItemId">The playlist item.</param>
+        Task<multiplayer_playlist_item> GetPlaylistItemAsync(long playlistItemId);
+
+        /// <summary>
         /// Creates a new playlist item.
         /// </summary>
         /// <returns>The playlist item ID.</returns>

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -77,9 +77,9 @@ namespace osu.Server.Spectator.Database
         Task RemovePlaylistItemAsync(long roomId, long playlistItemId);
 
         /// <summary>
-        /// Marks a playlist item as expired.
+        /// Marks a playlist item as having been played.
         /// </summary>
-        Task ExpirePlaylistItemAsync(long playlistItemId);
+        Task MarkPlaylistItemAsPlayedAsync(long playlistItemId);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as ended and no longer accepting new players or scores.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -58,10 +58,11 @@ namespace osu.Server.Spectator.Database
         Task RemoveRoomParticipantAsync(MultiplayerRoom room, MultiplayerRoomUser user);
 
         /// <summary>
-        /// Retrieves a playlist item.
+        /// Retrieves a playlist item from a room.
         /// </summary>
+        /// <param name="roomId">The room.</param>
         /// <param name="playlistItemId">The playlist item.</param>
-        Task<multiplayer_playlist_item> GetPlaylistItemAsync(long playlistItemId);
+        Task<multiplayer_playlist_item> GetPlaylistItemAsync(long roomId, long playlistItemId);
 
         /// <summary>
         /// Creates a new playlist item.
@@ -85,7 +86,7 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Marks a playlist item as having been played.
         /// </summary>
-        Task MarkPlaylistItemAsPlayedAsync(long playlistItemId);
+        Task MarkPlaylistItemAsPlayedAsync(long roomId, long playlistItemId);
 
         /// <summary>
         /// Marks the given <paramref name="room"/> as ended and no longer accepting new players or scores.

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -26,14 +26,19 @@ namespace osu.Server.Spectator.Database.Models
         /// <summary>
         /// Changes to this property will not be persisted to the database.
         /// </summary>
-        public DateTimeOffset? created_at { get; set; } = DateTimeOffset.Now;
+        public DateTimeOffset? created_at { get; set; }
 
         /// <summary>
         /// Changes to this property will not be persisted to the database.
         /// </summary>
-        public DateTimeOffset? updated_at { get; set; } = DateTimeOffset.Now;
+        public DateTimeOffset? updated_at { get; set; }
 
         public bool expired { get; set; }
+
+        /// <summary>
+        /// Changes to this property will not be persisted to the database.
+        /// </summary>
+        public DateTimeOffset? played_at { get; set; }
 
         // for deserialization
         public multiplayer_playlist_item()
@@ -57,6 +62,7 @@ namespace osu.Server.Spectator.Database.Models
             updated_at = DateTimeOffset.Now;
             expired = item.Expired;
             playlist_order = item.PlaylistOrder;
+            played_at = item.PlayedAt;
         }
 
         public async Task<MultiplayerPlaylistItem> ToMultiplayerPlaylistItem(IDatabaseAccess db) => new MultiplayerPlaylistItem
@@ -70,7 +76,7 @@ namespace osu.Server.Spectator.Database.Models
             AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             Expired = expired,
             PlaylistOrder = playlist_order ?? 0,
-            UpdatedAt = updated_at ?? DateTimeOffset.UtcNow
+            PlayedAt = played_at,
         };
 
         public multiplayer_playlist_item Clone() => (multiplayer_playlist_item)MemberwiseClone();

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -22,8 +22,17 @@ namespace osu.Server.Spectator.Database.Models
         public short? playlist_order { get; set; }
         public string? allowed_mods { get; set; }
         public string? required_mods { get; set; }
-        public DateTimeOffset? created_at { get; set; }
-        public DateTimeOffset? updated_at { get; set; }
+
+        /// <summary>
+        /// Read-only.
+        /// </summary>
+        public DateTimeOffset? created_at { get; set; } = DateTimeOffset.Now;
+
+        /// <summary>
+        /// Read-only.
+        /// </summary>
+        public DateTimeOffset? updated_at { get; set; } = DateTimeOffset.Now;
+
         public bool expired { get; set; }
         public int gameplay_order { get; set; }
 
@@ -61,7 +70,8 @@ namespace osu.Server.Spectator.Database.Models
             RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(required_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             Expired = expired,
-            GameplayOrder = gameplay_order
+            GameplayOrder = gameplay_order,
+            UpdatedAt = updated_at ?? DateTimeOffset.UtcNow
         };
 
         public multiplayer_playlist_item Clone() => (multiplayer_playlist_item)MemberwiseClone();

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Spectator.Database.Models
         public long room_id { get; set; }
         public int beatmap_id { get; set; }
         public short ruleset_id { get; set; }
-        public short? playlist_order { get; set; }
+        public ushort? playlist_order { get; set; }
         public string? allowed_mods { get; set; }
         public string? required_mods { get; set; }
 
@@ -34,7 +34,6 @@ namespace osu.Server.Spectator.Database.Models
         public DateTimeOffset? updated_at { get; set; } = DateTimeOffset.Now;
 
         public bool expired { get; set; }
-        public int gameplay_order { get; set; }
 
         // for deserialization
         public multiplayer_playlist_item()
@@ -57,7 +56,7 @@ namespace osu.Server.Spectator.Database.Models
             allowed_mods = JsonConvert.SerializeObject(item.AllowedMods);
             updated_at = DateTimeOffset.Now;
             expired = item.Expired;
-            gameplay_order = item.GameplayOrder;
+            playlist_order = item.PlaylistOrder;
         }
 
         public async Task<MultiplayerPlaylistItem> ToMultiplayerPlaylistItem(IDatabaseAccess db) => new MultiplayerPlaylistItem
@@ -70,7 +69,7 @@ namespace osu.Server.Spectator.Database.Models
             RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(required_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             Expired = expired,
-            GameplayOrder = gameplay_order,
+            PlaylistOrder = playlist_order ?? 0,
             UpdatedAt = updated_at ?? DateTimeOffset.UtcNow
         };
 

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -25,6 +25,7 @@ namespace osu.Server.Spectator.Database.Models
         public DateTimeOffset? created_at { get; set; }
         public DateTimeOffset? updated_at { get; set; }
         public bool expired { get; set; }
+        public int gameplay_order { get; set; }
 
         // for deserialization
         public multiplayer_playlist_item()
@@ -47,6 +48,7 @@ namespace osu.Server.Spectator.Database.Models
             allowed_mods = JsonConvert.SerializeObject(item.AllowedMods);
             updated_at = DateTimeOffset.Now;
             expired = item.Expired;
+            gameplay_order = item.GameplayOrder;
         }
 
         public async Task<MultiplayerPlaylistItem> ToMultiplayerPlaylistItem(IDatabaseAccess db) => new MultiplayerPlaylistItem
@@ -58,7 +60,8 @@ namespace osu.Server.Spectator.Database.Models
             RulesetID = ruleset_id,
             RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(required_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
             AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
-            Expired = expired
+            Expired = expired,
+            GameplayOrder = gameplay_order
         };
 
         public multiplayer_playlist_item Clone() => (multiplayer_playlist_item)MemberwiseClone();

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -24,12 +24,12 @@ namespace osu.Server.Spectator.Database.Models
         public string? required_mods { get; set; }
 
         /// <summary>
-        /// Read-only.
+        /// Changes to this property will not be persisted to the database.
         /// </summary>
         public DateTimeOffset? created_at { get; set; } = DateTimeOffset.Now;
 
         /// <summary>
-        /// Read-only.
+        /// Changes to this property will not be persisted to the database.
         /// </summary>
         public DateTimeOffset? updated_at { get; set; } = DateTimeOffset.Now;
 

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer;
@@ -44,6 +45,8 @@ namespace osu.Server.Spectator.Hubs
             {
                 foreach (var item in await db.GetAllPlaylistItemsAsync(room.RoomID))
                     room.Playlist.Add(await item.ToMultiplayerPlaylistItem(db));
+
+                await updatePlaylistOrder(db);
             }
 
             await updateCurrentItem();
@@ -56,14 +59,15 @@ namespace osu.Server.Spectator.Hubs
         {
             if (dbFactory == null) throw new InvalidOperationException($"Call {nameof(Initialise)} first.");
 
-            // When changing to host-only mode, ensure that at least one non-expired playlist item exists by duplicating the current item.
-            if (room.Settings.QueueMode == QueueMode.HostOnly && room.Playlist.All(item => item.Expired))
+            using (var db = dbFactory.GetInstance())
             {
-                using (var db = dbFactory.GetInstance())
+                // When changing to host-only mode, ensure that at least one non-expired playlist item exists by duplicating the current item.
+                if (room.Settings.QueueMode == QueueMode.HostOnly && room.Playlist.All(item => item.Expired))
                     await duplicateCurrentItem(db);
+
+                await updatePlaylistOrder(db);
             }
 
-            // When changing modes, items could have been added (above) or the queueing order could have changed.
             await updateCurrentItem();
         }
 
@@ -131,6 +135,7 @@ namespace osu.Server.Spectator.Hubs
                     case QueueMode.HostOnly:
                         // In host-only mode, the current item is re-used.
                         item.ID = CurrentItem.ID;
+                        item.GameplayOrder = CurrentItem.GameplayOrder;
 
                         await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
                         room.Playlist[currentIndex] = item;
@@ -139,10 +144,7 @@ namespace osu.Server.Spectator.Hubs
                         break;
 
                     default:
-                        item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
-                        room.Playlist.Add(item);
-
-                        await hub.OnPlaylistItemAdded(room, item);
+                        await addItem(db, item);
 
                         // The current item can change as a result of an item being added. For example, if all items earlier in the queue were expired.
                         await updateCurrentItem();
@@ -155,22 +157,25 @@ namespace osu.Server.Spectator.Hubs
         /// Duplicates <see cref="CurrentItem"/> into the database.
         /// </summary>
         /// <param name="db">The database connection.</param>
-        private async Task duplicateCurrentItem(IDatabaseAccess db)
+        private async Task duplicateCurrentItem(IDatabaseAccess db) => await addItem(db, new MultiplayerPlaylistItem
         {
-            var newItem = new MultiplayerPlaylistItem
-            {
-                OwnerID = CurrentItem.OwnerID,
-                BeatmapID = CurrentItem.BeatmapID,
-                BeatmapChecksum = CurrentItem.BeatmapChecksum,
-                RulesetID = CurrentItem.RulesetID,
-                AllowedMods = CurrentItem.AllowedMods,
-                RequiredMods = CurrentItem.RequiredMods
-            };
+            OwnerID = CurrentItem.OwnerID,
+            BeatmapID = CurrentItem.BeatmapID,
+            BeatmapChecksum = CurrentItem.BeatmapChecksum,
+            RulesetID = CurrentItem.RulesetID,
+            AllowedMods = CurrentItem.AllowedMods,
+            RequiredMods = CurrentItem.RequiredMods
+        });
 
-            newItem.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, newItem));
-            room.Playlist.Add(newItem);
+        private async Task addItem(IDatabaseAccess db, MultiplayerPlaylistItem item)
+        {
+            // Add the item to the list first in order to compute gameplay order before adding to the database.
+            room.Playlist.Add(item);
+            await updatePlaylistOrder(db);
 
-            await hub.OnPlaylistItemAdded(room, newItem);
+            // Actually add the item to the database and invoke callback on the hub.
+            item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
+            await hub.OnPlaylistItemAdded(room, item);
         }
 
         /// <summary>
@@ -178,38 +183,77 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         private async Task updateCurrentItem()
         {
-            MultiplayerPlaylistItem newItem;
+            // The playlist is already in correct gameplay order, so pick the next non-expired item or default to the last item.
+            MultiplayerPlaylistItem nextItem = room.Playlist.FirstOrDefault(i => !i.Expired) ?? room.Playlist.Last();
+            currentIndex = room.Playlist.IndexOf(nextItem);
+
+            long lastItemID = room.Settings.PlaylistItemId;
+            room.Settings.PlaylistItemId = nextItem.ID;
+
+            if (nextItem.ID != lastItemID)
+                await hub.OnMatchSettingsChanged(room);
+        }
+
+        /// <summary>
+        /// Updates the order of items in the playlist according to the queueing mode.
+        /// </summary>
+        private async Task updatePlaylistOrder(IDatabaseAccess db)
+        {
+            List<MultiplayerPlaylistItem> orderedItems;
 
             switch (room.Settings.QueueMode)
             {
                 default:
-                    // Pick the first available non-expired playlist item, or default to the last item for when all items are expired.
-                    newItem = room.Playlist.FirstOrDefault(i => !i.Expired) ?? room.Playlist.Last();
+                    orderedItems = room.Playlist.OrderBy(item => item.ID == 0 ? int.MaxValue : item.ID).ToList();
                     break;
 
                 case QueueMode.AllPlayersRoundRobin:
-                    newItem =
-                        room.Playlist
-                            // Group items by their owner.
-                            .GroupBy(i => i.OwnerID)
-                            // Order by descending number of expired (already played) items for each owner.
-                            .OrderBy(g => g.Count(i => i.Expired))
-                            // Get the first unexpired item from each owner.
-                            .Select(g => g.FirstOrDefault(i => !i.Expired))
-                            // Select the first unexpired item in order.
-                            .FirstOrDefault(i => i != null)
-                        // Default to the last item for when all items are expired.
-                        ?? room.Playlist.Last();
+                    // Todo: This could probably be more efficient, likely at the cost of increased complexity.
+                    // Number of "expired" or "used" items per player.
+                    Dictionary<int, int> perUserCounts = room.Playlist
+                                                             .GroupBy(item => item.OwnerID)
+                                                             .ToDictionary(group => group.Key, group => group.Count(item => item.Expired));
+
+                    // We'll run a simulation over all items which are not expired ("unprocessed"). Expired items will not have their ordering updated.
+                    List<MultiplayerPlaylistItem> processedItems = room.Playlist.Where(item => item.Expired).ToList();
+                    List<MultiplayerPlaylistItem> unprocessedItems = room.Playlist.Where(item => !item.Expired).ToList();
+
+                    // In every iteration of the simulation, pick the first available item from the user with the lowest number of items in the queue to add to the result set.
+                    // If multiple users have the same number of items in the queue, then the item with the lowest ID is chosen.
+                    while (unprocessedItems.Count > 0)
+                    {
+                        MultiplayerPlaylistItem candidateItem = unprocessedItems
+                                                                .OrderBy(item => perUserCounts[item.OwnerID])
+                                                                .ThenBy(item => item.ID == 0 ? int.MaxValue : item.ID)
+                                                                .First();
+
+                        unprocessedItems.Remove(candidateItem);
+                        processedItems.Add(candidateItem);
+
+                        perUserCounts[candidateItem.OwnerID]++;
+                    }
+
+                    orderedItems = processedItems;
                     break;
             }
 
-            currentIndex = room.Playlist.IndexOf(newItem);
+            for (int i = 0; i < orderedItems.Count; i++)
+            {
+                // Items which are already ordered correct don't need to be updated.
+                if (orderedItems[i].GameplayOrder == i)
+                    continue;
 
-            long lastItemID = room.Settings.PlaylistItemId;
-            room.Settings.PlaylistItemId = newItem.ID;
+                orderedItems[i].GameplayOrder = i;
 
-            if (newItem.ID != lastItemID)
-                await hub.OnMatchSettingsChanged(room);
+                // Items which have an ID of 0 are not in the database, so avoid propagating database/hub events for them.
+                if (orderedItems[i].ID <= 0)
+                    continue;
+
+                await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, orderedItems[i]));
+                await hub.OnPlaylistItemChanged(room, orderedItems[i]);
+            }
+
+            room.Playlist = orderedItems;
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Packaging;
+using osu.Game.Extensions;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -135,7 +135,7 @@ namespace osu.Server.Spectator.Hubs
                     case QueueMode.HostOnly:
                         // In host-only mode, the current item is re-used.
                         item.ID = CurrentItem.ID;
-                        item.GameplayOrder = CurrentItem.GameplayOrder;
+                        item.PlaylistOrder = CurrentItem.PlaylistOrder;
 
                         await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
                         room.Playlist[currentIndex] = item;
@@ -241,21 +241,21 @@ namespace osu.Server.Spectator.Hubs
             // This is so that the updated_at database column doesn't get refreshed as a result of change in ordering.
             List<MultiplayerPlaylistItem> orderedExpiredItems = room.Playlist.Where(item => item.Expired).OrderBy(item => item.UpdatedAt).ToList();
             for (int i = 0; i < orderedExpiredItems.Count; i++)
-                await setOrder(orderedExpiredItems[i], i);
+                await setOrder(orderedExpiredItems[i], (ushort)i);
 
             for (int i = 0; i < orderedActiveItems.Count; i++)
-                await setOrder(orderedActiveItems[i], i);
+                await setOrder(orderedActiveItems[i], (ushort)i);
 
             room.Playlist.Clear();
             room.Playlist.AddRange(orderedExpiredItems);
             room.Playlist.AddRange(orderedActiveItems);
 
-            async Task setOrder(MultiplayerPlaylistItem item, int order)
+            async Task setOrder(MultiplayerPlaylistItem item, ushort order)
             {
-                if (item.GameplayOrder == order)
+                if (item.PlaylistOrder == order)
                     return;
 
-                item.GameplayOrder = order;
+                item.PlaylistOrder = order;
 
                 // Items which have an ID of 0 are not in the database, so avoid propagating database/hub events for them.
                 if (item.ID <= 0)

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -82,8 +82,7 @@ namespace osu.Server.Spectator.Hubs
             {
                 // Expire and let clients know that the current item has finished.
                 await db.MarkPlaylistItemAsPlayedAsync(CurrentItem.ID);
-                CurrentItem.Expired = true;
-                CurrentItem.PlayedAt = DateTimeOffset.Now;
+                room.Playlist[currentIndex] = await (await db.GetPlaylistItemAsync(CurrentItem.ID)).ToMultiplayerPlaylistItem(db);
 
                 await hub.OnPlaylistItemChanged(room, CurrentItem);
                 await updatePlaylistOrder(db);

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -81,8 +81,8 @@ namespace osu.Server.Spectator.Hubs
             using (var db = dbFactory.GetInstance())
             {
                 // Expire and let clients know that the current item has finished.
-                await db.MarkPlaylistItemAsPlayedAsync(CurrentItem.ID);
-                room.Playlist[currentIndex] = await (await db.GetPlaylistItemAsync(CurrentItem.ID)).ToMultiplayerPlaylistItem(db);
+                await db.MarkPlaylistItemAsPlayedAsync(room.RoomID, CurrentItem.ID);
+                room.Playlist[currentIndex] = await (await db.GetPlaylistItemAsync(room.RoomID, CurrentItem.ID)).ToMultiplayerPlaylistItem(db);
 
                 await hub.OnPlaylistItemChanged(room, CurrentItem);
                 await updatePlaylistOrder(db);

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -181,11 +181,9 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         private async Task updateCurrentItem()
         {
-            MultiplayerPlaylistItem nextItem = room.Playlist
-                                                   .Where(i => !i.Expired)
-                                                   .OrderBy(i => i.PlaylistOrder)
-                                                   .FirstOrDefault()
-                                               ?? room.Playlist.Last();
+            // Pick the next non-expired playlist item by playlist order, or default to the most-recently-expired item.
+            MultiplayerPlaylistItem nextItem = room.Playlist.Where(i => !i.Expired).OrderBy(i => i.PlaylistOrder).FirstOrDefault()
+                                               ?? room.Playlist.OrderByDescending(i => i.PlayedAt).First();
 
             currentIndex = room.Playlist.IndexOf(nextItem);
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2021.1122.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1122.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1122.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1122.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1122.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2021.1204.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1204.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1204.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1204.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1204.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2021.615.0" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-web/pull/8408
- [x] https://github.com/ppy/osu-web/pull/8411
- [x] https://github.com/ppy/osu/pull/15890 (circular dependency)

Adds the new `PlaylistOrder` field to `MultiplayerPlaylistItem` and related classes, which allows the server to communicate the order with clients.