### PR TITLE
Add tags to track individual deployments uniquely on datadog

### DIFF
--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
@@ -22,6 +23,11 @@ namespace osu.Server.Spectator
             {
                 StatsdServerName = Environment.GetEnvironmentVariable("DD_AGENT_HOST") ?? "localhost",
                 Prefix = "osu.server.spectator",
+                ConstantTags = new[]
+                {
+                    $"hostname:{Dns.GetHostName()}",
+                    $"startup:{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}",
+                }
             });
 
             createHostBuilder(args).Build().Run();


### PR DESCRIPTION
As we are now deploying to kubernetes, where multiple deployments may be on the same physical host (ie. the one running `dogstatsd` we need to report statistics distinctly to avoid there's no clash when reporting. This will allow tracking user counts across all instances without conflict.

I've added the `startup` tag as a backup in case the `hostname` one doesn't work. It may also be useful to track the newest instance based on startup timestamp.