### PR TITLE
Add CreateUser() test setup method + refactor setup

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -216,16 +216,16 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                     {
                         type = database_match_type.head_to_head,
                         ends_at = DateTimeOffset.Now.AddMinutes(5),
-                        user_id = USER_ID,
+                        user_id = int.Parse(Hub.Context.UserIdentifier!),
                     });
 
             Database.Setup(db => db.GetRoomAsync(ROOM_ID_2))
                     .Callback<long>(InitialiseRoom)
-                    .ReturnsAsync(new multiplayer_room
+                    .ReturnsAsync(() => new multiplayer_room
                     {
                         type = database_match_type.head_to_head,
                         ends_at = DateTimeOffset.Now.AddMinutes(5),
-                        user_id = USER_ID_2
+                        user_id = int.Parse(Hub.Context.UserIdentifier!)
                     });
 
             Database.Setup(db => db.GetBeatmapChecksumAsync(It.IsAny<int>()))

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -159,6 +159,15 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserJoinPreRetrievalFailureCleansUpRoom()
         {
+            Database.Setup(db => db.GetRoomAsync(ROOM_ID))
+                    .Callback<long>(InitialiseRoom)
+                    .ReturnsAsync(() => new multiplayer_room
+                    {
+                        type = database_match_type.head_to_head,
+                        ends_at = DateTimeOffset.Now.AddMinutes(5),
+                        user_id = USER_ID,
+                    });
+
             SetUserContext(ContextUser2); // not the correct user to join the game first; triggers host mismatch failure.
             await Assert.ThrowsAnyAsync<Exception>(() => Hub.JoinRoom(ROOM_ID));
 


### PR DESCRIPTION
For writing tests with more than 2 users, I think it could be useful to have a `CreateUser()` setup method. This also reorders the setup method to read a bit more linearly.