### PR TITLE
Add base class structure for a "score uploader"

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -29,6 +29,7 @@ namespace osu.Server.Spectator.Tests
 
             mockStorage = new Mock<IScoreStorage>();
             uploader = new ScoreUploader(databaseFactory.Object, mockStorage.Object);
+            uploader.UploadInterval = 10000; // Set a high timer interval for testing purposes.
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Scoring;
@@ -94,6 +95,7 @@ namespace osu.Server.Spectator.Tests
 
             // Score with no token.
             uploader.Enqueue(2, new Score());
+            Thread.Sleep(1000); // Wait for cancellation.
             await uploader.Flush();
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 

--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using osu.Game.Scoring;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Hubs;
+using osu.Server.Spectator.Storage;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class ScoreUploaderTests
+    {
+        private readonly ScoreUploader uploader;
+        private readonly Mock<IDatabaseAccess> mockDatabase;
+        private readonly Mock<IScoreStorage> mockStorage;
+
+        public ScoreUploaderTests()
+        {
+            mockDatabase = new Mock<IDatabaseAccess>();
+            mockDatabase.Setup(db => db.GetScoreIdFromToken(1)).Returns(Task.FromResult<long?>(2));
+
+            var databaseFactory = new Mock<IDatabaseFactory>();
+            databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
+
+            mockStorage = new Mock<IScoreStorage>();
+            uploader = new ScoreUploader(databaseFactory.Object, mockStorage.Object);
+        }
+
+        [Fact]
+        public async Task ScoreUploadsEveryInterval()
+        {
+            enableUpload();
+
+            uploader.UploadInterval = 1000;
+
+            // First score.
+            uploader.Enqueue(1, new Score());
+            await Task.Delay(2000);
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
+
+            // Second score (ensure the loop keeps running).
+            uploader.Enqueue(1, new Score());
+            await Task.Delay(2000);
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task ScoreDoesNotUploadIfDisabled()
+        {
+            disableUpload();
+
+            uploader.Enqueue(1, new Score());
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ScoreOnlyUploadsOnce()
+        {
+            enableUpload();
+
+            uploader.Enqueue(1, new Score());
+            await uploader.Flush();
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ScoreUploadsWithDelayedScoreToken()
+        {
+            enableUpload();
+
+            // Score with no token.
+            uploader.Enqueue(2, new Score());
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+
+            // Give the score a token.
+            mockDatabase.Setup(db => db.GetScoreIdFromToken(2)).Returns(Task.FromResult<long?>(3));
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 3)), Times.Once);
+        }
+
+        [Fact]
+        public async Task TimedOutScoreDoesNotUpload()
+        {
+            enableUpload();
+
+            uploader.TimeoutInterval = 0;
+
+            // Score with no token.
+            uploader.Enqueue(2, new Score());
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+
+            // Give the score a token now. It should still not upload because it has timed out.
+            mockDatabase.Setup(db => db.GetScoreIdFromToken(2)).Returns(Task.FromResult<long?>(3));
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+
+            // New score that has a token (ensure the loop keeps running).
+            uploader.Enqueue(1, new Score());
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Once);
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
+        }
+
+        [Fact]
+        public async Task FailedScoreHandledGracefully()
+        {
+            enableUpload();
+
+            bool shouldThrow = true;
+            int uploadCount = 0;
+
+            mockStorage.Setup(storage => storage.WriteAsync(It.IsAny<Score>()))
+                       .Callback<Score>(_ =>
+                       {
+                           // ReSharper disable once AccessToModifiedClosure
+                           if (shouldThrow)
+                               throw new InvalidOperationException();
+
+                           uploadCount++;
+                       });
+
+            // Throwing score.
+            uploader.Enqueue(1, new Score());
+            await uploader.Flush();
+            Assert.Equal(0, uploadCount);
+
+            shouldThrow = false;
+
+            // Same score shouldn't reupload.
+            await uploader.Flush();
+            Assert.Equal(0, uploadCount);
+
+            uploader.Enqueue(1, new Score());
+            await uploader.Flush();
+            Assert.Equal(1, uploadCount);
+        }
+
+        private void enableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "1");
+        private void disableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "0");
+    }
+}

