### PR TITLE
Add sentry exception filter for `HubException`

### DIFF
--- a/osu.Server.Spectator/Entities/EntityStore.cs
+++ b/osu.Server.Spectator/Entities/EntityStore.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using osu.Framework.Extensions.ObjectExtensions;
 using StatsdClient;
 
@@ -80,7 +79,7 @@ namespace osu.Server.Spectator.Entities
                         }
 
                         if (!acceptingNewEntities)
-                            throw new HubException("Server is shutting down.");
+                            throw new ServerShuttingDownException();
 
                         entityMapping[id] = item = new TrackedEntity(id, this);
                         DogStatsd.Gauge($"{statsDPrefix}.total-tracked", entityMapping.Count);

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -5,9 +5,11 @@ using System;
 using System.IO;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using Sentry;
 using StatsdClient;
 
 namespace osu.Server.Spectator
@@ -38,18 +40,20 @@ namespace osu.Server.Spectator
             return Host.CreateDefaultBuilder(args)
                        .ConfigureWebHostDefaults(webBuilder =>
                        {
-#if DEBUG
-                           //todo: figure correct way to get dev environment state
-                           webBuilder.UseSentry()
-                                     .UseStartup<StartupDevelopment>();
-#else
                            webBuilder.UseSentry(o =>
                            {
-                               o.Dsn = "https://775dc89c1c3142e8a8fa5fd10590f443@sentry.ppy.sh/8";
+                               o.AddExceptionFilterForType<HubException>();
                                o.TracesSampleRate = 0.01;
+#if !DEBUG
+                               o.Dsn = "https://775dc89c1c3142e8a8fa5fd10590f443@sentry.ppy.sh/8";
+#endif
                                // TODO: set release name
-                           })
-                           .UseStartup<Startup>();
+                           });
+
+#if DEBUG
+                           webBuilder.UseStartup<StartupDevelopment>();
+#else
+                           webBuilder.UseStartup<Startup>();
 #endif
 
                            webBuilder.UseUrls(urls: new[] { "http://*:80" });

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -42,7 +41,7 @@ namespace osu.Server.Spectator
                        {
                            webBuilder.UseSentry(o =>
                            {
-                               o.AddExceptionFilterForType<HubException>();
+                               o.AddExceptionFilterForType<ServerShuttingDownException>();
                                o.TracesSampleRate = 0.01;
 #if !DEBUG
                                o.Dsn = "https://775dc89c1c3142e8a8fa5fd10590f443@sentry.ppy.sh/8";

--- a/osu.Server.Spectator/ServerShuttingDownException.cs
+++ b/osu.Server.Spectator/ServerShuttingDownException.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace osu.Server.Spectator;
+
+public class ServerShuttingDownException : HubException
+{
+    public ServerShuttingDownException()
+        : base("Server is shutting down.")
+    {
+    }
+}


### PR DESCRIPTION
These exceptions are intended for the end-user, and shouldn't be logged to sentry.

https://sentry.ppy.sh/organizations/ppy/issues/2771/?project=8&query=is%3Aunresolved&statsPeriod=14d