### PR TITLE
Force start/abort multiplayer games after a timeout

### DIFF
--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -34,7 +34,8 @@ namespace SampleMultiplayerClient
             connection.On<int, MultiplayerUserState>(nameof(IMultiplayerClient.UserStateChanged), ((IMultiplayerClient)this).UserStateChanged);
             connection.On<int, BeatmapAvailability>(nameof(IMultiplayerClient.UserBeatmapAvailabilityChanged), ((IMultiplayerClient)this).UserBeatmapAvailabilityChanged);
             connection.On(nameof(IMultiplayerClient.LoadRequested), ((IMultiplayerClient)this).LoadRequested);
-            connection.On(nameof(IMultiplayerClient.MatchStarted), ((IMultiplayerClient)this).MatchStarted);
+            connection.On(nameof(IMultiplayerClient.LoadAborted), ((IMultiplayerClient)this).LoadAborted);
+            connection.On(nameof(IMultiplayerClient.GameplayStarted), ((IMultiplayerClient)this).GameplayStarted);
             connection.On(nameof(IMultiplayerClient.ResultsReady), ((IMultiplayerClient)this).ResultsReady);
             connection.On<int, IEnumerable<APIMod>>(nameof(IMultiplayerClient.UserModsChanged), ((IMultiplayerClient)this).UserModsChanged);
             connection.On<MatchRoomState>(nameof(IMultiplayerClient.MatchRoomStateChanged), ((IMultiplayerClient)this).MatchRoomStateChanged);
@@ -205,7 +206,13 @@ namespace SampleMultiplayerClient
             return Task.CompletedTask;
         }
 
