### PR TITLE
Rework round robin ordering to not pin users to the front of the queue

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
@@ -13,93 +14,56 @@ namespace osu.Server.Spectator.Tests.Multiplayer
     public class MultiplayerAllPlayersRoundRobinQueueTests : MultiplayerTest
     {
         [Fact]
-        public async Task PicksFromLeastPlayedUser()
+        public async Task RoundRobinOrdering()
         {
             Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(5555)).ReturnsAsync("5555");
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
 
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser);
+            checkCurrentItem(1);
+
+            // User 1 adds an extra item
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
                 BeatmapID = 3333,
                 BeatmapChecksum = "3333"
-            });
-
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
-            {
-                BeatmapID = 4444,
-                BeatmapChecksum = "4444"
-            });
-
-            SetUserContext(ContextUser2);
-
-            await Hub.JoinRoom(ROOM_ID);
-
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
-            {
-                BeatmapID = 5555,
-                BeatmapChecksum = "5555"
             });
 
             checkCurrentItem(1);
+            checkOrder(1, 0);
+            checkOrder(2, 1);
 
-            await runGameplay();
-            checkCurrentItem(4);
-
+            // Item played.
             await runGameplay();
             checkCurrentItem(2);
+            checkOrder(2, 0);
 
-            await runGameplay();
-            checkCurrentItem(3);
-        }
+            // User 2 adds two items.
+            SetUserContext(ContextUser2);
 
-        [Fact]
-        public async Task CurrentItemUpdatedWhenChangingToAndFromAllPlayersMode()
-        {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
-
-            // The room is free-for-all initially.
-            await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
                 BeatmapID = 3333,
                 BeatmapChecksum = "3333"
             });
 
-            SetUserContext(ContextUser2);
-
-            await Hub.JoinRoom(ROOM_ID);
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
-                BeatmapID = 4444,
-                BeatmapChecksum = "4444"
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
             });
 
-            await runGameplay();
             checkCurrentItem(2);
+            checkOrder(2, 0);
+            checkOrder(3, 1);
+            checkOrder(4, 2);
 
-            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
-            checkCurrentItem(3);
-
-            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
-            checkCurrentItem(2);
-        }
-
-        [Fact]
-        public async Task CurrentItemOrderedByPlayedAt()
-        {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-
-            await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
-
-            SetUserContext(ContextUser2);
-            await Hub.JoinRoom(ROOM_ID);
+            // User 1 adds an item.
             SetUserContext(ContextUser);
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
@@ -108,30 +72,23 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
+            checkCurrentItem(2);
+            checkOrder(2, 0);
+            checkOrder(3, 1);
+            checkOrder(5, 2);
+            checkOrder(4, 3);
+
+            // Gameplay is now run to ensure the ordering doesn't change.
             await runGameplay();
-            await runGameplay();
-
-            // Item 3: Now the only non-expired item in the room.
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
-            {
-                BeatmapID = 3333,
-                BeatmapChecksum = "3333"
-            });
-
-            SetUserContext(ContextUser2);
-
-            // Item 4: Because this user hasn't had any items played, this item will be moved to the start.
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
-            {
-                BeatmapID = 3333,
-                BeatmapChecksum = "3333"
-            });
-
-            await runGameplay();
-            await runGameplay();
-
-            // Item 3 should be the "current" item, as it is in order of play rather than order of addition.
             checkCurrentItem(3);
+            await runGameplay();
+            checkCurrentItem(5);
+            await runGameplay();
+            checkCurrentItem(4);
+
+            // After playing the last item, it remains as the current item.
+            await runGameplay();
+            checkCurrentItem(4);
         }
 
         private async Task runGameplay()
@@ -166,6 +123,17 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.Equal(expectedItemId, room.Settings.PlaylistItemId);
+            }
+        }
+
+        private void checkOrder(long itemId, ushort order)
+        {
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(order, room.Playlist.Single(i => i.ID == itemId).PlaylistOrder);
             }
         }
     }

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -207,31 +207,27 @@ namespace osu.Server.Spectator.Hubs
                     break;
 
                 case QueueMode.AllPlayersRoundRobin:
-                    orderedActiveItems = new List<MultiplayerPlaylistItem>();
+                    var itemsByPriority = new List<(MultiplayerPlaylistItem item, int priority)>();
 
-                    // Todo: This could probably be more efficient, likely at the cost of increased complexity.
-                    // Number of "expired" or "used" items per player.
-                    Dictionary<int, int> perUserCounts = room.Playlist
-                                                             .GroupBy(item => item.OwnerID)
-                                                             .ToDictionary(group => group.Key, group => group.Count(item => item.Expired));
-
-                    // We'll run a simulation over all items which are not expired ("unprocessed"). Expired items will not have their ordering updated.
-                    List<MultiplayerPlaylistItem> unprocessedItems = room.Playlist.Where(item => !item.Expired).ToList();
-
-                    // In every iteration of the simulation, pick the first available item from the user with the lowest number of items in the queue to add to the result set.
-                    // If multiple users have the same number of items in the queue, then the item with the lowest ID is chosen.
-                    while (unprocessedItems.Count > 0)
+                    // Assign a priority for items from each user, starting from 0 and increasing in order which the user added the items.
+                    foreach (var group in room.Playlist.Where(item => !item.Expired).OrderBy(item => item.ID).GroupBy(item => item.OwnerID))
                     {
-                        MultiplayerPlaylistItem candidateItem = unprocessedItems
-                                                                .OrderBy(item => perUserCounts[item.OwnerID])
-                                                                .ThenBy(item => item.ID)
-                                                                .First();
-
-                        unprocessedItems.Remove(candidateItem);
-                        orderedActiveItems.Add(candidateItem);
-
-                        perUserCounts[candidateItem.OwnerID]++;
+                        int priority = 0;
+                        itemsByPriority.AddRange(group.Select(item => (item, priority++)));
                     }
+
+                    orderedActiveItems = itemsByPriority
+                                         // Order by each user's priority.
+                                         .OrderBy(i => i.priority)
+                                         // Many users will have the same priority of items, so attempt to break the tie by maintaining previous ordering.
+                                         // Suppose there are two users: User1 and User2. User1 adds two items, and then User2 adds a third. If the previous order is not maintained,
+                                         // then after playing the first item by User1, their second item will become priority=0 and jump to the front of the queue (because it was added first).
+                                         .ThenBy(i => i.item.PlaylistOrder)
+                                         // If there are still ties (normally shouldn't happen), break ties by making items added earlier go first.
+                                         // This could happen if e.g. the item orders get reset.
+                                         .ThenBy(i => i.item.ID)
+                                         .Select(i => i.item)
+                                         .ToList();
 
                     break;
             }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/15903

As per the tests, the following order now takes place. Notice in particular how items no longer jump the queue.

```
- User 1 adds two items (1, 2)

{ item: 1, user: 1 } <
{ item: 2, user: 1 }

- Item played

{ item: 2, user: 1 } <

- User 2 adds two items (3, 4)

{ item: 2, user: 1 } <
{ item: 3, user: 2 }
{ item: 4, user: 2 }

- User 1 adds an item (5)

{ item: 2, user: 1 } <
{ item: 3, user: 2 }
{ item: 5, user: 1 }
{ item: 4, user: 2 }
```