### PR TITLE
Fix logging from `async` methods throwing exceptions due to disposed context

### DIFF
--- a/osu.Server.Spectator.Tests/TeamVersusTests.cs
+++ b/osu.Server.Spectator.Tests/TeamVersusTests.cs
@@ -6,7 +6,6 @@ using Moq;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
-using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Hubs;
 using osu.Server.Spectator.Tests.Multiplayer;
 using Xunit;


### PR DESCRIPTION
Turns out https://github.com/ppy/osu-server-spectator/pull/100 was not enough (I knew there was a reason I didn't PR in that state - and also why I had a try-catch deployed previously...)

Example of failure on production:

```csharp
fail: Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher[8]
      Failed to invoke hub method 'EditPlaylistItem'.                                                                              
      System.ObjectDisposedException: Cannot access a disposed object.
      Object name: 'MultiplayerHub'.                                                                                                  
         at Microsoft.AspNetCore.SignalR.Hub.CheckDisposed()
         at osu.Server.Spectator.Hubs.MultiplayerHub.Log(ServerMultiplayerRoom room, String message, LogLevel logLevel) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 925
         at osu.Server.Spectator.Hubs.MultiplayerHub.changeAndBroadcastUserState(ServerMultiplayerRoom room, MultiplayerRoomU
ser user, MultiplayerUserState state) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 702
         at osu.Server.Spectator.Hubs.MultiplayerHub.unreadyAllUsers(ServerMultiplayerRoom room) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 921
         at osu.Server.Spectator.Hubs.MultiplayerHub.OnPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 907
         at osu.Server.Spectator.Hubs.MultiplayerQueue.EditItem(MultiplayerPlaylistItem item, MultiplayerRoomUser user) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerQueue.cs:line 175
         at osu.Server.Spectator.Hubs.MultiplayerHub.EditPlaylistItem(MultiplayerPlaylistItem item) in /Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 
         at Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher`1.ExecuteMethod(ObjectMethodExecutor methodExecutor, H
```