### PR TITLE
Unready all users on relevant playlist item changes

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -73,22 +73,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task CanNotStartExpiredItem()
-        {
-            await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
-
-            await Hub.ChangeState(MultiplayerUserState.Ready);
-            await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
-            await Hub.ChangeState(MultiplayerUserState.Idle);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.StartMatch());
-        }
-
-        [Fact]
         public async Task NewItemImmediatelySelectedWhenAllItemsExpired()
         {
             Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -447,6 +447,20 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
+        [Fact]
+        public async Task PlayersCanNotReadyWithAllItemsExpired()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
+
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.StartMatch();
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
+
+            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeState(MultiplayerUserState.Ready));
+        }
 
         [Fact]
         public async Task PlayersUnReadiedWhenCurrentItemIsEdited()
@@ -472,7 +486,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Equal(MultiplayerUserState.Ready, room.Users[1].State);
+                Assert.Equal(MultiplayerUserState.Idle, room.Users[1].State);
             }
         }
     }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -446,5 +446,34 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.Equal(USER_ID_2, room.Playlist[0].OwnerID);
             }
         }
+
+
+        [Fact]
+        public async Task PlayersUnReadiedWhenCurrentItemIsEdited()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+
+            SetUserContext(ContextUser);
+            await Hub.EditPlaylistItem(new MultiplayerPlaylistItem
+            {
+                ID = 1,
+                BeatmapID = 3333,
+                BeatmapChecksum = "3333"
+            });
+
+            using (var usage = Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.Equal(MultiplayerUserState.Ready, room.Users[1].State);
+            }
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -539,13 +539,7 @@ namespace osu.Server.Spectator.Hubs
                     Log(room, $"Switching queue mode to {settings.QueueMode}");
                 }
 
-                await ensureAllUsersValidMods(room);
-
-                // this should probably only happen for gameplay-related changes, but let's just keep things simple for now.
-                foreach (var u in room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray())
-                    await changeAndBroadcastUserState(room, u, MultiplayerUserState.Idle);
-
-                await Clients.Group(GetGroupId(room.RoomID)).SettingsChanged(settings);
+                await OnMatchSettingsChanged(room);
             }
         }
 
@@ -857,13 +851,27 @@ namespace osu.Server.Spectator.Hubs
         public async Task OnPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item)
         {
             await ensureAllUsersValidMods(room);
+
+            if (item.ID == room.Settings.PlaylistItemId)
+                await unreadyAllUsers(room);
+
             await Clients.Group(GetGroupId(room.RoomID)).PlaylistItemChanged(item);
         }
 
         public async Task OnMatchSettingsChanged(ServerMultiplayerRoom room)
         {
             await ensureAllUsersValidMods(room);
+
+            // this should probably only happen for gameplay-related changes, but let's just keep things simple for now.
+            await unreadyAllUsers(room);
+
             await Clients.Group(GetGroupId(room.RoomID)).SettingsChanged(room.Settings);
+        }
+
+        private async Task unreadyAllUsers(ServerMultiplayerRoom room)
+        {
+            foreach (var u in room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray())
+                await changeAndBroadcastUserState(room, u, MultiplayerUserState.Idle);
         }
 
         protected void Log(ServerMultiplayerRoom room, string message, LogLevel logLevel = LogLevel.Verbose) => base.Log($"[room:{room.RoomID}] {message}", logLevel);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -692,7 +692,7 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="room">The room.</param>
         /// <param name="oldState">The old state.</param>
         /// <param name="newState">The new state.</param>
-        private void ensureValidStateSwitch(MultiplayerRoom room, MultiplayerUserState oldState, MultiplayerUserState newState)
+        private void ensureValidStateSwitch(ServerMultiplayerRoom room, MultiplayerUserState oldState, MultiplayerUserState newState)
         {
             switch (newState)
             {
@@ -703,6 +703,9 @@ namespace osu.Server.Spectator.Hubs
                 case MultiplayerUserState.Ready:
                     if (oldState != MultiplayerUserState.Idle)
                         throw new InvalidStateChangeException(oldState, newState);
+
+                    if (room.Queue.CurrentItem.Expired)
+                        throw new InvalidStateException("Cannot ready up while all items have been played.");
 
                     break;
 


### PR DESCRIPTION
- Unready all users when the current item is edited.
- Prevent users readying up with all items expired.