### PR TITLE
Remove post-disposal logging hack

### DIFF
--- a/.idea/.idea.osu.Server.Spectator/.idea/misc.xml
+++ b/.idea/.idea.osu.Server.Spectator/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
+    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
+  </component>
+</project>

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -148,22 +148,11 @@ namespace osu.Server.Spectator.Hubs
 
         protected Task<ItemUsage<TUserState>> GetStateFromUser(int userId) => UserStates.GetForUse(userId);
 
-        protected override void Dispose(bool disposing)
-        {
-            // There is a case where we are logging events post context disposal.
-            // This can happen in asynchronous flows where the disposal completes before the async work we are running attempts to log.
-            // There's no easy way to check whether the context is in a disposed state, so this is a best effort solution.
-            postDisposalLoggableIdentifier = Context.UserIdentifier ?? "???";
-            base.Dispose(disposing);
-        }
-
         protected void Log(string message, LogLevel logLevel = LogLevel.Verbose) => logger.Add($"[user:{getLoggableUserIdentifier()}] {message.Trim()}", logLevel);
 
         protected void Error(string message, Exception exception) => logger.Add($"[user:{getLoggableUserIdentifier()}] {message.Trim()}", LogLevel.Error, exception);
 
-        private string getLoggableUserIdentifier() => postDisposalLoggableIdentifier ?? Context.UserIdentifier ?? "???";
-
-        private string? postDisposalLoggableIdentifier;
+        private string getLoggableUserIdentifier() => Context.UserIdentifier ?? "???";
 
         #region Implementation of ILogTarget
 


### PR DESCRIPTION
This was added in https://github.com/ppy/osu-server-spectator/pull/100 to resolve the same issue that was brought up again recently in https://github.com/ppy/osu-server-spectator/issues/114.

Was fixed in https://github.com/ppy/osu-server-spectator/pull/116 by not storing the `MultiplayerHub` inside `ServerMultiplayerRoom` and others. Can likely also remove the `???` fallback for `Context.UserIdentifier`, but that's less egregious.