### PR TITLE
Log errors in OnConnectedAsync()/OnDisconnectedAsync()

### DIFF
--- a/osu.Server.Spectator/LoggingHubFilter.cs
+++ b/osu.Server.Spectator/LoggingHubFilter.cs
@@ -36,6 +36,38 @@ namespace osu.Server.Spectator
             }
         }
 
+        public async Task OnConnectedAsync(HubLifetimeContext context, Func<HubLifetimeContext, Task> next)
+        {
+            if (!(context.Hub is ILogTarget logTarget))
+                throw new InvalidOperationException($"Hub implementation {context.Hub.GetType().Name} doesn't implement {nameof(ILogTarget)}.");
+
+            try
+            {
+                await next(context);
+            }
+            catch (Exception e)
+            {
+                logTarget.Error($"Failed to invoke OnConnectedAsync()", e);
+                throw;
+            }
+        }
+
+        public async Task OnDisconnectedAsync(HubLifetimeContext context, Exception? exception, Func<HubLifetimeContext, Exception?, Task> next)
+        {
+            if (!(context.Hub is ILogTarget logTarget))
+                throw new InvalidOperationException($"Hub implementation {context.Hub.GetType().Name} doesn't implement {nameof(ILogTarget)}.");
+
+            try
+            {
+                await next(context, exception);
+            }
+            catch (Exception e)
+            {
+                logTarget.Error($"Failed to invoke {nameof(OnDisconnectedAsync)}()", e);
+                throw;
+            }
+        }
+
         private static string getMethodCallDisplayString(HubInvocationContext invocationContext)
         {
             var methodCall = $"{invocationContext.HubMethodName}({string.Join(", ", invocationContext.HubMethodArguments.Select(getReadableString))})";


### PR DESCRIPTION
This is mostly a copy-pase of `InvokeMethodAsync`, overriding the default-implementation interface methods. It doesn't log the initial call like the former does, since that sounds like it may be a bit verbose.

```
2022-05-24 06:33:56 [error]: [user:18414468] Failed to invoke OnDisconnectedAsync()
2022-05-24 06:33:56 [error]: System.InvalidOperationException: Wangs
2022-05-24 06:33:56 [error]: at osu.Server.Spectator.Hubs.MultiplayerHub.CleanUpState(MultiplayerClientState state) in /home/smgi/Repos/osu-server-spectator/osu.Server.Spectator/Hubs/MultiplayerHub.cs:line 642
2022-05-24 06:33:56 [error]: at osu.Server.Spectator.Hubs.StatefulUserHub`2.cleanUpState(Boolean isDisconnect) in /home/smgi/Repos/osu-server-spectator/osu.Server.Spectator/Hubs/StatefulUserHub.cs:line 117
2022-05-24 06:33:56 [error]: at osu.Server.Spectator.Hubs.StatefulUserHub`2.OnDisconnectedAsync(Exception exception) in /home/smgi/Repos/osu-server-spectator/osu.Server.Spectator/Hubs/StatefulUserHub.cs:line 83
2022-05-24 06:33:56 [error]: at osu.Server.Spectator.LoggingHubFilter.OnDisconnectedAsync(HubLifetimeContext context, Exception exception, Func`3 next) in /home/smgi/Repos/osu-server-spectator/osu.Server.Spectator/LoggingHubFilter.cs:line 62
```