-        Task IMultiplayerClient.MatchStarted()
+        Task IMultiplayerClient.LoadAborted()
+        {
+            Console.WriteLine($"User {UserID} gameplay load was aborted");
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.GameplayStarted()
         {
             Console.WriteLine($"User {UserID} was informed the game started");
             return Task.CompletedTask;

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
     </ItemGroup>

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.405.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
     </ItemGroup>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.405.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
@@ -21,7 +21,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.StartMatch();
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
-                Assert.IsType<GameplayStartCountdown>(usage.Item?.Countdown);
+                Assert.IsType<ForceGameplayStartCountdown>(usage.Item?.Countdown);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
@@ -1,0 +1,159 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using osu.Game.Online.Multiplayer;
+using osu.Server.Spectator.Hubs;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests.Multiplayer
+{
+    public class AutomaticForceStartTest : MultiplayerTest
+    {
+        [Fact]
+        public async Task CountdownStartsWhenMatchStarts()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+
+            await Hub.StartMatch();
+            await waitForCountingDown();
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+                Assert.True(usage.Item?.IsCountdownRunning);
+        }
+
+        [Fact]
+        public async Task CountdownStopsWhenAllPlayersAbort()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+
+            await Hub.StartMatch();
+            await waitForCountingDown();
+
+            await Hub.AbortGameplay();
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+                Assert.True(usage.Item?.IsCountdownStoppedOrCancelled);
+        }
+
+        [Fact]
+        public async Task LoadingUsersAbortWhenCountdownEnds()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.StartMatch();
+
+            await finishCountdown();
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.True(room.State == MultiplayerRoomState.Open);
+                Assert.Equal(MultiplayerUserState.Idle, room.Users.Single(u => u.UserID == USER_ID).State);
+
+                UserReceiver.Verify(r => r.LoadAborted(), Times.Once);
+                UserReceiver.Verify(r => r.GameplayStarted(), Times.Never);
+            }
+        }
+
+        [Fact]
+        public async Task LoadedUsersStartWhenCountdownEnds()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.StartMatch();
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+
+            await finishCountdown();
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.True(room.State == MultiplayerRoomState.Playing);
+                Assert.Equal(MultiplayerUserState.Playing, room.Users.Single(u => u.UserID == USER_ID).State);
+
+                UserReceiver.Verify(r => r.LoadAborted(), Times.Never);
+                UserReceiver.Verify(r => r.GameplayStarted(), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task ReadyAndLoadedUsersStartWhenCountdownEnds()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+
+            // User 1 becomes ready for gameplay.
+            SetUserContext(ContextUser);
+            await Hub.StartMatch();
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
+
+            // User 2 becomes loaded.
+            SetUserContext(ContextUser2);
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+
+            await finishCountdown();
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+            {
+                var room = usage.Item;
+                Debug.Assert(room != null);
+
+                Assert.True(room.State == MultiplayerRoomState.Playing);
+                Assert.Equal(MultiplayerUserState.Playing, room.Users.Single(u => u.UserID == USER_ID).State);
+                Assert.Equal(MultiplayerUserState.Playing, room.Users.Single(u => u.UserID == USER_ID_2).State);
+
+                UserReceiver.Verify(r => r.GameplayStarted(), Times.Once);
+                User2Receiver.Verify(r => r.GameplayStarted(), Times.Once);
+            }
+        }
+
+        private async Task finishCountdown()
+        {
+            ServerMultiplayerRoom? room;
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+            {
+                room = usage.Item;
+                room?.SkipToEndOfCountdown();
+            }
+
+            Debug.Assert(room != null);
+
+            int attempts = 200;
+            while (attempts-- > 0 && room.IsCountdownRunning)
+                Thread.Sleep(10);
+        }
+
+        private async Task waitForCountingDown()
+        {
+            ServerMultiplayerRoom? room;
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+                room = usage.Item;
+
+            Debug.Assert(room != null);
+
+            int attempts = 200;
+            while (attempts-- > 0 && room.Countdown == null)
+                Thread.Sleep(10);
+
+            Assert.NotNull(room.Countdown);
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +20,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
     public class DelegatingMultiplayerClient : IMultiplayerClient, IClientProxy
     {
         private readonly IEnumerable<IMultiplayerClient> clients;
+
+        public DelegatingMultiplayerClient()
+            : this(Enumerable.Empty<IMultiplayerClient>())
+        {
+        }
 
         public DelegatingMultiplayerClient(IEnumerable<IMultiplayerClient> clients)
         {

--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -103,10 +103,16 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 await c.LoadRequested();
         }
 
-        public virtual async Task MatchStarted()
+        public virtual async Task LoadAborted()
         {
             foreach (var c in clients)
-                await c.MatchStarted();
+                await c.LoadAborted();
+        }
+
+        public virtual async Task GameplayStarted()
+        {
+            foreach (var c in clients)
+                await c.GameplayStarted();
         }
 
         public virtual async Task ResultsReady()

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
@@ -43,7 +43,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Clients.Verify(clients => clients.Client(ContextUser2.Object.ConnectionId).UserStateChanged(USER_ID_2, MultiplayerUserState.WaitingForLoad), Times.Never);
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
-            Receiver.Verify(c => c.MatchStarted(), Times.Once);
+            Receiver.Verify(c => c.GameplayStarted(), Times.Once);
             Clients.Verify(clients => clients.Client(ContextUser2.Object.ConnectionId).UserStateChanged(USER_ID_2, MultiplayerUserState.Playing), Times.Never);
 
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
@@ -43,7 +43,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Clients.Verify(clients => clients.Client(ContextUser2.Object.ConnectionId).UserStateChanged(USER_ID_2, MultiplayerUserState.WaitingForLoad), Times.Never);
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
-            Receiver.Verify(c => c.GameplayStarted(), Times.Once);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
+            UserReceiver.Verify(c => c.GameplayStarted(), Times.Once);
             Clients.Verify(clients => clients.Client(ContextUser2.Object.ConnectionId).UserStateChanged(USER_ID_2, MultiplayerUserState.Playing), Times.Never);
 
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
@@ -67,7 +68,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task SpectatingUserReceivesLoadRequestedAfterMatchStarted()
+        public async Task SpectatingUserReceivesLoadRequestedAfterGameplayStarted()
         {
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeState(MultiplayerUserState.Ready);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -50,8 +50,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -82,9 +81,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             var newItem = new MultiplayerPlaylistItem
@@ -131,9 +128,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
@@ -157,9 +152,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
@@ -208,9 +201,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             // The first user should now be able to add another item.

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -99,14 +99,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
 
-            SetUserContext(ContextUser2);
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser, ContextUser2);
 
             SetUserContext(ContextUser);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             SetUserContext(ContextUser2);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -299,7 +299,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.False(room.CountdownCancellationRequested);
+                Assert.False(room.IsCountdownStoppedOrCancelled);
                 Assert.True(room.IsCountdownRunning);
             }
 
@@ -331,7 +331,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.False(room.CountdownCancellationRequested);
+                Assert.False(room.IsCountdownStoppedOrCancelled);
                 Assert.True(room.IsCountdownRunning);
             }
         }
