### PR TITLE
Remove spinning loops in countdown tests

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -15,7 +15,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 {
     public class MultiplayerCountdownTest : MultiplayerTest
     {
-        [Fact(Timeout = 1000)]
+        private const int test_timeout = 60000;
+
+        [Fact(Timeout = test_timeout)]
         public async Task CanStartCountdownIfNotReady()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -31,7 +33,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 4000)]
+        [Fact(Timeout = test_timeout)]
         public async Task GameplayStartsWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -62,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task GameplayStartsWhenCountdownFinished()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -95,7 +97,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task GameplayDoesNotStartWhenCountdownCancelled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -117,7 +119,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task NewCountdownOverridesExisting()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -174,7 +176,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task CanNotStartCountdownDuringMatch()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -184,7 +186,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(async () => await Hub.SendMatchRequest(new StartMatchCountdownRequest { Duration = TimeSpan.FromMinutes(1) }));
         }
 
-        [Fact(Timeout = 4000)]
+        [Fact(Timeout = test_timeout)]
         public async Task TimeRemainingUpdatedOnJoin()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -210,7 +212,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Assert.True(secondRoom.Countdown?.TimeRemaining.TotalSeconds < 60);
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task CanNotStartCountdownIfAutoStartEnabled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -219,7 +221,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(async () => await Hub.SendMatchRequest(new StartMatchCountdownRequest { Duration = TimeSpan.FromMinutes(1) }));
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task AutoStartCountdownDoesNotStartWithZeroDuration()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -234,7 +236,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task AutoStartCountdownStartsWhenHostReadies()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -249,7 +251,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task AutoStartCountdownStartsWhenGuestReadies()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -266,7 +268,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task AutoStartCountdownContinuesWhileAllUsersNotReady()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -303,7 +305,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task AutoStartCountdownCanNotBeCancelled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -324,7 +326,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact(Timeout = 1000)]
+        [Fact(Timeout = test_timeout)]
         public async Task CountdownStoppedWhenAutoStartDurationChanged()
         {
             await Hub.JoinRoom(ROOM_ID);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.NotNull(room.Countdown);
-                task = room.WaitForCountdownCompletion();
+                task = room.GetCurrentCountdownTask();
             }
 
             await task;

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -39,9 +39,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.SendMatchRequest(new StartMatchCountdownRequest { Duration = TimeSpan.FromSeconds(3) });
 
-            using (var usage = await Hub.GetRoom(ROOM_ID))
-                Assert.NotNull(usage.Item?.Countdown);
-
             Task task;
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
@@ -49,7 +46,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                task = room.WaitForCountdown();
+                Assert.NotNull(room.Countdown);
+                task = room.WaitForCountdownCompletion();
             }
 
             await task;

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerCountdownTest.cs
@@ -15,7 +15,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 {
     public class MultiplayerCountdownTest : MultiplayerTest
     {
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task CanStartCountdownIfNotReady()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -31,7 +31,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 4000)]
         public async Task GameplayStartsWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task GameplayStartsWhenCountdownFinished()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -97,7 +97,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task GameplayDoesNotStartWhenCountdownCancelled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -119,7 +119,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task NewCountdownOverridesExisting()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -195,7 +195,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task CanNotStartCountdownDuringMatch()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -205,7 +205,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(async () => await Hub.SendMatchRequest(new StartMatchCountdownRequest { Duration = TimeSpan.FromMinutes(1) }));
         }
 
-        [Fact]
+        [Fact(Timeout = 4000)]
         public async Task TimeRemainingUpdatedOnJoin()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -231,7 +231,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Assert.True(secondRoom.Countdown?.TimeRemaining.TotalSeconds < 60);
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task CanNotStartCountdownIfAutoStartEnabled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -240,7 +240,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Assert.ThrowsAsync<InvalidStateException>(async () => await Hub.SendMatchRequest(new StartMatchCountdownRequest { Duration = TimeSpan.FromMinutes(1) }));
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task AutoStartCountdownDoesNotStartWithZeroDuration()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -255,7 +255,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task AutoStartCountdownStartsWhenHostReadies()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -270,7 +270,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task AutoStartCountdownStartsWhenGuestReadies()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -287,7 +287,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task AutoStartCountdownContinuesWhileAllUsersNotReady()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -324,7 +324,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task AutoStartCountdownCanNotBeCancelled()
         {
             await Hub.JoinRoom(ROOM_ID);
@@ -345,7 +345,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
         }
 
