### PR TITLE
Add support for enqueueing items in host-only mode, and changing arbitrary playlist items

### DIFF
--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -100,6 +100,9 @@ namespace SampleMultiplayerClient
         public Task AddPlaylistItem(MultiplayerPlaylistItem item) =>
             connection.InvokeAsync(nameof(IMultiplayerServer.AddPlaylistItem), item);
 
+        public Task EditPlaylistItem(MultiplayerPlaylistItem item) =>
+            connection.InvokeAsync(nameof(IMultiplayerServer.EditPlaylistItem), item);
+
         public Task RemovePlaylistItem(long playlistItemId) =>
             connection.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), playlistItemId);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
@@ -24,6 +24,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RulesetID = 0,
                 AllowedMods = new[]
@@ -43,6 +44,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RulesetID = 3,
                 AllowedMods = new[]
@@ -59,6 +61,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RulesetID = 0,
                 RequiredMods = new[]
@@ -76,6 +79,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RulesetID = 3,
                 RequiredMods = new[]
@@ -92,6 +96,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RulesetID = 0,
                 RequiredMods = new[]
@@ -113,6 +118,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 RequiredMods = new[]
                 {
@@ -133,6 +139,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
                 {
@@ -169,6 +176,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
                 {
@@ -208,6 +216,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
@@ -239,6 +248,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
@@ -282,6 +292,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
                 {
@@ -301,6 +312,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
                 {
@@ -336,6 +348,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 BeatmapChecksum = "checksum",
                 AllowedMods = new[]
                 {
@@ -354,6 +367,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
             {
+                ID = 1,
                 RulesetID = 2,
                 BeatmapChecksum = "checksum",
             });

--- a/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/ModValidationTests.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -42,7 +42,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -77,7 +77,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -94,7 +94,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -116,7 +116,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -137,7 +137,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -174,7 +174,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -214,7 +214,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 RulesetID = 2,
@@ -246,7 +246,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 RulesetID = 2,
@@ -290,7 +290,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
 
             SetUserContext(ContextUser);
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -310,7 +310,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             assertUserMods(USER_ID_2, "HR", "AD");
 
             SetUserContext(ContextUser);
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -346,7 +346,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapChecksum = "checksum",
@@ -365,7 +365,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotEmpty(room.Users.First().Mods);
             }
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 RulesetID = 2,

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -9,6 +9,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests.Multiplayer
@@ -127,7 +128,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task UsersCanRemoveTheirOwnItems()
+        public async Task GuestsCanRemoveTheirOwnItems()
         {
             Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
 
@@ -156,7 +157,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task UsersCanNotRemoveOtherUsersItems()
+        public async Task GuestsCanNotRemoveOtherUsersItems()
         {
             Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
 
@@ -177,7 +178,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task HostCanRemoveOtherUsersItems()
+        public async Task HostCanRemoveGuestsItems()
         {
             Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
 
@@ -269,6 +270,181 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.RemovePlaylistItem(1));
             Database.Verify(db => db.RemovePlaylistItemAsync(It.IsAny<long>(), It.IsAny<long>()), Times.Never);
             Receiver.Verify(client => client.PlaylistItemRemoved(It.IsAny<long>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GuestsCanUpdateTheirOwnItems()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
+
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 2,
+                BeatmapID = 4444,
+                BeatmapChecksum = "4444"
+            });
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(2, room.Playlist.Count);
+
+                Database.Verify(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()), Times.Once);
+                Receiver.Verify(client => client.PlaylistItemAdded(It.IsAny<MultiplayerPlaylistItem>()), Times.Once);
+
+                Database.Verify(db => db.UpdatePlaylistItemAsync(It.Is<multiplayer_playlist_item>(i => i.id == 2 && i.beatmap_id == 4444)), Times.Once);
+                Receiver.Verify(client => client.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == 2 && i.BeatmapID == 4444)), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task HostCanUpdateGuestsItems()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
+
+            SetUserContext(ContextUser);
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 2,
+                BeatmapID = 4444,
+                BeatmapChecksum = "4444"
+            });
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(2, room.Playlist.Count);
+
+                Database.Verify(db => db.AddPlaylistItemAsync(It.IsAny<multiplayer_playlist_item>()), Times.Once);
+                Receiver.Verify(client => client.PlaylistItemAdded(It.IsAny<MultiplayerPlaylistItem>()), Times.Once);
+
+                Database.Verify(db => db.UpdatePlaylistItemAsync(It.Is<multiplayer_playlist_item>(i => i.id == 2 && i.beatmap_id == 4444)), Times.Once);
+                Receiver.Verify(client => client.PlaylistItemChanged(It.Is<MultiplayerPlaylistItem>(i => i.ID == 2 && i.BeatmapID == 4444)), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task HostCanChangeItemsWhenMaxItemsReached()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+
+            for (int i = 1; i < MultiplayerQueue.PER_USER_LIMIT; i++)
+            {
+                await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+                {
+                    BeatmapID = 3333,
+                    BeatmapChecksum = "3333"
+                });
+            }
+
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 1,
+                BeatmapID = 4444,
+                BeatmapChecksum = "4444"
+            });
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(MultiplayerQueue.PER_USER_LIMIT, room.Playlist.Count);
+                Assert.Equal(4444, room.Playlist[0].BeatmapID);
+            }
+        }
+
+        [Fact]
+        public async Task ExpiredItemsCanNotBeChanged()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.StartMatch();
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 1,
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            }));
+        }
+
+        [Fact]
+        public async Task OwnerChangesWhenItemChanges()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser);
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(USER_ID, room.Playlist[0].OwnerID);
+            }
+
+            await Hub.TransferHost(USER_ID_2);
+            SetUserContext(ContextUser2);
+
+            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 1,
+                BeatmapID = 4444,
+                BeatmapChecksum = "4444"
+            });
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(USER_ID_2, room.Playlist[0].OwnerID);
+            }
         }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -289,7 +289,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 2,
                 BeatmapID = 4444,