@@ -350,7 +350,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.True(room.CountdownCancellationRequested || !room.IsCountdownRunning);
+                Assert.True(room.IsCountdownStoppedOrCancelled);
             }
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
@@ -363,7 +363,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.True(room.CountdownCancellationRequested || !room.IsCountdownRunning);
+                Assert.True(room.IsCountdownStoppedOrCancelled);
             }
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.False(room.Countdown is MatchStartCountdown);
+                Assert.IsNotType<MatchStartCountdown>(room.Countdown);
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
@@ -92,7 +92,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.False(room.Countdown is MatchStartCountdown);
+                Assert.IsNotType<MatchStartCountdown>(room.Countdown);
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
@@ -170,7 +170,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.False(room.Countdown is MatchStartCountdown);
+                Assert.IsNotType<MatchStartCountdown>(room.Countdown);
                 Receiver.Verify(r => r.MatchEvent(It.Is<CountdownChangedEvent>(e => e.Countdown == null)), Times.Exactly(2));
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Null(room.Countdown);
+                Assert.False(room.Countdown is MatchStartCountdown);
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
@@ -93,7 +93,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Null(room.Countdown);
+                Assert.False(room.Countdown is MatchStartCountdown);
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
@@ -188,8 +188,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Null(room.Countdown);
-                Receiver.Verify(r => r.MatchEvent(It.IsAny<CountdownChangedEvent>()), Times.Exactly(4));
+                Assert.False(room.Countdown is MatchStartCountdown);
+                Receiver.Verify(r => r.MatchEvent(It.Is<CountdownChangedEvent>(e => e.Countdown == null)), Times.Exactly(2));
                 GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -42,12 +42,13 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // all users finish loading.
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
             Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Playing), Times.Once);
             using (var room = await Rooms.GetForUse(ROOM_ID))
                 Assert.Equal(MultiplayerRoomState.Playing, room.Item?.State);
 
             // server requests users start playing.
-            Receiver.Verify(r => r.GameplayStarted(), Times.Once);
+            UserReceiver.Verify(r => r.GameplayStarted(), Times.Once);
             using (var room = await Rooms.GetForUse(ROOM_ID))
                 Assert.All(room.Item?.Users, u => Assert.Equal(MultiplayerUserState.Playing, u.State));
 
@@ -106,6 +107,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // first user finishes loading.
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             // room is still waiting for second user to load.
             using (var room = await Rooms.GetForUse(ROOM_ID))
@@ -115,11 +117,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // second user finishes loading, which triggers gameplay to start.
             SetUserContext(ContextUser2);
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
                 Assert.Equal(MultiplayerRoomState.Playing, room.Item?.State);
-                Receiver.Verify(r => r.GameplayStarted(), Times.Once);
+                UserReceiver.Verify(r => r.GameplayStarted(), Times.Once);
                 Assert.All(room.Item?.Users, u => Assert.Equal(MultiplayerUserState.Playing, u.State));
                 Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Playing), Times.Once);
                 Receiver.Verify(r => r.UserStateChanged(USER_ID_2, MultiplayerUserState.Playing), Times.Once);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.Equal(MultiplayerRoomState.Playing, room.Item?.State);
 
             // server requests users start playing.
-            Receiver.Verify(r => r.MatchStarted(), Times.Once);
+            Receiver.Verify(r => r.GameplayStarted(), Times.Once);
             using (var room = await Rooms.GetForUse(ROOM_ID))
                 Assert.All(room.Item?.Users, u => Assert.Equal(MultiplayerUserState.Playing, u.State));
 
@@ -110,7 +110,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // room is still waiting for second user to load.
             using (var room = await Rooms.GetForUse(ROOM_ID))
                 Assert.Equal(MultiplayerRoomState.WaitingForLoad, room.Item?.State);
-            Receiver.Verify(r => r.MatchStarted(), Times.Never);
+            Receiver.Verify(r => r.GameplayStarted(), Times.Never);
 
             // second user finishes loading, which triggers gameplay to start.
             SetUserContext(ContextUser2);
@@ -119,7 +119,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
                 Assert.Equal(MultiplayerRoomState.Playing, room.Item?.State);
-                Receiver.Verify(r => r.MatchStarted(), Times.Once);
+                Receiver.Verify(r => r.GameplayStarted(), Times.Once);
                 Assert.All(room.Item?.Users, u => Assert.Equal(MultiplayerUserState.Playing, u.State));
                 Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Playing), Times.Once);
                 Receiver.Verify(r => r.UserStateChanged(USER_ID_2, MultiplayerUserState.Playing), Times.Once);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -35,8 +35,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -65,8 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Idle);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -110,8 +108,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -133,8 +130,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Idle);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -169,9 +165,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-            await Hub.ChangeState(MultiplayerUserState.Results);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -263,8 +263,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.RemovePlaylistItem(1));
