### PR TITLE
Add graceful shutdown support

### DIFF
--- a/osu.Server.Spectator/Entities/EntityStore.cs
+++ b/osu.Server.Spectator/Entities/EntityStore.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Hosting;
 using osu.Framework.Extensions.ObjectExtensions;
 using StatsdClient;
 
@@ -27,18 +26,6 @@ namespace osu.Server.Spectator.Entities
         private string statsDPrefix => $"entities.{typeof(T).Name}";
 
         private bool acceptingNewEntities = true;
-
-        public EntityStore(GracefulShutdownManager shutdownManager, IHostApplicationLifetime applicationLifetime)
-            : this()
-        {
-            // Registration is required here to ensure `ApplicationStopping` triggers the shutdown wait before SignalR disconnects clients.
-            // Hope we can find a better way to make this work in the future.
-            applicationLifetime.ApplicationStopping.Register(shutdownManager.WaitForSafeShutdown);
-        }
-
-        public EntityStore()
-        {
-        }
 
         public void StopAcceptingEntities() => acceptingNewEntities = false;
 

--- a/osu.Server.Spectator/Entities/EntityStore.cs
+++ b/osu.Server.Spectator/Entities/EntityStore.cs
@@ -40,10 +40,18 @@ namespace osu.Server.Spectator.Entities
         {
         }
 
-        /// <summary>
-        /// Inform this entity store that a server shutdown transition is in progress, and new entities should not be allowed.
-        /// </summary>
         public void StopAcceptingEntities() => acceptingNewEntities = false;
+
+        public int RemainingUsages
+        {
+            get
+            {
+                lock (entityMapping)
+                    return entityMapping.Count;
+            }
+        }
+
+        public string EntityName => typeof(T).Name;
 
         /// <summary>
         /// Retrieves an entity.
@@ -261,15 +269,6 @@ namespace osu.Server.Spectator.Entities
             {
                 if (IsDestroyed) throw new InvalidOperationException("Attempted to use an item which has already been destroyed");
                 if (shouldBeLocked && !isLocked) throw new InvalidOperationException("Attempted to access a tracked entity without holding a lock");
-            }
-        }
-
-        public bool AnyRemainingUsage
-        {
-            get
-            {
-                lock (entityMapping)
-                    return entityMapping.Count > 0;
             }
         }
     }

--- a/osu.Server.Spectator/Entities/IEntityStore.cs
+++ b/osu.Server.Spectator/Entities/IEntityStore.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.Spectator.Entities;
+
+public interface IEntityStore
+{
+    bool AnyRemainingUsage { get; }
+
+    void StopAcceptingEntities();
+}

--- a/osu.Server.Spectator/Entities/IEntityStore.cs
+++ b/osu.Server.Spectator/Entities/IEntityStore.cs
@@ -5,7 +5,18 @@ namespace osu.Server.Spectator.Entities;
 
 public interface IEntityStore
 {
-    bool AnyRemainingUsage { get; }
+    /// <summary>
+    /// Number of entities remaining in use.
+    /// </summary>
+    int RemainingUsages { get; }
 
+    /// <summary>
+    /// A display name for the managed entity.
+    /// </summary>
+    string EntityName { get; }
+
+    /// <summary>
+    /// Inform this entity store that a server shutdown transition is in progress, and new entities should not be allowed.
+    /// </summary>
     void StopAcceptingEntities();
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,8 @@ namespace osu.Server.Spectator.Extensions
         {
             return serviceCollection.AddSingleton<EntityStore<SpectatorClientState>>()
                                     .AddSingleton<EntityStore<MultiplayerClientState>>()
-                                    .AddSingleton<EntityStore<ServerMultiplayerRoom>>();
+                                    .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
+                                    .AddSingleton<GracefulShutdownManager>();
         }
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -26,22 +26,10 @@ public class GracefulShutdownManager
 
     public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime)
     {
-        addDependentStore(roomStore);
-        addDependentStore(clientStateStore);
+        dependentStores.Add(roomStore);
+        dependentStores.Add(clientStateStore);
 
         hostApplicationLifetime.ApplicationStopping.Register(shutdownSafely);
-    }
-
-    /// <summary>
-    /// Add an entity store which should be waited on for all usages to have finished.
-    /// </summary>
-    /// <param name="store"></param>
-    private void addDependentStore(IEntityStore? store)
-    {
-        if (store == null)
-            return;
-
-        dependentStores.Add(store);
     }
 
     private void shutdownSafely()

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -10,6 +10,9 @@ using osu.Server.Spectator.Entities;
 
 namespace osu.Server.Spectator;
 
