### PR TITLE
Fix users not removed from gameplay group after aborting gameplay

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+
+namespace osu.Server.Spectator.Tests.Multiplayer
+{
+    /// <summary>
+    /// Used in testing. Delegates calls to one or more <see cref="IMultiplayerClient"/>s.
+    /// Note: All members must be virtual!!
+    /// </summary>
+    public class DelegatingMultiplayerClient : IMultiplayerClient
+    {
+        private readonly IEnumerable<IMultiplayerClient> clients;
+
+        public DelegatingMultiplayerClient(IEnumerable<IMultiplayerClient> clients)
+        {
+            this.clients = clients;
+        }
+
+        public virtual async Task RoomStateChanged(MultiplayerRoomState state)
+        {
+            foreach (var c in clients)
+                await c.RoomStateChanged(state);
+        }
+
+        public virtual async Task UserJoined(MultiplayerRoomUser user)
+        {
+            foreach (var c in clients)
+                await c.UserJoined(user);
+        }
+
+        public virtual async Task UserLeft(MultiplayerRoomUser user)
+        {
+            foreach (var c in clients)
+                await c.UserLeft(user);
+        }
+
+        public virtual async Task UserKicked(MultiplayerRoomUser user)
+        {
+            foreach (var c in clients)
+                await c.UserKicked(user);
+        }
+
+        public virtual async Task HostChanged(int userId)
+        {
+            foreach (var c in clients)
+                await c.HostChanged(userId);
+        }
+
+        public virtual async Task SettingsChanged(MultiplayerRoomSettings newSettings)
+        {
+            foreach (var c in clients)
+                await c.SettingsChanged(newSettings);
+        }
+
+        public virtual async Task UserStateChanged(int userId, MultiplayerUserState state)
+        {
+            foreach (var c in clients)
+                await c.UserStateChanged(userId, state);
+        }
+
+        public virtual async Task MatchUserStateChanged(int userId, MatchUserState state)
+        {
+            foreach (var c in clients)
+                await c.MatchUserStateChanged(userId, state);
+        }
+
+        public virtual async Task MatchRoomStateChanged(MatchRoomState state)
+        {
+            foreach (var c in clients)
+                await c.MatchRoomStateChanged(state);
+        }
+
+        public virtual async Task MatchEvent(MatchServerEvent e)
+        {
+            foreach (var c in clients)
+                await c.MatchEvent(e);
+        }
+
+        public virtual async Task UserBeatmapAvailabilityChanged(int userId, BeatmapAvailability beatmapAvailability)
+        {
+            foreach (var c in clients)
+                await c.UserBeatmapAvailabilityChanged(userId, beatmapAvailability);
+        }
+
+        public virtual async Task UserModsChanged(int userId, IEnumerable<APIMod> mods)
+        {
+            foreach (var c in clients)
+                await c.UserModsChanged(userId, mods);
+        }
+
+        public virtual async Task LoadRequested()
+        {
+            foreach (var c in clients)
+                await c.LoadRequested();
+        }
+
+        public virtual async Task MatchStarted()
+        {
+            foreach (var c in clients)
+                await c.MatchStarted();
+        }
+
+        public virtual async Task ResultsReady()
+        {
+            foreach (var c in clients)
+                await c.ResultsReady();
+        }
+
+        public virtual async Task PlaylistItemAdded(MultiplayerPlaylistItem item)
+        {
+            foreach (var c in clients)
+                await c.PlaylistItemAdded(item);
+        }
+
+        public virtual async Task PlaylistItemRemoved(long playlistItemId)
+        {
+            foreach (var c in clients)
+                await c.PlaylistItemRemoved(playlistItemId);
+        }
+
+        public virtual async Task PlaylistItemChanged(MultiplayerPlaylistItem item)
+        {
+            foreach (var c in clients)
+                await c.PlaylistItemChanged(item);
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -313,23 +313,7 @@ namespace osu.Server.Spectator.Hubs
 
                 ensureValidStateSwitch(room, user.State, newState);
 
-                user.State = newState;
-
-                // handle whether this user should be receiving gameplay messages or not.
-                switch (newState)
-                {
-                    case MultiplayerUserState.FinishedPlay:
-                    case MultiplayerUserState.Idle:
-                        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
-                        break;
-
-                    case MultiplayerUserState.Ready:
-                    case MultiplayerUserState.Spectating:
-                        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
-                        break;
-                }
-
-                await Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(CurrentContextUserId, newState);
+                await changeAndBroadcastUserState(room, user, newState);
 
                 if (newState == MultiplayerUserState.Spectating
                     && (room.State == MultiplayerRoomState.WaitingForLoad || room.State == MultiplayerRoomState.Playing))
@@ -697,11 +681,27 @@ namespace osu.Server.Spectator.Hubs
             }
         }
 
-        private Task changeAndBroadcastUserState(ServerMultiplayerRoom room, MultiplayerRoomUser user, MultiplayerUserState state)
+        private async Task changeAndBroadcastUserState(ServerMultiplayerRoom room, MultiplayerRoomUser user, MultiplayerUserState state)
         {
             Log(room, $"User state changed from {user.State} to {state}");
+
             user.State = state;
-            return Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(user.UserID, user.State);
+
+            // handle whether this user should be receiving gameplay messages or not.
+            switch (state)
+            {
+                case MultiplayerUserState.FinishedPlay:
+                case MultiplayerUserState.Idle:
+                    await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
+                    break;
+
+                case MultiplayerUserState.Ready:
+                case MultiplayerUserState.Spectating:
+                    await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
+                    break;
+            }
+
+            await Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(user.UserID, user.State);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/17321

When exiting gameplay via `AbortGameplay()`, users were not being removed from the gameplay group.

Testing is as follows:
1. Join two users.
2. Make both users ready.
3. Start match.
4. Exit match with both users.
5. Make only the host ready.
6. Start match. Both users will start even though the second was not ready. The second user will quit back to the subscreen and show an exception.

This is a chonky PR mainly because I've added support to be able to assert calls on individual users rather than a "general" receiver for the gameplay/non-gameplay groups. This is done by:
- Storing the movement of clients around calls to `AddToGroupAsync()`/`RemoveFromGroupAsync()`.
- Creating a new `DelegatingMultiplayerClient` that receives the clients for a particular group. This new object now becomes the target type of the `Receiver`/`GameplayReceiver`/`Receiver2` mock objects.
- Adding new `UserReceiver`/`User2Receiver` mock objects for assertions on the individual users.