### PR TITLE
Fix incorrect group adjustments when unready-ing all users

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
@@ -43,23 +43,42 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             };
 
             await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
 
-            MultiplayerRoom? room;
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
 
-            using (var usage = await Hub.GetRoom(ROOM_ID))
+            using (var roomUsage = await Hub.GetRoom(ROOM_ID))
             {
-                // unsafe, but just for tests.
-                room = usage.Item;
+                var room = roomUsage.Item;
                 Debug.Assert(room != null);
+
+                Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Ready), Times.Once);
+                Receiver.Verify(r => r.UserStateChanged(USER_ID_2, MultiplayerUserState.Ready), Times.Once);
+                Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Ready, u.State));
             }
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
-            Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Ready), Times.Once);
-            Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Ready, u.State));
-
+            SetUserContext(ContextUser);
             await Hub.ChangeSettings(testSettings);
-            Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Idle), Times.Once);
-            Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
+
+            using (var roomUsage = await Hub.GetRoom(ROOM_ID))
+            {
+                var room = roomUsage.Item;
+                Debug.Assert(room != null);
+
+                Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Idle), Times.Once);
+                Receiver.Verify(r => r.UserStateChanged(USER_ID_2, MultiplayerUserState.Idle), Times.Once);
+                Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
+            }
+
+            // Check that users have been removed from groups by attempting to start gameplay, and making sure the second user does not start while in an idle state.
+            SetUserContext(ContextUser);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.StartMatch();
+
+            UserReceiver.Verify(r => r.LoadRequested(), Times.Once);
+            User2Receiver.Verify(r => r.LoadRequested(), Times.Never);
         }
 
         [Fact]

--- a/osu.Server.Spectator/Entities/EntityStore.cs
+++ b/osu.Server.Spectator/Entities/EntityStore.cs
@@ -25,6 +25,20 @@ namespace osu.Server.Spectator.Entities
         private string statsDPrefix => $"entities.{typeof(T).Name}";
 
         /// <summary>
+        /// Retrieves an entity.
+        /// </summary>
+        /// <remarks>
+        /// !!DANGER!! This does not lock on the usage, so it should be used with care assuming the returned value may be invalidated at any point in time.
+        /// </remarks>
+        /// <param name="id">The ID of the requested entity.</param>
+        /// <returns>The entity.</returns>
+        public T? GetEntityUnsafe(long id)
+        {
+            lock (entityMapping)
+                return !entityMapping.TryGetValue(id, out var entity) ? null : entity.GetItemUnsafe();
+        }
+
+        /// <summary>
         /// Retrieve an entity with a lock for use.
         /// </summary>
         /// <param name="id">The ID of the requested entity.</param>

--- a/osu.Server.Spectator/Extensions/EntityStoreExtensions.cs
+++ b/osu.Server.Spectator/Extensions/EntityStoreExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Hubs;
+
+namespace osu.Server.Spectator.Extensions
+{
+    public static class EntityStoreExtensions
+    {
+        /// <summary>
+        /// Retrieves the connection ID for a user from an <see cref="EntityStore{T}"/>, bypassing <see cref="EntityStore{T}"/> locking.
+        /// </summary>
+        /// <remarks>
+        /// May be used while nested in a locked entity usage (via <see cref="EntityStore{T}.GetForUse"/>).
+        /// </remarks>
+        /// <param name="store">The user entity store.</param>
+        /// <param name="id">The user ID.</param>
+        /// <typeparam name="TUserState">The user state.</typeparam>
+        /// <returns>The connection ID for the user matching the given <paramref name="id"/>. A non-null return does not mean that the user hasn't been disconnected.</returns>
+        public static string? GetConnectionIdForUser<TUserState>(this EntityStore<TUserState> store, long id)
+            where TUserState : ClientState
+        {
+            return store.GetEntityUnsafe(id)?.ConnectionId;
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -12,6 +12,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
 using osu.Game.Online.Rooms;
+using osu.Game.Resources.Localisation.Web;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
@@ -721,18 +722,22 @@ namespace osu.Server.Spectator.Hubs
 
             user.State = state;
 
-            // handle whether this user should be receiving gameplay messages or not.
-            switch (state)
-            {
-                case MultiplayerUserState.FinishedPlay:
-                case MultiplayerUserState.Idle:
-                    await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
-                    break;
+            string? connectionId = UserStates.GetConnectionIdForUser(user.UserID);
 
-                case MultiplayerUserState.Ready:
-                case MultiplayerUserState.Spectating:
-                    await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(room.RoomID, true));
-                    break;
+            if (connectionId != null)
+            {
+                switch (state)
+                {
+                    case MultiplayerUserState.FinishedPlay:
+                    case MultiplayerUserState.Idle:
+                        await Groups.RemoveFromGroupAsync(connectionId, GetGroupId(room.RoomID, true));
+                        break;
+
+                    case MultiplayerUserState.Ready:
+                    case MultiplayerUserState.Spectating:
+                        await Groups.AddToGroupAsync(connectionId, GetGroupId(room.RoomID, true));
+                        break;
+                }
             }
 
             await Clients.Group(GetGroupId(room.RoomID)).UserStateChanged(user.UserID, user.State);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/17477
Supersedes https://github.com/ppy/osu-server-spectator/pull/111

The primary purpose is to fix users not being removed from groups when multiple users' states are adjusted at once. Once such way that this could happen is via the following process:
1. Join player 1 (host), player 2 (guest).
2. Ready up player 2.
3. Change room settings on player 1 (e.g. the queue mode). Player 2 will unready.
4. Start play _without_ ready-ing up player 2.
5. Player 2 will attempt to enter gameplay, but fail with the `AbortGameplay` exception.

The reason why this occurs is that `changeAndBroadcastUserState` only mutates groups for the current context's connection ID:
https://github.com/ppy/osu-server-spectator/blob/b18144df5da7c447051cf479ddc4cc02d489d9cc/osu.Server.Spectator/Hubs/MultiplayerHub.cs#L724-L736
Meaning that in the above sequence, player 2 never got removed from the gameplay group - only player 1 which triggered the change in match settings.