### PR TITLE
Send UserLeft callback to the leaving user

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -103,6 +103,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Groups = new Mock<IGroupManager>();
 
             hubContext.Setup(ctx => ctx.Groups).Returns(Groups.Object);
+            hubContext.Setup(ctx => ctx.Clients.Client(It.IsAny<string>())).Returns<string>(connectionId => (IClientProxy)Clients.Object.Client(connectionId));
             hubContext.Setup(ctx => ctx.Clients.Group(It.IsAny<string>())).Returns<string>(groupName => (IClientProxy)Clients.Object.Group(groupName));
             hubContext.Setup(ctx => ctx.Clients.All).Returns((IClientProxy)Clients.Object.All);
 
@@ -136,6 +137,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID, true)) { CallBase = true };
             Receiver2 = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID_2, false)) { CallBase = true };
 
+            Clients.Setup(clients => clients.Client(USER_ID.ToString())).Returns(UserReceiver.Object);
+            Clients.Setup(clients => clients.Client(USER_ID_2.ToString())).Returns(User2Receiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID, false))).Returns(Receiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID, true))).Returns(GameplayReceiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID_2, false))).Returns(Receiver2.Object);

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -347,7 +347,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.LeaveRoom();
 
             UserReceiver.Verify(r => r.UserLeft(It.IsAny<MultiplayerRoomUser>()), Times.Once);
-            User2Receiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Never);
+            UserReceiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Never);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -317,5 +317,37 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AbortGameplay());
         }
+
+        [Fact]
+        public async Task KickedUserReceivesCallback()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+
+            // Join another user to be kicked.
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser);
+            await Hub.KickUser(USER_ID_2);
+
+            User2Receiver.Verify(r => r.UserLeft(It.IsAny<MultiplayerRoomUser>()), Times.Never);
+            User2Receiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LeftUserReceivesCallback()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+
+            // Join another user to make sure the room doesn't close when the user leaves.
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser);
+            await Hub.LeaveRoom();
+
+            UserReceiver.Verify(r => r.UserLeft(It.IsAny<MultiplayerRoomUser>()), Times.Once);
+            User2Receiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Never);
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -846,7 +846,11 @@ namespace osu.Server.Spectator.Hubs
                 await Clients.Group(GetGroupId(room.RoomID)).UserKicked(user);
             }
             else
+            {
+                // the target user has already been removed from the group, so send the message to them separately.
+                await Clients.Client(state.ConnectionId).UserLeft(user);
                 await Clients.Group(GetGroupId(room.RoomID)).UserLeft(user);
+            }
         }
 
         internal Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId) => Rooms.GetForUse(roomId);


### PR DESCRIPTION
If a new client logs into a user from an existing room, the existing user leaves the room as their connection is "cleaned up". They should receive a `UserLeft` callback to notify them that this is the case so that they can leave the room.

Note: The above scenario will throw an assert on older clients without the changes in https://github.com/ppy/osu/pull/17663.

Manually-tested scenarios:
- User leaves room.
- User is kicked.
- User is logged into by another client.