+/// <summary>
+/// Ensures that shutdown is delayed until any existing usages have ceased.
+/// </summary>
 public class GracefulShutdownManager
 {
     private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
@@ -17,7 +20,7 @@ public class GracefulShutdownManager
     private Task? shutdownTask;
 
     /// <summary>
-    /// Call to trigger and block on waiting for a safe shutdown state.
+    /// Blocks until safe to continue with shutdown. Can be invoked from multiple locations.
     /// </summary>
     public void WaitForSafeShutdown()
     {
@@ -27,7 +30,11 @@ public class GracefulShutdownManager
         shutdownTask.Wait();
     }
 
-    public void AddStore(IEntityStore? store)
+    /// <summary>
+    /// Add an entity store which should be waited on for all usages to have finished.
+    /// </summary>
+    /// <param name="store"></param>
+    public void AddDependentStore(IEntityStore? store)
     {
         if (store == null)
             return;

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -54,12 +54,15 @@ public class GracefulShutdownManager
 
             while (true)
             {
-                bool remaining = dependentStores.Any(store => store.AnyRemainingUsage);
+                var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
 
-                if (!remaining)
+                if (remaining.Sum(s => s.RemainingUsages) == 0)
                     break;
 
-                Logger.Log($"Waiting for usages of existing entities to finish...");
+                Logger.Log("Waiting for usages of existing entities to finish...");
+                foreach (var r in remaining)
+                    Logger.Log($"{r.EntityName,10}: {r.RemainingUsages}");
+
                 Thread.Sleep(10000);
             }
 

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -22,25 +22,12 @@ public class GracefulShutdownManager
 
     private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
 
-    private Task? shutdownTask;
-
     public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime)
     {
         addDependentStore(roomStore);
         addDependentStore(clientStateStore);
 
-        hostApplicationLifetime.ApplicationStopping.Register(WaitForSafeShutdown);
-    }
-
-    /// <summary>
-    /// Blocks until safe to continue with shutdown. Can be invoked from multiple locations.
-    /// </summary>
-    public void WaitForSafeShutdown()
-    {
-        lock (this)
-            shutdownTask ??= Task.Factory.StartNew(shutdownSafely, TaskCreationOptions.LongRunning);
-
-        shutdownTask.Wait();
+        hostApplicationLifetime.ApplicationStopping.Register(shutdownSafely);
     }
 
     /// <summary>
@@ -52,39 +39,35 @@ public class GracefulShutdownManager
         if (store == null)
             return;
 
-        lock (dependentStores)
-            dependentStores.Add(store);
+        dependentStores.Add(store);
     }
 
     private void shutdownSafely()
     {
-        lock (dependentStores)
+        Logger.Log("Server shutdown triggered");
+
+        foreach (var store in dependentStores)
+            store.StopAcceptingEntities();
+
+        TimeSpan timeWaited = new TimeSpan();
+
+        TimeSpan timeBetweenChecks = TimeSpan.FromSeconds(10);
+
+        while (timeWaited < TIME_BEFORE_FORCEFUL_SHUTDOWN)
         {
-            Logger.Log("Server shutdown triggered");
+            var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
 
-            foreach (var store in dependentStores)
-                store.StopAcceptingEntities();
+            if (remaining.Sum(s => s.RemainingUsages) == 0)
+                break;
 
-            TimeSpan timeWaited = new TimeSpan();
+            Logger.Log("Waiting for usages of existing entities to finish...");
+            foreach (var r in remaining)
+                Logger.Log($"{r.EntityName,10}: {r.RemainingUsages}");
 
-            TimeSpan timeBetweenChecks = TimeSpan.FromSeconds(10);
-
-            while (timeWaited < TIME_BEFORE_FORCEFUL_SHUTDOWN)
-            {
-                var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
-
-                if (remaining.Sum(s => s.RemainingUsages) == 0)
-                    break;
-
-                Logger.Log("Waiting for usages of existing entities to finish...");
-                foreach (var r in remaining)
-                    Logger.Log($"{r.EntityName,10}: {r.RemainingUsages}");
-
-                Thread.Sleep(timeBetweenChecks);
-                timeWaited = timeWaited.Add(timeBetweenChecks);
-            }
-
-            Logger.Log("All entities cleaned up. Server shutdown unblocking.");
+            Thread.Sleep(timeBetweenChecks);
+            timeWaited = timeWaited.Add(timeBetweenChecks);
         }
+
+        Logger.Log("All entities cleaned up. Server shutdown unblocking.");
     }
 }

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Logging;
+using osu.Server.Spectator.Entities;
+
+namespace osu.Server.Spectator;
+
+public class GracefulShutdownManager
+{
+    private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
+
+    private Task? shutdownTask;
+
+    /// <summary>
+    /// Call to trigger and block on waiting for a safe shutdown state.
+    /// </summary>
+    public void WaitForSafeShutdown()
+    {
+        lock (this)
+            shutdownTask ??= Task.Factory.StartNew(shutdownSafely, TaskCreationOptions.LongRunning);
+
+        shutdownTask.Wait();
+    }
+
+    public void AddStore(IEntityStore? store)
+    {
+        if (store == null)
+            return;
+
+        lock (dependentStores)
+            dependentStores.Add(store);
+    }
+
+    private void shutdownSafely()
+    {
+        lock (dependentStores)
+        {
+            Logger.Log("Server shutdown triggered");
+
+            foreach (var store in dependentStores)
+                store.StopAcceptingEntities();
+
+            while (true)
+            {
+                bool remaining = dependentStores.Any(store => store.AnyRemainingUsage);
+
+                if (!remaining)
+                    break;
+
+                Logger.Log($"Waiting for usages of existing entities to finish...");
+                Thread.Sleep(10000);
+            }
+
+            Logger.Log("All entities cleaned up. Server shutdown unblocking.");
+        }
+    }
+}

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
 using osu.Server.Spectator.Entities;
