### PR TITLE
Ensure `UserFinishedPlaying` is never called with a `Playing` state

### DIFF
--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -192,6 +192,10 @@ namespace osu.Server.Spectator.Hubs
 
         private async Task endPlaySession(int userId, SpectatorState state)
         {
+            // Ensure that the state is no longer playing (e.g. if client crashes).
+            if (state.State == SpectatedUserState.Playing)
+                state.State = SpectatedUserState.Quit;
+
             await Clients.All.UserFinishedPlaying(userId, state);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/19061

If a user forcefully quits their game, or the game crashes, the multiplayer server could send back a `UserFinishedPlaying(State = Playing)` message.