--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -145,6 +145,20 @@ namespace osu.Server.Spectator.Tests
             Assert.Equal(1, uploadCount);
         }
 
+        [Fact]
+        public async Task TimedOutItemGetsOneAttempt()
+        {
+            enableUpload();
+
+            uploader.TimeoutInterval = 0;
+
+            // Score with no token.
+            uploader.Enqueue(1, new Score());
+            Thread.Sleep(1000); // Wait for cancellation.
+            await uploader.Flush();
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
+        }
+
         private void enableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "1");
         private void disableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "0");
     }

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -50,7 +50,7 @@ namespace osu.Server.Spectator.Tests
             database.Setup(db => db.GetUsernameAsync(streamer_id)).ReturnsAsync(() => "user");
             database.Setup(db => db.GetBeatmapChecksumAsync(beatmap_id)).ReturnsAsync(() => "d2a97fb2fa4529a5e857fe0466dc1daf");
 
-            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object);
+            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, new ScoreUploader(databaseFactory.Object));
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -50,7 +50,9 @@ namespace osu.Server.Spectator.Tests
             database.Setup(db => db.GetUsernameAsync(streamer_id)).ReturnsAsync(() => "user");
             database.Setup(db => db.GetBeatmapChecksumAsync(beatmap_id)).ReturnsAsync(() => "d2a97fb2fa4529a5e857fe0466dc1daf");
 
-            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, new ScoreUploader(databaseFactory.Object));
+            var scoreUploader = new Mock<IScoreUploader>();
+
+            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, scoreUploader.Object);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -286,7 +286,7 @@ namespace osu.Server.Spectator.Database
         {
             var connection = await getConnectionAsync();
 
-            return await connection.QuerySingleAsync<long?>("SELECT `score_id` FROM `solo_score_tokens` WHERE `id` = @Id", new
+            return await connection.QuerySingleOrDefaultAsync<long?>("SELECT `score_id` FROM `solo_score_tokens` WHERE `id` = @Id", new
             {
                 Id = token
             });

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -282,6 +282,16 @@ namespace osu.Server.Spectator.Database
             return new BeatmapUpdates(Array.Empty<int>(), lastEntry?.queue_id ?? 0);
         }
 
+        public async Task<long?> GetScoreIdFromToken(long token)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleAsync<long?>("SELECT `score_id` FROM `solo_score_tokens` WHERE `id` = @Id", new
+            {
+                Id = token
+            });
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -112,5 +112,12 @@ namespace osu.Server.Spectator.Database
         /// <param name="limit">Maximum number of entries to return. Defaults to 50.</param>
         /// <returns>Update metadata.</returns>
         Task<BeatmapUpdates> GetUpdatedBeatmapSets(int? lastQueueId, int limit = 50);
+
+        /// <summary>
+        /// Retrieves the score ID for a given score token. Will return null while the score has not yet been submitted.
+        /// </summary>
+        /// <param name="token">The score token.</param>
+        /// <returns>The score ID.</returns>
+        Task<long?> GetScoreIdFromToken(long token);
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -16,7 +16,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<EntityStore<MultiplayerClientState>>()
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
                                     .AddSingleton<GracefulShutdownManager>()
-                                    .AddSingleton<MetadataBroadcaster>();
+                                    .AddSingleton<MetadataBroadcaster>()
+                                    .AddSingleton<ScoreUploader>();
         }
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs;
+using osu.Server.Spectator.Storage;
 
 namespace osu.Server.Spectator.Extensions
 {
@@ -17,7 +18,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
-                                    .AddSingleton<IScoreUploader, ScoreUploader>();
+                                    .AddSingleton<IScoreStorage, FileScoreStorage>()
+                                    .AddSingleton<ScoreUploader>();
         }
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
-                                    .AddSingleton<ScoreUploader>();
+                                    .AddSingleton<IScoreUploader, ScoreUploader>();
         }
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -28,7 +28,7 @@ public class GracefulShutdownManager
     private readonly EntityStore<ServerMultiplayerRoom> roomStore;
 
     public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime,
