### PR TITLE
Improve round robin queueing algorithm

### DIFF
--- a/osu.Server.Spectator.Tests/Extensions/EnumerableExtensionsTest.cs
+++ b/osu.Server.Spectator.Tests/Extensions/EnumerableExtensionsTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Server.Spectator.Extensions;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests.Extensions
+{
+    public class EnumerableExtensionsTest
+    {
+        [Fact]
+        public void InterleaveNoCollectionsDoesNotReturnAny()
+        {
+            IEnumerable<IEnumerable<int>> collections = Array.Empty<IEnumerable<int>>();
+            Assert.Empty(collections.Interleave());
+        }
+
+        [Fact]
+        public void InterleaveEmptyCollectionsDoesNotReturnAny()
+        {
+            IEnumerable<IEnumerable<int>> collections = new[] { Array.Empty<int>(), Array.Empty<int>() };
+            Assert.Empty(collections.Interleave());
+        }
+
+        [Fact]
+        public void InterleaveSingleCollectionReturnsAllElementsFromCollection()
+        {
+            const int count = 10;
+
+            IEnumerable<IEnumerable<int>> collections = new[] { Enumerable.Range(0, count) };
+
+            IEnumerable<int>[] result = collections.Interleave().ToArray();
+            Assert.Equal(count, result.Length);
+
+            for (int i = 0; i < count; i++)
+                Assert.Equal(new[] { i }, result[i]);
+        }
+
+        [Fact]
+        public void InterleaveCollectionsOfSameCountReturnsInterleavedElements()
+        {
+            const int count = 10;
+
+            IEnumerable<IEnumerable<int>> collections = new[] { Enumerable.Range(0, count), Enumerable.Range(0, count).Reverse() };
+
+            IEnumerable<int>[] result = collections.Interleave().ToArray();
+            Assert.Equal(count, result.Length);
+
+            for (int i = 0; i < count; i++)
+                Assert.Equal(new[] { i, count - i - 1 }, result[i]);
+        }
+
+        [Fact]
+        public void InterleaveCollectionsOfDifferentLengthContinuesToCompletion()
+        {
+            const int max_count = 10;
+            const int second_count = 5;
+            const int third_count = 2;
+
+            IEnumerable<IEnumerable<int>> collections = new[] { Enumerable.Range(0, max_count), Enumerable.Range(0, second_count), Enumerable.Range(0, third_count) };
+
+            IEnumerable<int>[] result = collections.Interleave().ToArray();
+            Assert.Equal(max_count, result.Length);
+
+            for (int i = 0; i < max_count; i++)
+            {
+                List<int> expected = new List<int> { i };
+
+                if (i < second_count)
+                    expected.Add(i);
+
+                if (i < third_count)
+                    expected.Add(i);
+
+                Assert.Equal(expected, result[i]);
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -66,6 +66,172 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await checkCurrentItem(4);
         }
 
+        [Fact]
+        public async Task RoundRobinOrderingWithManyUsers()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+
+            CreateUser(1, out var contextUser1, out _);
+            CreateUser(2, out var contextUser2, out _);
+            CreateUser(3, out var contextUser3, out _);
+            CreateUser(4, out var contextUser4, out _);
+
+            // ---
+            // User 1 joins and begins adding items.
+            // ---
+
+            SetUserContext(contextUser1);
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   | (new)
+            await checkOrder(1);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  2   |  1   | (new)
+            await addItem();
+            await checkOrder(1, 2);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  2   |  1   |
+            // |  3   |  1   | (new)
+            await addItem();
+            await checkOrder(1, 2, 3);
+
+            // ---
+            // User 2 joins and begins adding items.
+            // ---
+
+            SetUserContext(contextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   | (new)
+            // |  2   |  1   |
+            // |  3   |  1   |
+            await addItem();
+            await checkOrder(1, 4, 2, 3);
+
+            // ---
+            // User 3 joins and begins adding items.
+            // ---
+
+            SetUserContext(contextUser3);
+            await Hub.JoinRoom(ROOM_ID);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   | (new)
+            // |  2   |  1   |
+            // |  3   |  1   |
+            await addItem();
+            await checkOrder(1, 4, 5, 2, 3);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  2   |  1   |
+            // |  6   |  3   | (new)
+            // |  3   |  1   |
+            await addItem();
+            await checkOrder(1, 4, 5, 2, 6, 3);
+
+            // ---
+            // User 2 adds more items.
+            // ---
+
+            SetUserContext(contextUser2);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  2   |  1   |
+            // |  7   |  2   | (new)
+            // |  6   |  3   |
+            // |  3   |  1   |
+            await addItem();
+            await checkOrder(1, 4, 5, 2, 7, 6, 3);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  2   |  1   |
+            // |  7   |  2   |
+            // |  6   |  3   |
+            // |  3   |  1   |
+            // |  8   |  2   | (new)
+            await addItem();
+            await checkOrder(1, 4, 5, 2, 7, 6, 3, 8);
+
+            // ---
+            // User 4 joins and begins adding items.
+            // ---
+
+            SetUserContext(contextUser4);
+            await Hub.JoinRoom(ROOM_ID);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  9   |  4   | (new)
+            // |  2   |  1   |
+            // |  7   |  2   |
+            // |  6   |  3   |
+            // |  3   |  1   |
+            // |  8   |  2   |
+            await addItem();
+            await checkOrder(1, 4, 5, 9, 2, 7, 6, 3, 8);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  9   |  4   |
+            // |  2   |  1   |
+            // |  7   |  2   |
+            // |  6   |  3   |
+            // |  10  |  4   | (new)
+            // |  3   |  1   |
+            // |  8   |  2   |
+            await addItem();
+            await checkOrder(1, 4, 5, 9, 2, 7, 6, 10, 3, 8);
+
+            // | item | user |
+            // | ---- | ---- |
+            // |  1   |  1   |
+            // |  4   |  2   |
+            // |  5   |  3   |
+            // |  9   |  4   |
+            // |  2   |  1   |
+            // |  7   |  2   |
+            // |  6   |  3   |
+            // |  10  |  4   |
+            // |  3   |  1   |
+            // |  8   |  2   |
+            // |  11  |  4   | (new)
+            await addItem();
+            await checkOrder(1, 4, 5, 9, 2, 7, 6, 10, 3, 8, 11);
+        }
+
         private async Task runGameplay()
         {
             SetUserContext(ContextUser2);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -232,6 +232,34 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await checkOrder(1, 4, 5, 9, 2, 7, 6, 10, 3, 8, 11);
         }
 
+        [Fact]
+        public async Task OrderUpdatedOnRemoval()
+        {
+            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+
+            await Hub.JoinRoom(ROOM_ID);
+            await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
+            await addItem();
+            await addItem();
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            await addItem();
+            await addItem();
+            await addItem();
+
+            // Items should be initially interleaved.
+            await checkOrder(1, 4, 2, 5, 3, 6);
+
+            // Remove item with id 4.
+            await Hub.RemovePlaylistItem(4);
+            await checkOrder(1, 5, 2, 6, 3);
+
+            // Remove item with id 5.
+            await Hub.RemovePlaylistItem(5);
+            await checkOrder(1, 6, 2, 3);
+        }
+
         private async Task runGameplay()
         {
             SetUserContext(ContextUser2);

--- a/osu.Server.Spectator/Extensions/EnumerableExtensions.cs
+++ b/osu.Server.Spectator/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Server.Spectator.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Interleaves sequential elements from one or more collections, returning groups of interleaved elements.
+        /// </summary>
+        /// <remarks>
+        /// Runtime complexity is <c>O(n * m)</c> where <c>n</c> is the given number of collections
+        /// and <c>m</c> is the maximum number of elements in of any collection.
+        /// </remarks>
+        /// <param name="collections">The collections to interleave.</param>
+        /// <typeparam name="T">The type of element in each collection.</typeparam>
+        /// <returns>
+        /// For the collections:
+        /// <code>
+        /// A = [A1, A2, A3, A4]
+        /// B = [B1, B2]
+        /// C = [C1, C2, C3]
+        /// </code>
+        /// This returns the groups of elements <c>[A1, B1, C1]</c>, <c>[A2, B2, C2]</c>, <c>[A3, C3]</c>, <c>[A4]</c>.
+        /// </returns>
+        public static IEnumerable<IEnumerable<T>> Interleave<T>(this IEnumerable<IEnumerable<T>> collections)
+        {
+            var enumerators = new List<IEnumerator<T>>();
+
+            try
+            {
+                foreach (var c in collections)
+                    enumerators.Add(c.GetEnumerator());
+
+                while (true)
+                {
+                    T[] interleaved = enumerators.Where(it => it.MoveNext())
+                                                 .Select(it => it.Current)
+                                                 .ToArray(); // The enumerators must be consumed immediately due to lazy evaluation.
+
+                    if (interleaved.Length == 0)
+                        break;
+
+                    yield return interleaved;
+                }
+            }
+            finally
+            {
+                foreach (var it in enumerators)
+                    it.Dispose();
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -198,10 +198,14 @@ namespace osu.Server.Spectator.Hubs
                 throw new InvalidStateException("Attempted to remove an item which has already been played.");
 
             using (var db = dbFactory.GetInstance())
+            {
                 await db.RemovePlaylistItemAsync(room.RoomID, playlistItemId);
 
-            room.Playlist.Remove(item);
-            await hub.NotifyPlaylistItemRemoved(room, playlistItemId);
+                room.Playlist.Remove(item);
+                await hub.NotifyPlaylistItemRemoved(room, playlistItemId);
+
+                await updatePlaylistOrder(db);
+            }
 
             await updateCurrentItem();
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-server-spectator/issues/126

Firstly, a very simple fix - the playlist wasn't reordered when items were removed.

As for round robin... The previous algorithm didn't really work at all, and after much trying/deliberation, this is what I've come up with. It's a rework of the algorithm in entirety.

Consider the queue as sets of items such that each user appears at most once in each set. The order in which items from users are picked into sets is by the order in which they were added to the playlist.

In the first set containing the single earliest item added by each user, items are sorted by their existing `PlaylistOrder` value. When an item is added by a _new_ user, it is added with `PlaylistOrder = ushort.Max`, so it will always be added to the end of this list.  
Preserving the existing `PlaylistOrder` is important for when items are played, in order to prevent the next item by the same user whose item was played from jumping to the front of the queue.

If there is a `PlaylistOrder` tie in the first set, which is currently not possible but may become possible in the future if we allow rooms to be created with more than 1 item, then the tie is broken by taking the order in which the items were added.

Any further sets of items are ordered such that they maintain the same ordering as the first set.

The sets are then combined to form the queue.

---

One edge case of this algorithm is during removal. Suppose the queue is
```
| item | user |
| ---- | ---- |
|  1   |  1   |
|  4   |  2   |
|  5   |  3   |
|  9   |  4   |
|  2   |  1   |
|  7   |  2   |
|  6   |  3   |
|  10  |  4   |
```
If the item 4 is removed, the movement of item 7 is as follows:
```
| item | user |
| ---- | ---- |
|  1   |  1   |
|  5   |  3   |
|  9   |  4   |   
|      |      |<---|
|  2   |  1   |    |
|  7   |  2   | ---|
|  6   |  3   |
|  10  |  4   |
```
Which is unexpected since item 7 was added earlier than item 9.

This is due to the preservation of order via the use of the existing `PlaylistOrder` value. There may be a simple solution to this, but I haven't figured it out yet, and from the view of not complicating this PR too much I'd say we should go with it.