### PR TITLE
Cancel countdown when changing auto-start setting

### DIFF
--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -572,6 +572,12 @@ namespace osu.Server.Spectator.Hubs
                     Log(room, $"Switching queue mode to {settings.QueueMode}");
                 }
 
+                if (previousSettings.AutoStartDuration != settings.AutoStartDuration)
+                {
+                    room.StopCountdown();
+                    Log(room, $"Switching auto-start duration to {settings.AutoStartDuration}");
+                }
+
                 await OnMatchSettingsChanged(room);
 
                 await updateRoomStateIfRequired(room);


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/pull/17449#issuecomment-1079804704, except cancelling instead of restarting as it's easier to handle different cases.