-                                   IScoreUploader scoreUploader)
+                                   ScoreUploader scoreUploader)
     {
         this.roomStore = roomStore;
 

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -27,12 +27,14 @@ public class GracefulShutdownManager
     private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
     private readonly EntityStore<ServerMultiplayerRoom> roomStore;
 
-    public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime)
+    public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime,
+                                   IScoreUploader scoreUploader)
     {
         this.roomStore = roomStore;
 
         dependentStores.Add(roomStore);
         dependentStores.Add(clientStateStore);
+        dependentStores.Add(scoreUploader);
 
         hostApplicationLifetime.ApplicationStopping.Register(shutdownSafely);
     }

--- a/osu.Server.Spectator/Hubs/IScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/IScoreUploader.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Scoring;
+
+namespace osu.Server.Spectator.Hubs
+{
+    public interface IScoreUploader
+    {
+        void Enqueue(long token, Score score);
+    }
+}

--- a/osu.Server.Spectator/Hubs/IScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/IScoreUploader.cs
@@ -2,10 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Scoring;
+using osu.Server.Spectator.Entities;
 
 namespace osu.Server.Spectator.Hubs
 {
-    public interface IScoreUploader
+    public interface IScoreUploader : IEntityStore
     {
         void Enqueue(long token, Score score);
     }

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -16,10 +16,19 @@ namespace osu.Server.Spectator.Hubs
     public class ScoreUploader : IEntityStore, IDisposable
     {
         /// <summary>
-        /// A timeout to drop scores which haven't had IDs assigned to their tokens.
+        /// Amount of time (in milliseconds) between checks for pending score uploads.
+        /// </summary>
+        public double UploadInterval
+        {
+            get => timer.Interval;
+            set => timer.Interval = value;
+        }
+
+        /// <summary>
+        /// Amount of time (in milliseconds) before any individual score times out if a score ID hasn't been set.
         /// This can happen if the user forcefully terminated the game before the API score submission request is sent, but after EndPlaySession() has been invoked.
         /// </summary>
-        private const int timeout_seconds = 30;
+        public double TimeoutInterval = 30000;
 
         private bool shouldSaveReplays => Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
 
@@ -57,7 +66,7 @@ namespace osu.Server.Spectator.Hubs
             Interlocked.Increment(ref remainingUsages);
 
             var cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(TimeSpan.FromSeconds(timeout_seconds));
+            cancellation.CancelAfter(TimeSpan.FromMilliseconds(TimeoutInterval));
 
             queue.Enqueue(new UploadItem(token, score, cancellation));
         }

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -80,13 +80,16 @@ namespace osu.Server.Spectator.Hubs
                             continue;
                         }
 