@@ -397,8 +396,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem
@@ -455,8 +453,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeState(MultiplayerUserState.Ready));

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -204,6 +204,23 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// <param name="context">The user context.</param>
         protected void SetUserContext(Mock<HubCallerContext> context) => Hub.Context = context.Object;
 
+        protected async Task LoadAndFinishGameplay(params Mock<HubCallerContext>[] users)
+        {
+            foreach (var u in users)
+            {
+                SetUserContext(u);
+
+                await Hub.ChangeState(MultiplayerUserState.Loaded);
+                await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
+            }
+
+            foreach (var u in users)
+            {
+                SetUserContext(u);
+                await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            }
+        }
+
         private void setUpMockDatabase()
         {
             DatabaseFactory.Setup(factory => factory.GetInstance()).Returns(Database.Object);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -55,12 +55,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// <summary>
         /// A receiver specific to the user with ID <see cref="USER_ID"/>.
         /// </summary>
-        protected readonly Mock<IMultiplayerClient> UserReceiver;
+        protected readonly Mock<DelegatingMultiplayerClient> UserReceiver;
 
         /// <summary>
         /// A receiver specific to the user with ID <see cref="USER_ID_2"/>.
         /// </summary>
-        protected readonly Mock<IMultiplayerClient> User2Receiver;
+        protected readonly Mock<DelegatingMultiplayerClient> User2Receiver;
 
         /// <summary>
         /// The user with ID <see cref="USER_ID"/>.
@@ -130,8 +130,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             ContextUser2.Setup(context => context.UserIdentifier).Returns(USER_ID_2.ToString());
             ContextUser2.Setup(context => context.ConnectionId).Returns(USER_ID_2.ToString());
 
-            UserReceiver = new Mock<IMultiplayerClient>();
-            User2Receiver = new Mock<IMultiplayerClient>();
+            UserReceiver = new Mock<DelegatingMultiplayerClient>();
+            User2Receiver = new Mock<DelegatingMultiplayerClient>();
 
             Receiver = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID, false)) { CallBase = true };
             GameplayReceiver = new Mock<DelegatingMultiplayerClient>(getClientsForGroup(ROOM_ID, true)) { CallBase = true };

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -114,6 +114,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -143,8 +144,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
             SetUserContext(ContextUser2);
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -179,9 +182,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
 
             await Hub.StartMatch();
-            await Hub.ChangeState(MultiplayerUserState.Loaded);
-
-            await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
+            await LoadAndFinishGameplay(ContextUser);
 
             VerifyRemovedFromGameplayGroup(ContextUser, ROOM_ID);
             VerifyRemovedFromGameplayGroup(ContextUser2, ROOM_ID, false);
@@ -206,6 +207,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             VerifyAddedToGameplayGroup(ContextUser, ROOM_ID);
             VerifyAddedToGameplayGroup(ContextUser2, ROOM_ID, false);
@@ -268,6 +270,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Test during Playing state.
             await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
             await Hub.ChangeState(MultiplayerUserState.Idle);
             using (var room = await Rooms.GetForUse(ROOM_ID))
                 Assert.Equal(MultiplayerUserState.Playing, room.Item?.Users[0].State);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -318,8 +318,9 @@ namespace osu.Server.Spectator.Hubs
 
                         break;
 
-                    // If a client triggered `Loaded` before they received the `Idle` message from their gameplay being aborted.
+                    // If a client a triggered gameplay state before they received the `Idle` message from their gameplay being aborted.
                     case MultiplayerUserState.Loaded:
+                    case MultiplayerUserState.ReadyForGameplay:
                         if (!isGameplayState(user.State))
                             return;
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -671,7 +671,7 @@ namespace osu.Server.Spectator.Hubs
                         foreach (var u in loadedUsers)
                             await HubContext.ChangeAndBroadcastUserState(room, u, MultiplayerUserState.Playing);
 
-                        await Clients.Group(GetGroupId(room.RoomID)).MatchStarted();
+                        await Clients.Group(GetGroupId(room.RoomID)).GameplayStarted();
 
                         await HubContext.ChangeRoomState(room, MultiplayerRoomState.Playing);
                     }

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -182,7 +182,7 @@ namespace osu.Server.Spectator.Hubs
 
             await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID, true)).SendAsync(nameof(IMultiplayerClient.LoadRequested));
 
