### PR TITLE
Fix multiple tests not `await`ing on async actions

### DIFF
--- a/osu.Server.Spectator.Tests/MatchTypeRoomEventHookTests.cs
+++ b/osu.Server.Spectator.Tests/MatchTypeRoomEventHookTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
-using osu.Server.Spectator.Database;
+using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Hubs;
+using osu.Server.Spectator.Tests.Multiplayer;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests
@@ -12,14 +14,25 @@ namespace osu.Server.Spectator.Tests
     /// <summary>
     /// Tests covering propagation of events through <see cref="ServerMultiplayerRoom"/> to the <see cref="MultiplayerHub"/> via callbacks.
     /// </summary>
-    public class MatchTypeRoomEventHookTests
+    public class MatchTypeRoomEventHookTests : MultiplayerTest
     {
         [Fact]
-        public void NewUserJoinedTriggersRulesetHook()
+        public async Task NewUserJoinedTriggersRulesetHook()
         {
             var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
-            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+
+            await room.Initialise(DatabaseFactory.Object);
 
             Mock<MatchTypeImplementation> typeImplementation = new Mock<MatchTypeImplementation>(room, hubCallbacks.Object);
             room.MatchTypeImplementation = typeImplementation.Object;
@@ -30,11 +43,22 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public void UserLeavesTriggersRulesetHook()
+        public async Task UserLeavesTriggersRulesetHook()
         {
             var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
-            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+
+            await room.Initialise(DatabaseFactory.Object);
 
             var user = new MultiplayerRoomUser(1);
 
@@ -48,11 +72,22 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public void TypeChangeTriggersInitialJoins()
+        public async Task TypeChangeTriggersInitialJoins()
         {
             var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
-            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+
+            await room.Initialise(DatabaseFactory.Object);
 
             // join a number of users initially to the room
             for (int i = 0; i < 5; i++)

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         protected EntityStore<ServerMultiplayerRoom> Rooms { get; }
         protected EntityStore<MultiplayerClientState> UserStates { get; }
 
-        private readonly Mock<IDatabaseFactory> mockDatabaseFactory;
+        protected readonly Mock<IDatabaseFactory> DatabaseFactory;
 
         protected readonly Mock<IDatabaseAccess> Database;
 
@@ -56,7 +56,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             currentItemId = 0;
             playlistItems = new List<multiplayer_playlist_item>();
 
-            mockDatabaseFactory = new Mock<IDatabaseFactory>();
+            DatabaseFactory = new Mock<IDatabaseFactory>();
             Database = new Mock<IDatabaseAccess>();
             setUpMockDatabase();
 
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             Rooms = new EntityStore<ServerMultiplayerRoom>();
             UserStates = new EntityStore<MultiplayerClientState>();
-            Hub = new TestMultiplayerHub(cache, Rooms, UserStates, mockDatabaseFactory.Object);
+            Hub = new TestMultiplayerHub(cache, Rooms, UserStates, DatabaseFactory.Object);
 
             Clients = new Mock<IHubCallerClients<IMultiplayerClient>>();
             Groups = new Mock<IGroupManager>();
@@ -127,7 +127,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
         private void setUpMockDatabase()
         {
-            mockDatabaseFactory.Setup(factory => factory.GetInstance()).Returns(Database.Object);
+            DatabaseFactory.Setup(factory => factory.GetInstance()).Returns(Database.Object);
 
             Database.Setup(db => db.GetRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)

--- a/osu.Server.Spectator.Tests/TeamVersusTests.cs
+++ b/osu.Server.Spectator.Tests/TeamVersusTests.cs
@@ -1,26 +1,38 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Hubs;
+using osu.Server.Spectator.Tests.Multiplayer;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests
 {
-    public class TeamVersusTests
+    public class TeamVersusTests : MultiplayerTest
     {
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        public void UserRequestsValidTeamChange(int team)
+        public async Task UserRequestsValidTeamChange(int team)
         {
             var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
-            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+            await room.Initialise(DatabaseFactory.Object);
 
             var teamVersus = new TeamVersus(room, hubCallbacks.Object);
 
@@ -42,11 +54,21 @@ namespace osu.Server.Spectator.Tests
         [InlineData(-1)]
         [InlineData(2)]
         [InlineData(3)]
-        public void UserRequestsInvalidTeamChange(int team)
+        public async Task UserRequestsInvalidTeamChange(int team)
         {
             var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
-            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+            await room.Initialise(DatabaseFactory.Object);
             var teamVersus = new TeamVersus(room, hubCallbacks.Object);
 
             // change the match type
@@ -68,10 +90,21 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public void NewUsersAssignedToTeamWithFewerUsers()
+        public async Task NewUsersAssignedToTeamWithFewerUsers()
         {
-            var room = new ServerMultiplayerRoom(1, new Mock<IMultiplayerServerMatchCallbacks>().Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+            await room.Initialise(DatabaseFactory.Object);
 
             // change the match type
             room.ChangeMatchType(MatchType.TeamVersus);
@@ -98,10 +131,21 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public void InitialUsersAssignedToTeamsEqually()
+        public async Task InitialUsersAssignedToTeamsEqually()
         {
-            var room = new ServerMultiplayerRoom(1, new Mock<IMultiplayerServerMatchCallbacks>().Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+            await room.Initialise(DatabaseFactory.Object);
 
             // join a number of users initially to the room
             for (int i = 0; i < 5; i++)
@@ -118,10 +162,21 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public void StateMaintainedBetweenRulesetSwitch()
+        public async Task StateMaintainedBetweenRulesetSwitch()
         {
-            var room = new ServerMultiplayerRoom(1, new Mock<IMultiplayerServerMatchCallbacks>().Object);
-            room.Initialise(new Mock<IDatabaseFactory>().Object);
+            var hubCallbacks = new Mock<IMultiplayerServerMatchCallbacks>();
+            var room = new ServerMultiplayerRoom(1, hubCallbacks.Object)
+            {
+                Playlist =
+                {
+                    new MultiplayerPlaylistItem
+                    {
+                        BeatmapID = 3333,
+                        BeatmapChecksum = "3333"
+                    },
+                }
+            };
+            await room.Initialise(DatabaseFactory.Object);
 
             room.ChangeMatchType(MatchType.TeamVersus);
 


### PR DESCRIPTION
These were showing up as warnings. Required a bit more effort than expected to repair (turns out they were silently failing until now with unobserved exceptions).