-                        using (item)
+                        try
                         {
                             if (scoreId != null)
                                 await uploadScore(scoreId.Value, item);
                             else
                                 Console.WriteLine($"Score upload timed out for token: {item.Token}");
-
+                        }
+                        finally
+                        {
+                            item.Dispose();
                             Interlocked.Decrement(ref remainingUsages);
                         }
                     }

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading.Tasks;
+using System.Timers;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Server.Spectator.Database;
+
+namespace osu.Server.Spectator.Hubs
+{
+    public class ScoreUploader : IDisposable
+    {
+        // private bool shouldSaveReplays => Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
+
+        private readonly ConcurrentQueue<(long token, Score score)> queue = new ConcurrentQueue<(long token, Score score)>();
+        private readonly IDatabaseFactory databaseFactory;
+        private readonly Timer timer;
+
+        public ScoreUploader(IDatabaseFactory databaseFactory)
+        {
+            this.databaseFactory = databaseFactory;
+
+            timer = new Timer(5000);
+            timer.AutoReset = false;
+            timer.Elapsed += update;
+            timer.Start();
+        }
+
+        public void Enqueue(long token, Score score) => queue.Enqueue((token, score));
+
+        private async void update(object? sender, ElapsedEventArgs args)
+        {
+            try
+            {
+                if (queue.IsEmpty)
+                    return;
+
+                Console.WriteLine($"Beginning upload of {queue.Count} scores");
+
+                using (var db = databaseFactory.GetInstance())
+                {
+                    while (queue.TryDequeue(out var item))
+                    {
+                        long? scoreId = await db.GetScoreIdFromToken(item.token);
+
+                        if (scoreId == null)
+                        {
+                            // Score is not ready yet.
+                            queue.Enqueue(item);
+                        }
+                        else
+                        {
+                            await uploadScore(scoreId.Value, item.score);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error during score upload: {e}");
+            }
+            finally
+            {
+                timer.Start();
+            }
+        }
+
+        private async Task uploadScore(long scoreId, Score score)
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            score.ScoreInfo.Date = now;
+            var legacyEncoder = new LegacyScoreEncoder(score, null);
+
+            string path = Path.Combine(SpectatorHub.REPLAYS_PATH, now.Year.ToString(), now.Month.ToString(), now.Day.ToString());
+
+            Directory.CreateDirectory(path);
+
+            string filename = $"replay-{score.ScoreInfo.Ruleset.ShortName}_{score.ScoreInfo.BeatmapInfo.OnlineID}_{scoreId}.osr";
+
+            Console.WriteLine($"Writing replay for score {scoreId} to {filename}");
+
+            using (var outStream = File.Create(Path.Combine(path, filename)))
+                legacyEncoder.Encode(outStream);
+        }
+
+        public void Dispose()
+        {
+            timer.Stop();
+            timer.Dispose();
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         private const int timeout_seconds = 30;
 
-        // private bool shouldSaveReplays => Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
+        private bool shouldSaveReplays => Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
 
         private readonly ConcurrentQueue<UploadItem> queue = new ConcurrentQueue<UploadItem>();
         private readonly IDatabaseFactory databaseFactory;
@@ -93,6 +93,9 @@ namespace osu.Server.Spectator.Hubs
 
         private async Task uploadScore(long scoreId, UploadItem item)
         {
+            if (!shouldSaveReplays)
+                return;
+
             var now = DateTimeOffset.UtcNow;
 
             item.Score.ScoreInfo.Date = now;

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -144,6 +144,7 @@ namespace osu.Server.Spectator.Hubs
 
         private int remainingUsages;
 
+        // Using the count of items in the queue isn't correct since items are dequeued for processing.
         public int RemainingUsages => remainingUsages;
 
         public string EntityName => "Score uploads";

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -45,6 +45,8 @@ namespace osu.Server.Spectator.Hubs
 
         public void Enqueue(long token, Score score)
         {
+            Interlocked.Increment(ref remainingUsages);
+
             var cancellation = new CancellationTokenSource();
             cancellation.CancelAfter(TimeSpan.FromSeconds(timeout_seconds));
 
@@ -84,6 +86,8 @@ namespace osu.Server.Spectator.Hubs
                                 await uploadScore(scoreId.Value, item);
                             else
                                 Console.WriteLine($"Score upload timed out for token: {item.Token}");
+
+                            Interlocked.Decrement(ref remainingUsages);
                         }
                     }
                 }
@@ -133,6 +137,17 @@ namespace osu.Server.Spectator.Hubs
             {
                 Cancellation.Dispose();
             }
+        }
+
+        private int remainingUsages;
+
+        public int RemainingUsages => remainingUsages;
+
+        public string EntityName => "Score uploads";
+
+        public void StopAcceptingEntities()
+        {
+            // Handled by the spectator hub.
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -96,16 +96,14 @@ namespace osu.Server.Spectator.Hubs
             if (!shouldSaveReplays)
                 return;
 
-            var now = DateTimeOffset.UtcNow;
-
-            item.Score.ScoreInfo.Date = now;
+            var scoreInfo = item.Score.ScoreInfo;
             var legacyEncoder = new LegacyScoreEncoder(item.Score, null);
 
-            string path = Path.Combine(SpectatorHub.REPLAYS_PATH, now.Year.ToString(), now.Month.ToString(), now.Day.ToString());
+            string path = Path.Combine(SpectatorHub.REPLAYS_PATH, scoreInfo.Date.Year.ToString(), scoreInfo.Date.Month.ToString(), scoreInfo.Date.Day.ToString());
 
             Directory.CreateDirectory(path);
 
-            string filename = $"replay-{item.Score.ScoreInfo.Ruleset.ShortName}_{item.Score.ScoreInfo.BeatmapInfo.OnlineID}_{scoreId}.osr";
+            string filename = $"replay-{scoreInfo.Ruleset.ShortName}_{scoreInfo.BeatmapInfo.OnlineID}_{scoreId}.osr";
 
             Console.WriteLine($"Writing replay for score {scoreId} to {filename}");
 

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Spectator.Hubs
             timerCancellationSource = new CancellationTokenSource();
             timerCancellationToken = timerCancellationSource.Token;
 
-            timer = new Timer(5000);
+            timer = new Timer(50);
             timer.AutoReset = false;
             timer.Elapsed += (_, _) => Task.Run(Flush);
             timer.Start();

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -14,7 +14,7 @@ using Timer = System.Timers.Timer;
 
 namespace osu.Server.Spectator.Hubs
 {
-    public class ScoreUploader : IDisposable
+    public class ScoreUploader : IScoreUploader, IDisposable
     {
         /// <summary>
         /// A timeout to drop scores which haven't had IDs assigned to their tokens.

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -116,6 +116,8 @@ namespace osu.Server.Spectator.Hubs
                     if (score == null || scoreToken == null)
                         return;
 
+                    score.ScoreInfo.Date = DateTimeOffset.UtcNow;
+
                     scoreUploader.Enqueue(scoreToken.Value, score);
                 }
                 finally

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -19,9 +19,9 @@ namespace osu.Server.Spectator.Hubs
         public const string REPLAYS_PATH = "replays";
 
         private readonly IDatabaseFactory databaseFactory;
-        private readonly ScoreUploader scoreUploader;
+        private readonly IScoreUploader scoreUploader;
 
-        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, ScoreUploader scoreUploader)
+        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, IScoreUploader scoreUploader)
             : base(cache, users)
         {
             this.databaseFactory = databaseFactory;

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -19,9 +19,9 @@ namespace osu.Server.Spectator.Hubs
         public const string REPLAYS_PATH = "replays";
 
         private readonly IDatabaseFactory databaseFactory;
-        private readonly IScoreUploader scoreUploader;
+        private readonly ScoreUploader scoreUploader;
 
-        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, IScoreUploader scoreUploader)
+        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, ScoreUploader scoreUploader)
             : base(cache, users)
         {
             this.databaseFactory = databaseFactory;

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
-using osu.Game.Scoring.Legacy;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 
@@ -20,14 +18,14 @@ namespace osu.Server.Spectator.Hubs
     {
         public const string REPLAYS_PATH = "replays";
 
-        private bool shouldSaveReplays => Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
-
         private readonly IDatabaseFactory databaseFactory;
+        private readonly ScoreUploader scoreUploader;
 
-        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory)
+        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, ScoreUploader scoreUploader)
             : base(cache, users)
         {
             this.databaseFactory = databaseFactory;
+            this.scoreUploader = scoreUploader;
         }
 
         public async Task BeginPlaySession(long? scoreToken, SpectatorState state)
@@ -72,6 +70,7 @@ namespace osu.Server.Spectator.Hubs
                                 OnlineID = state.BeatmapID.Value,
                                 MD5Hash = beatmapChecksum,
                             },
+                            MaximumStatistics = state.MaximumStatistics
                         }
                     };
                 }