-            await room.StartCountdown(new GameplayStartCountdown { TimeRemaining = gameplay_load_timeout }, StartOrStopGameplay);
+            await room.StartCountdown(new ForceGameplayStartCountdown { TimeRemaining = gameplay_load_timeout }, StartOrStopGameplay);
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace osu.Server.Spectator.Hubs
         {
             Debug.Assert(room.State == MultiplayerRoomState.WaitingForLoad);
 
-            await room.StopCountdown<GameplayStartCountdown>();
+            await room.StopCountdown<ForceGameplayStartCountdown>();
 
             bool anyUserPlaying = false;
 

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -185,6 +185,10 @@ namespace osu.Server.Spectator.Hubs
             await room.StartCountdown(new GameplayStartCountdown { TimeRemaining = gameplay_load_timeout }, StartOrStopGameplay);
         }
 
+        /// <summary>
+        /// Starts gameplay for all users in the <see cref="MultiplayerUserState.Loaded"/> or <see cref="MultiplayerUserState.ReadyForGameplay"/> states,
+        /// and aborts gameplay for any others in the <see cref="MultiplayerUserState.WaitingForLoad"/> state.
+        /// </summary>
         public async Task StartOrStopGameplay(ServerMultiplayerRoom room)
         {
             Debug.Assert(room.State == MultiplayerRoomState.WaitingForLoad);

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -193,9 +193,19 @@ namespace osu.Server.Spectator.Hubs
         }
 
         /// <summary>
-        /// Stops the current countdown, preventing its callback from running.
+        /// Stops any current countdown, preventing its callback from running.
         /// </summary>
         public void StopCountdown() => countdownStopSource?.Cancel();
+
+        /// <summary>
+        /// Stops the current countdown if it's of the given type, preventing its callback from running.
+        /// </summary>
+        /// <typeparam name="T">The countdown type.</typeparam>
+        public void StopCountdown<T>()
+        {
+            if (Countdown is T)
+                StopCountdown();
+        }
 
         /// <summary>
         /// Skips to the end of the currently-running countdown, if one is running,

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -206,7 +206,7 @@ namespace osu.Server.Spectator.Hubs
         /// <summary>
         /// Whether the current countdown has been requested to stop.
         /// </summary>
-        public bool CountdownCancellationRequested => countdownStopSource?.IsCancellationRequested == true;
+        public bool IsCountdownStoppedOrCancelled => countdownStopSource?.IsCancellationRequested != false;
 
         /// <summary>
         /// Whether a countdown is currently running.

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -9,10 +9,10 @@
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="7.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.4" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.429.0" />

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.405.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.405.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.405.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.405.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.405.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.429.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.429.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.429.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.429.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.429.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.320.1" />
         <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/17933

The user state transition process for entering gameplay now looks like this:
```
1. Idle
2. Ready
3. WaitingForLoad (set by the server)
4. Loaded (set by the client, beatmap loaded but user is not yet ready to start gameplay)
5. ReadyForGameplay (set by the client, user is ready to start gameplay)
6. Playing (set by the server)
```

I've had to adjust existing tests to conform to the above new process for entering gameplay.

When the a match is started (clients receive `LoadRequested()`):
1. A 1-minute countdown is started.
2. Once the countdown fires, it starts gameplay for all users in the `Loaded` or `ReadyForGameplay` states, and aborts the loading process for all clients in the `WaitingForLoad` state (setting them to `Idle` and calling `LoadAborted()` in the process).  
- This may abort all users in the match if no users have finished loading.
- Countdowns are used since they provide an existing system and it would also be nice to eventually display a progress bar in the client.

Normal gameplay start:

https://user-images.githubusercontent.com/1329837/164751717-3a87e54b-1e21-4de5-8b74-78b054b48949.mp4

When one user is in a blocking overlay:

https://user-images.githubusercontent.com/1329837/164751764-c91b468d-113a-490c-8390-b4aa9cad7c41.mp4

When one user takes too long to load:

https://user-images.githubusercontent.com/1329837/164751811-263fbb31-f34c-403d-a2a7-33c6fb247ede.mp4

Notes on groups:
- The gameplay group is no longer used to transmit the `GameplayStarted` (previously `MatchStarted`) event. This is an intentional change because players in the `Ready` state are added to the gameplay group and it feels wrong to potentially send gameplay-related messages to those clients. The messages are invoked on individual clients instead.
- I plan to clean up group handling in a separate PR since I think there is worth to doing so, such as the automatic SignalR handling of connection lifetime.  
- As a result, I've had to update existing tests which were previously asserting on the gameplay/non-gameplay receivers to now assert on the individual clients.