### PR TITLE
Improve log output to help diagnose issues server-side

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -175,14 +175,15 @@ namespace osu.Server.Spectator.Hubs
             await updatePlaylistOrder(db);
         }
 
+        public IEnumerable<MultiplayerPlaylistItem> UpcomingItems => room.Playlist.Where(i => !i.Expired).OrderBy(i => i.PlaylistOrder);
+
         /// <summary>
         /// Updates <see cref="CurrentItem"/> and the playlist item ID stored in the room's settings.
         /// </summary>
         private async Task updateCurrentItem()
         {
             // Pick the next non-expired playlist item by playlist order, or default to the most-recently-expired item.
-            MultiplayerPlaylistItem nextItem = room.Playlist.Where(i => !i.Expired).OrderBy(i => i.PlaylistOrder).FirstOrDefault()
-                                               ?? room.Playlist.OrderByDescending(i => i.PlayedAt).First();
+            MultiplayerPlaylistItem nextItem = UpcomingItems.FirstOrDefault() ?? room.Playlist.OrderByDescending(i => i.PlayedAt).First();
 
             currentIndex = room.Playlist.IndexOf(nextItem);
 

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
+using osu.Framework.Logging;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
 
@@ -22,9 +22,12 @@ namespace osu.Server.Spectator.Hubs
     {
         protected readonly EntityStore<TUserState> UserStates;
 
+        private readonly Logger logger;
+
         protected StatefulUserHub(IDistributedCache cache, EntityStore<TUserState> userStates)
         {
-            this.UserStates = userStates;
+            logger = Logger.GetLogger(GetType().Name.Replace("Hub", string.Empty));
+            UserStates = userStates;
         }
 
         protected KeyValuePair<long, TUserState>[] GetAllStates() => UserStates.GetAllEntities();
@@ -138,6 +141,6 @@ namespace osu.Server.Spectator.Hubs
 
         protected Task<ItemUsage<TUserState>> GetStateFromUser(int userId) => UserStates.GetForUse(userId);
 
-        protected void Log(string message) => Console.WriteLine($@"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)} [{CurrentContextUserId}]: {message.Trim()}");
+        protected void Log(string message, LogLevel logLevel = LogLevel.Verbose) => logger.Add($"[{CurrentContextUserId}]: {message.Trim()}", logLevel);
     }
 }

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -70,7 +70,7 @@ namespace osu.Server.Spectator.Hubs
 
         public sealed override async Task OnDisconnectedAsync(Exception? exception)
         {
-            Log("Disconnected");
+            Log("User disconnected");
 
             await cleanUpState(true);
         }
@@ -141,6 +141,6 @@ namespace osu.Server.Spectator.Hubs
 
         protected Task<ItemUsage<TUserState>> GetStateFromUser(int userId) => UserStates.GetForUse(userId);
 
-        protected void Log(string message, LogLevel logLevel = LogLevel.Verbose) => logger.Add($"[{CurrentContextUserId}]: {message.Trim()}", logLevel);
+        protected void Log(string message, LogLevel logLevel = LogLevel.Verbose) => logger.Add($"[user:{CurrentContextUserId}] {message.Trim()}", logLevel);
     }
 }

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -2,8 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
 using StatsdClient;
 
 namespace osu.Server.Spectator
@@ -12,6 +15,9 @@ namespace osu.Server.Spectator
     {
         public static void Main(string[] args)
         {
+            Logger.GameIdentifier = "osu-server-spectator";
+            Logger.Storage = new NativeStorage(Path.Combine(Environment.CurrentDirectory, "Logs"));
+
             DogStatsd.Configure(new StatsdConfig
             {
                 StatsdServerName = Environment.GetEnvironmentVariable("DD_AGENT_HOST") ?? "localhost",

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -93,8 +93,11 @@ namespace osu.Server.Spectator
 
             app.UseWebSockets();
 
-            app.UseEndpoints(endpoints => { endpoints.MapHub<SpectatorHub>("/spectator"); });
-            app.UseEndpoints(endpoints => { endpoints.MapHub<MultiplayerHub>("/multiplayer"); });
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHub<SpectatorHub>("/spectator");
+                endpoints.MapHub<MultiplayerHub>("/multiplayer");
+            });
         }
     }
 }