-        [Fact]
+        [Fact(Timeout = 1000)]
         public async Task CountdownStoppedWhenAutoStartDurationChanged()
         {
             await Hub.JoinRoom(ROOM_ID);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -399,7 +399,7 @@ namespace osu.Server.Spectator.Hubs
                         if (room.Settings.AutoStartEnabled)
                             throw new InvalidStateException("Cannot start manual countdown if auto-start is enabled.");
 
-                        room.StartCountdown(new MatchStartCountdown { TimeRemaining = countdown.Duration }, HubContext.StartMatch);
+                        await room.StartCountdown(new MatchStartCountdown { TimeRemaining = countdown.Duration }, HubContext.StartMatch);
 
                         break;
 
@@ -409,7 +409,7 @@ namespace osu.Server.Spectator.Hubs
                         if (room.Settings.AutoStartEnabled)
                             throw new InvalidStateException("Cannot cancel auto-start countdown.");
 
-                        room.StopCountdown();
+                        await room.StopCountdown();
                         break;
 
                     default:
@@ -651,7 +651,7 @@ namespace osu.Server.Spectator.Hubs
                         bool shouldHaveCountdown = !room.Queue.CurrentItem.Expired && room.Users.Any(u => u.State == MultiplayerUserState.Ready);
 
                         if (shouldHaveCountdown && room.Countdown == null)
-                            room.StartCountdown(new MatchStartCountdown { TimeRemaining = room.Settings.AutoStartDuration }, HubContext.StartMatch);
+                            await room.StartCountdown(new MatchStartCountdown { TimeRemaining = room.Settings.AutoStartDuration }, HubContext.StartMatch);
                     }
 
                     break;

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -91,7 +91,7 @@ namespace osu.Server.Spectator.Hubs
 
             // Assume some destructive operation took place to warrant unreadying all users, and pre-emptively stop the countdown.
             // For example, gameplay-specific changes to the match settings or the current playlist item.
-            room.StopCountdown();
+            await room.StopCountdown();
         }
 
         public async Task EnsureAllUsersValidMods(ServerMultiplayerRoom room)

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -198,12 +198,9 @@ namespace osu.Server.Spectator.Hubs
         }
 
         /// <summary>
-        /// Wait synchronously for the current countdown to complete.
-        /// </summary>
-        /// <returns>
         /// A task which will become completed when the active countdown completes. Make sure to await this *outside* a usage.
-        /// </returns>
-        public Task WaitForCountdownCompletion() => countdownTask;
+        /// </summary>
+        public Task GetCurrentCountdownTask() => countdownTask;
 
         #endregion
     }

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -201,17 +201,22 @@ namespace osu.Server.Spectator.Hubs
         /// Skips to the end of the currently-running countdown, if one is running,
         /// and runs the callback (e.g. to start the match) as soon as possible unless the countdown has been cancelled.
         /// </summary>
-        public void SkipToEndOfCountdown() => countdownSkipSource?.Cancel();
+        /// <returns>
+        /// A task which will become completed when the active countdown completes. Make sure to await this *outside* a usage.
+        /// </returns>
+        public Task SkipToEndOfCountdown()
+        {
+            countdownSkipSource?.Cancel();
+            return countdownTask;
+        }
 
         /// <summary>
-        /// Whether the current countdown has been requested to stop.
+        /// Wait synchronously for the current countdown to complete.
         /// </summary>
-        public bool CountdownCancellationRequested => countdownStopSource?.IsCancellationRequested == true;
-
-        /// <summary>
-        /// Whether a countdown is currently running.
-        /// </summary>
-        public bool IsCountdownRunning => !countdownTask.IsCompleted;
+        /// <returns>
+        /// A task which will become completed when the active countdown completes. Make sure to await this *outside* a usage.
+        /// </returns>
+        public Task WaitForCountdown() => countdownTask;
 
         #endregion
     }

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer;
@@ -141,12 +142,10 @@ namespace osu.Server.Spectator.Hubs
                         if (roomUsage.Item == null)
                             return;
 
-                        // A new countdown may have since replaced the currently tracked countdown.
-                        if (roomUsage.Item.Countdown != countdown)
-                            return;
-
                         if (stopSource.IsCancellationRequested)
                             return;
+
+                        Debug.Assert(Countdown == countdown);
 
                         await StopCountdown();
 

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -175,13 +175,13 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         public async Task StopCountdown()
         {
-            countdownStopSource?.Cancel();
+            if (Countdown == null)
+                return;
 
-            if (Countdown != null)
-            {
-                Countdown = null;
-                await hub.NotifyNewMatchEvent(this, new CountdownChangedEvent { Countdown = null });
-            }
+            countdownStopSource?.Cancel();
+            Countdown = null;
+
+            await hub.NotifyNewMatchEvent(this, new CountdownChangedEvent { Countdown = null });
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/ServerMultiplayerRoom.cs
@@ -115,9 +115,9 @@ namespace osu.Server.Spectator.Hubs
 
             Countdown = countdown;
 
-            countdownTask = start();
-
             await hub.NotifyNewMatchEvent(this, new CountdownChangedEvent { Countdown = countdown });
+
+            countdownTask = start();
 
             async Task start()
             {


### PR DESCRIPTION
While reviewing the new force gameplay PR I noticed that this is being added in more places, and doesn't feel great.

Addresses two points:
- The previous tests were waiting for a countdown to start as if it could be a delayed operation (but it can't be).
- The previous tests were using a loop to wait for a countdown to complete rather than checking the task completion direction.