@@ -18,6 +17,9 @@ namespace osu.Server.Spectator;
 /// </summary>
 public class GracefulShutdownManager
 {
+    // This should probably be configurable in the future.
+    // 6 hours is way too long, but set initially to test the whole process out.
+    // We can manually override this for immediate shutdown if/when required from a kubernetes or docker level.
     public static readonly TimeSpan TIME_BEFORE_FORCEFUL_SHUTDOWN = TimeSpan.FromHours(6);
 
     private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -52,7 +52,12 @@ public class GracefulShutdownManager
             foreach (var store in dependentStores)
                 store.StopAcceptingEntities();
 
-            while (true)
+            int timeWaited = 0;
+
+            const int seconds_between_checks = 10;
+            const int max_hours_before_forceful_shutdown = 6;
+
+            while (timeWaited < 3600 * max_hours_before_forceful_shutdown)
             {
                 var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
 
@@ -63,7 +68,8 @@ public class GracefulShutdownManager
                 foreach (var r in remaining)
                     Logger.Log($"{r.EntityName,10}: {r.RemainingUsages}");
 
-                Thread.Sleep(10000);
+                Thread.Sleep(seconds_between_checks * 1000);
+                timeWaited += seconds_between_checks;
             }
 
             Logger.Log("All entities cleaned up. Server shutdown unblocking.");

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -168,6 +168,10 @@ namespace osu.Server.Spectator.Hubs
 
             using (var db = databaseFactory.GetInstance())
             {
+                // TODO: this call should be transactional, and mark the room as managed by this server instance.
+                // This will allow for other instances to know not to reinitialise the room if the host arrives there.
+                // Alternatively, we can move lobby retrieval away from osu-web and not require this in the first place.
+                // Needs further discussion and consideration either way.
                 var databaseRoom = await db.GetRoomAsync(roomId);
 
                 if (databaseRoom == null)

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -65,6 +65,8 @@ namespace osu.Server.Spectator
             });
 
             // Allow a bit of extra time in addition to the graceful shutdown window for asp.net level forced shutdown.
+            // This time may be used to tidy up user states and update the database to a sane state (ie. marking open multiplayer
+            // rooms as closed).
             services.Configure<HostOptions>(opts => opts.ShutdownTimeout = GracefulShutdownManager.TIME_BEFORE_FORCEFUL_SHUTDOWN.Add(TimeSpan.FromMinutes(1)));
 
             ConfigureAuthentication(services);


### PR DESCRIPTION
This will change shutdown behaviour to wait for all multiplayer rooms and spectator sessions to end before shutting down the server. Until now I've been manually managing this with two deploys. The new behaviour is required to deploy to kubernetes, where the application lifetime will be automatically managed.

This works well because websocket connections persist to existing server instances, but new connections will be directed to the fresher instance. Client side handling of the new `The server is shutting down.` error message allows clients which are attempting to start new spectator sessions or multiplayer rooms to first trigger a reconnect and find the newer server.

Eventually we may want to use multiple endpoints or sticky cookies/headers to persist server across connection loss (aka cloudflare support, since cloudflare arbitrarily drops websocket connections) but for now we are avoiding this by dropping cloudflare temporarily.

Not sure if tests can be added for this kind of coverage. You'll have to take my word that it works. And some videos.

The case where graceful shutdown works:

https://user-images.githubusercontent.com/191335/170455093-37688cbe-5106-45e3-8d60-c6ea03b22620.mp4

The case where it times out:

https://user-images.githubusercontent.com/191335/170455511-aa5c1e23-a0da-4ec9-a111-c991d7090c91.mp4

I've chosen a very high number for the non-graceful timeout as there's no harm in having old instances sitting around. We'll adjust as necessary (and potentially move to envvar if we want to tune it further).

