### PR TITLE
Fix incorrect group adjustments when unready-ing all users

### DIFF
--- a/osu.Server.Spectator/Hubs/IMultiplayerServerMatchCallbacks.cs
+++ b/osu.Server.Spectator/Hubs/IMultiplayerServerMatchCallbacks.cs
@@ -53,13 +53,15 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         /// <param name="room">The room to send the event to.</param>
         /// <param name="item">The changed item.</param>
-        Task OnPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item);
+        /// <param name="client">The current client.</param>
+        Task OnPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item, MultiplayerClientState? client);
 
         /// <summary>
         /// Let the hub know that the room settings have been changed.
         /// </summary>
         /// <param name="room">The room to send the event to.</param>
-        Task OnMatchSettingsChanged(ServerMultiplayerRoom room);
+        /// <param name="client">The current client.</param>
+        Task OnMatchSettingsChanged(ServerMultiplayerRoom room, MultiplayerClientState? client);
 
         /// <summary>
         /// Retrieves a <see cref="ServerMultiplayerRoom"/> usage.


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/17477

This is a request-for-comments PR because I don't know how to better do this given the limitations imposed by `EntityStore`.

The primary purpose is to fix users not being removed from groups when multiple users' states are adjusted at once. Once such way that this could happen is via the following process:
1. Join player 1 (host), player 2 (guest).
2. Ready up player 2.
3. Change room settings on player 1 (e.g. the queue mode). Player 2 will unready.
4. Start play _without_ ready-ing up player 2.
5. Player 2 will attempt to enter gameplay, but fail with the `AbortGameplay` exception.

The reason why this occurs is that `changeAndBroadcastUserState` only mutates groups for the current context's connection ID:
https://github.com/ppy/osu-server-spectator/blob/b18144df5da7c447051cf479ddc4cc02d489d9cc/osu.Server.Spectator/Hubs/MultiplayerHub.cs#L724-L736
Meaning that in the above sequence, player 2 never got removed from the gameplay group - only player 1 which triggered the change in match settings.

In order to fix this, I've passed a `MultiplayerClientState` to this `changeAndBroadcastUserState` method.
- This change ripples throughout the rest of the codebase, and makes it pretty unmaintainable.  
- Non-nullability is enforced at this point. The given `MultiplayerClientState` must match the given `MultiplayerRoomUser`.

Then, the `changeAndBroadcastAllUserStates` method has been added in order to ease the implementation of the former. This one serves to re-retrieve a `MultiplayerClientState` for the given users taking into account an optional existing `MultiplayerClientState` that has been retrieved from an upper level.