### PR TITLE
Allow running without replay saving enabled

### DIFF
--- a/.idea/.idea.osu.Server.Spectator/.idea/misc.xml
+++ b/.idea/.idea.osu.Server.Spectator/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="SwUserDefinedSpecifications">
+    <option name="specTypeByUrl">
+      <map />
+    </option>
+  </component>
   <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
     <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
   </component>


### PR DESCRIPTION
I'm looking to deploy the next server version on our production kubernetes cluster (unsure whether it will stick or not but let's see).

For the time being this means we can't be storing replays, as there's not enough storage to do so when deployed in this fashion.

I've set the default value to *not* store replays by default. Can be flipped if preferred.