@@ -329,7 +329,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             });
 
             SetUserContext(ContextUser);
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 2,
                 BeatmapID = 4444,
@@ -370,7 +370,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapID = 4444,
@@ -401,7 +401,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapID = 3333,
@@ -431,7 +431,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.TransferHost(USER_ID_2);
             SetUserContext(ContextUser2);
 
-            await Hub.AddPlaylistItem(new MultiplayerPlaylistItem
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
             {
                 ID = 1,
                 BeatmapID = 4444,

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -450,6 +450,24 @@ namespace osu.Server.Spectator.Hubs
             }
         }
 
+        public async Task EditPlaylistItem(MultiplayerPlaylistItem item)
+        {
+            using (var userUsage = await GetOrCreateLocalUserState())
+            using (var roomUsage = await getLocalUserRoom(userUsage.Item))
+            {
+                var room = roomUsage.Item;
+                if (room == null)
+                    throw new InvalidOperationException("Attempted to operate on a null room");
+
+                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                if (user == null)
+                    throw new InvalidOperationException("Local user was not found in the expected room");
+
+                Log(room, $"Editing playlist item {item.ID} for beatmap {item.BeatmapID}");
+                await room.Queue.EditItem(item, user);
+            }
+        }
+
         public async Task RemovePlaylistItem(long playlistItemId)
         {
             using (var userUsage = await GetOrCreateLocalUserState())


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-server-spectator/pull/94 (this PR includes it to not merge conflict)
- [x] https://github.com/ppy/osu/pull/16020

This adds support for:
- The host being able to add items to the queue, rather than only being able to change the existing one.
- The host being able to change items in all modes.
- Guests being able to change their own items in non-host-only mode. This is not yet supported client side (just lacking design implementation), but is a work item in https://github.com/ppy/osu/pull/15640.

Some tests have been moved from the host-only queue test class to the more broad queue tests, which accounts for a bulk of the test changes.