@@ -109,30 +108,15 @@ namespace osu.Server.Spectator.Hubs
             {
                 try
                 {
-                    var score = usage.Item?.Score;
+                    Score? score = usage.Item?.Score;
+                    long? scoreToken = usage.Item?.ScoreToken;
 
                     // Score may be null if the BeginPlaySession call failed but the client is still sending frame data.
                     // For now it's safe to drop these frames.
-                    if (score == null)
+                    if (score == null || scoreToken == null)
                         return;
 
-                    var now = DateTimeOffset.UtcNow;
-
-                    if (shouldSaveReplays)
-                    {
-                        score.ScoreInfo.Date = now;
-                        var legacyEncoder = new LegacyScoreEncoder(score, null);
-
-                        string path = Path.Combine(REPLAYS_PATH, now.Year.ToString(), now.Month.ToString(), now.Day.ToString());
-
-                        Directory.CreateDirectory(path);
-
-                        string filename = $"{now.ToUnixTimeSeconds()}-{CurrentContextUserId}-{score.ScoreInfo.Ruleset.OnlineID}-{score.ScoreInfo.BeatmapInfo.OnlineID}.osr";
-
-                        Log($"Writing replay for user {CurrentContextUserId} to {filename}");
-                        using (var outStream = File.Create(Path.Combine(path, filename)))
-                            legacyEncoder.Encode(outStream);
-                    }
+                    scoreUploader.Enqueue(scoreToken.Value, score);
                 }
                 finally
                 {

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -117,7 +117,7 @@ namespace osu.Server.Spectator
             app.ApplicationServices.GetRequiredService<GracefulShutdownManager>();
 
             app.ApplicationServices.GetRequiredService<MetadataBroadcaster>();
-            app.ApplicationServices.GetRequiredService<IScoreUploader>();
+            app.ApplicationServices.GetRequiredService<ScoreUploader>();
         }
     }
 }

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -117,7 +117,7 @@ namespace osu.Server.Spectator
             app.ApplicationServices.GetRequiredService<GracefulShutdownManager>();
 
             app.ApplicationServices.GetRequiredService<MetadataBroadcaster>();
