### PR TITLE
Kick user on connection cleanup

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -103,6 +103,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Groups = new Mock<IGroupManager>();
 
             hubContext.Setup(ctx => ctx.Groups).Returns(Groups.Object);
+            hubContext.Setup(ctx => ctx.Clients.Client(It.IsAny<string>())).Returns<string>(connectionId => (IClientProxy)Clients.Object.Client(connectionId));
             hubContext.Setup(ctx => ctx.Clients.Group(It.IsAny<string>())).Returns<string>(groupName => (IClientProxy)Clients.Object.Group(groupName));
             hubContext.Setup(ctx => ctx.Clients.All).Returns((IClientProxy)Clients.Object.All);
 
@@ -136,6 +137,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID, true)) { CallBase = true };
             Receiver2 = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID_2, false)) { CallBase = true };
 
+            Clients.Setup(clients => clients.Client(USER_ID.ToString())).Returns(UserReceiver.Object);
+            Clients.Setup(clients => clients.Client(USER_ID_2.ToString())).Returns(User2Receiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID, false))).Returns(Receiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID, true))).Returns(GameplayReceiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID_2, false))).Returns(Receiver2.Object);

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -317,5 +317,22 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AbortGameplay());
         }
+
+        [Fact]
+        public async Task KickUser()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser);
+            await Hub.KickUser(USER_ID_2);
+
+            UserReceiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Once);
+            User2Receiver.Verify(r => r.UserKicked(It.IsAny<MultiplayerRoomUser>()), Times.Once);
+            UserReceiver.Verify(r => r.UserLeft(It.IsAny<MultiplayerRoomUser>()), Times.Never);
+            User2Receiver.Verify(r => r.UserLeft(It.IsAny<MultiplayerRoomUser>()), Times.Never);
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -219,7 +219,7 @@ namespace osu.Server.Spectator.Hubs
 
                 try
                 {
-                    await leaveRoom(userUsage.Item);
+                    await leaveRoom(userUsage.Item, false);
                 }
                 finally
                 {
@@ -625,7 +625,7 @@ namespace osu.Server.Spectator.Hubs
 
         protected override async Task CleanUpState(MultiplayerClientState state)
         {
-            await leaveRoom(state);
+            await leaveRoom(state, true);
             await base.CleanUpState(state);
         }
 
@@ -791,10 +791,10 @@ namespace osu.Server.Spectator.Hubs
             return await Rooms.GetForUse(roomId);
         }
 
-        private async Task leaveRoom(MultiplayerClientState state)
+        private async Task leaveRoom(MultiplayerClientState state, bool wasKick)
         {
             using (var roomUsage = await getLocalUserRoom(state))
-                await leaveRoom(state, roomUsage, false);
+                await leaveRoom(state, roomUsage, wasKick);
         }
 
         private async Task leaveRoom(MultiplayerClientState state, ItemUsage<ServerMultiplayerRoom> roomUsage, bool wasKick)


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu-server-spectator/pull/118

Hard to test the duplicate connection scenario, so I haven't added a test for it. I have added a test for kicking users, which requires the additional changes to `MultiplayerTest`'s setup.