### PR DESCRIPTION
In addition to separating out the spectator and multiplayer hub output (which should help reduce noise), I've added proper room context and missing log events for all the remaining client to server requests, in addition to some forced server actions (ie. when the server changes a user's state on their behalf).

Note that I'd like to improve the exception logging, but that turns out to be a bit more involved. I've added log output before most of the exceptions are fired, which can help understand them by providing context.

Sample output:

```csharp
[multiplayer] 2021-12-07 06:52:32 [verbose]: [user:11] Connected
[spectator] 2021-12-07 06:52:32 [verbose]: [user:12] Connected
[multiplayer] 2021-12-07 06:52:32 [verbose]: [user:12] Connected
[spectator] 2021-12-07 06:52:32 [verbose]: [user:11] Connected
[multiplayer] 2021-12-07 06:52:38 [verbose]: [user:11] Attempting to join room 6
[multiplayer] 2021-12-07 06:52:38 [verbose]: [user:11] Retrieving room 6 from database
[multiplayer] 2021-12-07 06:52:39 [verbose]: [user:11] [room:6] Host marking room active
[multiplayer] 2021-12-07 06:52:39 [verbose]: [user:11] [room:6] User joined
[multiplayer] 2021-12-07 06:52:48 [verbose]: [user:12] Attempting to join room 6
[multiplayer] 2021-12-07 06:52:49 [verbose]: [user:12] [room:6] User joined
[multiplayer] 2021-12-07 06:52:52 [verbose]: [user:12] [room:6] Adding playlist item for beatmap 830459
[multiplayer] 2021-12-07 06:52:52 [verbose]: [user:12] [room:6] Item ID 13 added at slot 2 (of 2)
[multiplayer] 2021-12-07 06:52:57 [verbose]: [user:12] [room:6] Adding playlist item for beatmap 830459
[multiplayer] 2021-12-07 06:52:57 [verbose]: [user:12] [room:6] Item ID 14 added at slot 3 (of 3)
[multiplayer] 2021-12-07 06:53:00 [verbose]: [user:11] [room:6] Adding playlist item for beatmap 830459
[multiplayer] 2021-12-07 06:53:00 [verbose]: [user:11] [room:6] Item ID 15 added at slot 3 (of 4)
[multiplayer] 2021-12-07 06:53:13 [verbose]: [user:11] [room:6] Adding playlist item for beatmap 830459
[multiplayer] 2021-12-07 06:53:13 [verbose]: [user:11] [room:6] Item ID 16 added at slot 5 (of 5)
[multiplayer] 2021-12-07 06:53:14 [verbose]: [user:11] [room:6] Adding playlist item for beatmap 830459
fail: Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher[8]
      Failed to invoke hub method 'AddPlaylistItem'.
      osu.Game.Online.Multiplayer.InvalidStateException: Can't enqueue more than 3 items at once.
         at osu.Server.Spectator.Hubs.MultiplayerQueue.AddItem(MultiplayerPlaylistItem item, MultiplayerRoomUser user) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerQueue.cs:line 113
         at osu.Server.Spectator.Hubs.MultiplayerHub.AddPlaylistItem(MultiplayerPlaylistItem item) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 448
         at Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher`1.ExecuteMethod(ObjectMethodExecutor methodExecutor, Hub hub, Object[] arguments)
         at Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher`1.<>c__DisplayClass16_0.<<Invoke>g__ExecuteInvocation|0>d.MoveNext()
[multiplayer] 2021-12-07 06:53:20 [verbose]: [user:11] Requesting to leave room
[multiplayer] 2021-12-07 06:53:20 [verbose]: [user:11] [room:6] User left
[multiplayer] 2021-12-07 06:53:23 [verbose]: [user:12] Requesting to leave room
[multiplayer] 2021-12-07 06:53:23 [verbose]: [user:12] [room:6] User left
[multiplayer] 2021-12-07 06:53:23 [verbose]: [user:12] [room:6] Stopping tracking of room (all users left).
[spectator] 2021-12-07 06:53:24 [verbose]: [user:11] User disconnected
[multiplayer] 2021-12-07 06:53:24 [verbose]: [user:11] User disconnected
[spectator] 2021-12-07 06:53:36 [verbose]: [user:12] User disconnected
[multiplayer] 2021-12-07 06:53:36 [verbose]: [user:12] User disconnected
```