-            app.ApplicationServices.GetRequiredService<ScoreUploader>();
+            app.ApplicationServices.GetRequiredService<IScoreUploader>();
         }
     }
 }

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -117,6 +117,7 @@ namespace osu.Server.Spectator
             app.ApplicationServices.GetRequiredService<GracefulShutdownManager>();
 
             app.ApplicationServices.GetRequiredService<MetadataBroadcaster>();
+            app.ApplicationServices.GetRequiredService<ScoreUploader>();
         }
     }
 }

--- a/osu.Server.Spectator/Storage/FileScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/FileScoreStorage.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Server.Spectator.Hubs;
+
+namespace osu.Server.Spectator.Storage
+{
+    public class FileScoreStorage : IScoreStorage
+    {
+        public Task WriteAsync(Score score)
+        {
+            var scoreInfo = score.ScoreInfo;
+            var legacyEncoder = new LegacyScoreEncoder(score, null);
+
+            string path = Path.Combine(SpectatorHub.REPLAYS_PATH, scoreInfo.Date.Year.ToString(), scoreInfo.Date.Month.ToString(), scoreInfo.Date.Day.ToString());
+
+            Directory.CreateDirectory(path);
+
+            string filename = $"replay-{scoreInfo.Ruleset.ShortName}_{scoreInfo.BeatmapInfo.OnlineID}_{score.ScoreInfo.OnlineID}.osr";
+
+            Console.WriteLine($"Writing replay for score {score.ScoreInfo.OnlineID} to {filename}");
+
+            using (var outStream = File.Create(Path.Combine(path, filename)))
+                legacyEncoder.Encode(outStream);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/osu.Server.Spectator/Storage/IScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/IScoreStorage.cs
@@ -1,13 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using osu.Game.Scoring;
-using osu.Server.Spectator.Entities;
 
-namespace osu.Server.Spectator.Hubs
+namespace osu.Server.Spectator.Storage
 {
-    public interface IScoreUploader : IEntityStore
+    public interface IScoreStorage
     {
-        void Enqueue(long token, Score score);
+        Task WriteAsync(Score score);
     }
 }


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-server-spectator/pull/153
- [x] https://github.com/ppy/osu/pull/21587
- [x] https://github.com/ppy/osu/pull/21588

Following the structure set by `MetadataBroadcaster`, this PR adds a `ScoreUploader` class which performs the background process of waiting for scores to receive ids and doing an upload. Right now it doesn't actually "upload" and instead stores to files as it previously did, however the file name has been renamed to account for the solo-score ID.

https://user-images.githubusercontent.com/1329837/206978833-60d1a4bf-325b-466a-bfd0-7637378be3a4.mp4
