### PR TITLE
Fix deleted beatmaps being allowed to be added to a multiplayer room

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator.Database
         {
             var connection = await getConnectionAsync();
 
-            return await connection.QuerySingleOrDefaultAsync<string?>("SELECT checksum from osu_beatmaps where beatmap_id = @BeatmapID", new
+            return await connection.QuerySingleOrDefaultAsync<string?>("SELECT checksum from osu_beatmaps WHERE beatmap_id = @BeatmapID AND deleted_at IS NULL", new
             {
                 BeatmapId = beatmapId
             });


### PR DESCRIPTION
Deleted beatmaps shouldn't be allowed to be used in multiplayer. As discoverd in https://github.com/ppy/osu/discussions/17106#discussioncomment-2599163.