### PR TITLE
Add S3 upload for replays

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -160,7 +160,7 @@ namespace osu.Server.Spectator.Tests
             mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
         }
 
-        private void enableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "1");
-        private void disableUpload() => Environment.SetEnvironmentVariable("SAVE_REPLAYS", "0");
+        private void enableUpload() => AppSettings.SaveReplays = true;
+        private void disableUpload() => AppSettings.SaveReplays = false;
     }
 }

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -97,7 +97,7 @@ namespace osu.Server.Spectator.Tests
         [InlineData(true)]
         public async Task ReplayDataIsSaved(bool savingEnabled)
         {
-            Environment.SetEnvironmentVariable("SAVE_REPLAYS", savingEnabled ? "1" : "0");
+            AppSettings.SaveReplays = savingEnabled;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Server.Spectator
+{
+    public static class AppSettings
+    {
+        public static bool SaveReplays { get; }
+        public static string S3Key { get; }
+        public static string S3Secret { get; }
+        public static string ReplaysBucket { get; }
+
+        static AppSettings()
+        {
+            SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
+            S3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? string.Empty;
+            S3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? string.Empty;
+            ReplaysBucket = Environment.GetEnvironmentVariable("REPLAYS_BUCKET") ?? string.Empty;
+        }
+    }
+}

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -7,7 +7,7 @@ namespace osu.Server.Spectator
 {
     public static class AppSettings
     {
-        public static bool SaveReplays { get; }
+        public static bool SaveReplays { get; set; }
         public static string S3Key { get; }
         public static string S3Secret { get; }
         public static string ReplaysBucket { get; }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
-                                    .AddSingleton<IScoreStorage, FileScoreStorage>()
+                                    .AddSingleton<IScoreStorage, S3ScoreStorage>()
                                     .AddSingleton<ScoreUploader>();
         }
 

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -117,7 +117,7 @@ namespace osu.Server.Spectator.Hubs
 
                 Console.WriteLine($"Uploading replay for score {scoreId}");
 
-                S3.Upload(AppSettings.ReplaysBucket, scoreId.ToString(CultureInfo.InvariantCulture), outStream, outStream.Length);
+                await S3.Upload(AppSettings.ReplaysBucket, scoreId.ToString(CultureInfo.InvariantCulture), outStream, outStream.Length);
             }
         }
 

--- a/osu.Server.Spectator/S3.cs
+++ b/osu.Server.Spectator/S3.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace osu.Server.Spectator
+{
+    public static class S3
+    {
+        public static byte[]? Retrieve(string bucket, string key, RegionEndpoint? endpoint = null)
+        {
+            using (var client = getClient(endpoint))
+            {
+                try
+                {
+                    var obj = client.GetObjectAsync(bucket, key).Result;
+
+                    using (var memory = new MemoryStream())
+                    {
+                        obj.ResponseStream.CopyTo(memory);
+                        return memory.ToArray();
+                    }
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
+        }
+
+        public static bool CheckExists(string bucket, string key)
+        {
+            using (var client = getClient())
+            {
+                try
+                {
+                    var obj = client.GetObjectAsync(bucket, key).Result;
+                    return obj?.ContentLength > 0;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        public static void Delete(string bucket, string key)
+        {
+            using (var client = getClient())
+            {
+                client.DeleteObjectAsync(bucket, key).Wait();
+            }
+        }
+
+        private static AmazonS3Client getClient(RegionEndpoint? endpoint = null)
+        {
+            return new AmazonS3Client(new BasicAWSCredentials(AppSettings.S3Key, AppSettings.S3Secret), new AmazonS3Config
+            {
+                CacheHttpClient = true,
+                HttpClientCacheSize = 32,
+                RegionEndpoint = endpoint ?? RegionEndpoint.USWest1,
+                UseHttp = true,
+                ForcePathStyle = true
+            });
+        }
+
+        public static List<string> List(string bucket, string prefix)
+        {
+            using (var client = getClient())
+            {
+                return client.ListObjectsV2Async(new ListObjectsV2Request
+                {
+                    BucketName = bucket,
+                    Prefix = prefix
+                }).Result.S3Objects.Select(o => o.Key).ToList();
+            }
+        }
+
+        public static void Upload(string bucket, string key, Stream stream, long contentLength, string? contentType = null)
+        {
+            using (var client = getClient())
+            {
+                client.PutObjectAsync(new PutObjectRequest
+                {
+                    BucketName = bucket,
+                    Key = key,
+                    CannedACL = S3CannedACL.PublicRead,
+                    Headers =
+                    {
+                        ContentLength = contentLength,
+                        ContentType = contentType,
+                    },
+                    InputStream = stream
+                }).Wait();
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/S3.cs
+++ b/osu.Server.Spectator/S3.cs
@@ -1,10 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
@@ -14,51 +12,6 @@ namespace osu.Server.Spectator
 {
     public static class S3
     {
-        public static byte[]? Retrieve(string bucket, string key, RegionEndpoint? endpoint = null)
-        {
-            using (var client = getClient(endpoint))
-            {
-                try
-                {
-                    var obj = client.GetObjectAsync(bucket, key).Result;
-
-                    using (var memory = new MemoryStream())
-                    {
-                        obj.ResponseStream.CopyTo(memory);
-                        return memory.ToArray();
-                    }
-                }
-                catch (Exception)
-                {
-                    return null;
-                }
-            }
-        }
-
-        public static bool CheckExists(string bucket, string key)
-        {
-            using (var client = getClient())
-            {
-                try
-                {
-                    var obj = client.GetObjectAsync(bucket, key).Result;
-                    return obj?.ContentLength > 0;
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-        }
-
-        public static void Delete(string bucket, string key)
-        {
-            using (var client = getClient())
-            {
-                client.DeleteObjectAsync(bucket, key).Wait();
-            }
-        }
-
         private static AmazonS3Client getClient(RegionEndpoint? endpoint = null)
         {
             return new AmazonS3Client(new BasicAWSCredentials(AppSettings.S3Key, AppSettings.S3Secret), new AmazonS3Config
@@ -71,23 +24,11 @@ namespace osu.Server.Spectator
             });
         }
 
-        public static List<string> List(string bucket, string prefix)
+        public static async Task Upload(string bucket, string key, Stream stream, long contentLength, string? contentType = null)
         {
             using (var client = getClient())
             {
-                return client.ListObjectsV2Async(new ListObjectsV2Request
-                {
-                    BucketName = bucket,
-                    Prefix = prefix
-                }).Result.S3Objects.Select(o => o.Key).ToList();
-            }
-        }
-
-        public static void Upload(string bucket, string key, Stream stream, long contentLength, string? contentType = null)
-        {
-            using (var client = getClient())
-            {
-                client.PutObjectAsync(new PutObjectRequest
+                await client.PutObjectAsync(new PutObjectRequest
                 {
                     BucketName = bucket,
                     Key = key,
@@ -98,7 +39,7 @@ namespace osu.Server.Spectator
                         ContentType = contentType,
                     },
                     InputStream = stream
-                }).Wait();
+                });
             }
         }
     }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AWSSDK.S3" Version="3.7.101.34" />
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-server-spectator/pull/154
- [x] https://github.com/ppy/osu/pull/21627

Environment variables:
`SAVE_REPLAYS`: Needs to be 1.
`S3_KEY`: AWS key.
`S3_SECRET`: AWS secret.
`REPLAYS_BUCKET`: Bucket name.

https://user-images.githubusercontent.com/1329837/207252484-34490c37-3437-401a-92ab-f6eb4e010501.mp4