### PR TITLE
Send notifications about score processing completion to clients

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1225.1" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1225.1" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SpectatorClient.cs
+++ b/SampleSpectatorClient/SpectatorClient.cs
@@ -25,7 +25,7 @@ namespace SampleSpectatorClient
             connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserBeganPlaying), ((ISpectatorClient)this).UserBeganPlaying);
             connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
             connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
-            connection.On<int, long>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserScoreProcessed);
+            connection.On<int, long>(nameof(ISpectatorClient.UserScoreProcessed), ((ISpectatorClient)this).UserScoreProcessed);
         }
 
         Task ISpectatorClient.UserBeganPlaying(int userId, SpectatorState state)
@@ -58,7 +58,7 @@ namespace SampleSpectatorClient
 
         Task ISpectatorClient.UserScoreProcessed(int userId, long scoreId)
         {
-            Console.WriteLine($"{connection.ConnectionId} Processing score with ID scoreId for player {userId} completed");
+            Console.WriteLine($"{connection.ConnectionId} Processing score with ID {scoreId} for player {userId} completed");
             return Task.CompletedTask;
         }
 

--- a/SampleSpectatorClient/SpectatorClient.cs
+++ b/SampleSpectatorClient/SpectatorClient.cs
@@ -25,6 +25,7 @@ namespace SampleSpectatorClient
             connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserBeganPlaying), ((ISpectatorClient)this).UserBeganPlaying);
             connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
             connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
+            connection.On<int, long>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserScoreProcessed);
         }
 
         Task ISpectatorClient.UserBeganPlaying(int userId, SpectatorState state)
@@ -52,6 +53,12 @@ namespace SampleSpectatorClient
         Task ISpectatorClient.UserSentFrames(int userId, FrameDataBundle data)
         {
             Console.WriteLine($"{connection.ConnectionId} Received frames from {userId}: {data.Frames.First()}");
+            return Task.CompletedTask;
+        }
+
+        Task ISpectatorClient.UserScoreProcessed(int userId, long scoreId)
+        {
+            Console.WriteLine($"{connection.ConnectionId} Processing score with ID scoreId for player {userId} completed");
             return Task.CompletedTask;
         }
 

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -58,7 +58,9 @@ namespace osu.Server.Spectator.Tests
             mockScoreStorage = new Mock<IScoreStorage>();
             scoreUploader = new ScoreUploader(databaseFactory.Object, mockScoreStorage.Object);
 
-            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, scoreUploader);
+            var mockScoreProcessedSubscriber = new Mock<IScoreProcessedSubscriber>();
+
+            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, scoreUploader, mockScoreProcessedSubscriber.Object);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.18.3" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -12,12 +12,16 @@ namespace osu.Server.Spectator
         public static string S3Secret { get; }
         public static string ReplaysBucket { get; }
 
+        public static string RedisHost { get; }
+
         static AppSettings()
         {
             SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
             S3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? string.Empty;
             S3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? string.Empty;
             ReplaysBucket = Environment.GetEnvironmentVariable("REPLAYS_BUCKET") ?? string.Empty;
+
+            RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost";
         }
     }
 }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -303,6 +303,16 @@ namespace osu.Server.Spectator.Database
             });
         }
 
+        public async Task<bool> IsScoreProcessedAsync(long scoreId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleOrDefaultAsync<bool>("SELECT 1 FROM `solo_scores_process_history` WHERE `score_id` = @ScoreId", new
+            {
+                ScoreId = scoreId
+            });
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -126,5 +126,10 @@ namespace osu.Server.Spectator.Database
         /// <param name="token">The score token.</param>
         /// <returns>The score ID.</returns>
         Task<long?> GetScoreIdFromToken(long token);
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the score with the supplied <paramref name="scoreId"/> has been successfully processed.
+        /// </summary>
+        Task<bool> IsScoreProcessedAsync(long scoreId);
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs;
 using osu.Server.Spectator.Storage;
+using StackExchange.Redis;
 
 namespace osu.Server.Spectator.Extensions
 {
@@ -24,7 +25,8 @@ namespace osu.Server.Spectator.Extensions
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)
         {
-            return serviceCollection.AddSingleton<IDatabaseFactory, DatabaseFactory>();
+            return serviceCollection.AddSingleton<IDatabaseFactory, DatabaseFactory>()
+                                    .AddSingleton<IConnectionMultiplexer, ConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(AppSettings.RedisHost));
         }
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -20,7 +20,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
                                     .AddSingleton<IScoreStorage, S3ScoreStorage>()
-                                    .AddSingleton<ScoreUploader>();
+                                    .AddSingleton<ScoreUploader>()
+                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>();
         }
 
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>();
         }
 
+        /// <summary>
+        /// Adds MySQL (<see cref="IDatabaseFactory"/>) and Redis (<see cref="IConnectionMultiplexer"/>) services.
+        /// </summary>
         public static IServiceCollection AddDatabaseServices(this IServiceCollection serviceCollection)
         {
             return serviceCollection.AddSingleton<IDatabaseFactory, DatabaseFactory>()

--- a/osu.Server.Spectator/Hubs/IScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/IScoreProcessedSubscriber.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Server.Spectator.Hubs;
+
+/// <summary>
+/// Allows hub clients to receive notifications about the completion of processing of a score.
+/// </summary>
+public interface IScoreProcessedSubscriber
+{
+    /// <summary>
+    /// Registers a hub client for future notifications about the completion of processing of a score.
+    /// </summary>
+    /// <param name="receiverConnectionId">The ID of the connection that should receive the notifications.</param>
+    /// <param name="userId">The ID of the user who set the score.</param>
+    /// <param name="scoreId">The ID of the score which is being processed.</param>
+    /// <param name="callback">The callback to execute when the score has been successfully processed.</param>
+    Task RegisterForNotificationAsync(string receiverConnectionId, int userId, long scoreId, ScoreProcessedAsyncCallback callback);
+}
+
+/// <summary>
+/// Callback delegate that will be invoked when a score has been successfully processed.
+/// </summary>
+/// <param name="scoreId">The ID of the score that was processed.</param>
+public delegate Task ScoreProcessedAsyncCallback(string receiverConnectionId, int userId, long scoreId);

--- a/osu.Server.Spectator/Hubs/IScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/IScoreProcessedSubscriber.cs
@@ -16,8 +16,7 @@ public interface IScoreProcessedSubscriber
     /// <param name="receiverConnectionId">The ID of the connection that should receive the notifications.</param>
     /// <param name="userId">The ID of the user who set the score.</param>
     /// <param name="scoreId">The ID of the score which is being processed.</param>
-    /// <param name="callback">The callback to execute when the score has been successfully processed.</param>
-    Task RegisterForNotificationAsync(string receiverConnectionId, int userId, long scoreId, ScoreProcessedAsyncCallback callback);
+    Task RegisterForNotificationAsync(string receiverConnectionId, int userId, long scoreId);
 }
 
 /// <summary>

--- a/osu.Server.Spectator/Hubs/MetadataBroadcaster.cs
+++ b/osu.Server.Spectator/Hubs/MetadataBroadcaster.cs
@@ -54,7 +54,7 @@ public class MetadataBroadcaster : IDisposable
                 if (updates.BeatmapSetIDs.Any())
                 {
                     Console.WriteLine($"Broadcasting new beatmaps to client: {string.Join(',', updates.BeatmapSetIDs.Select(i => i.ToString()))}");
-                    await metadataHubContext.Clients.All.SendAsync(nameof(IMetadataClient.BeatmapSetsUpdated), updates);
+                    await metadataHubContext.Clients.All.SendAsync(nameof(IMetadataClient.BeatmapSetsUpdated), updates, cancellationToken: timerCancellationToken);
                 }
             }
         }

--- a/osu.Server.Spectator/Hubs/ScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/ScoreProcessedSubscriber.cs
@@ -1,0 +1,176 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using osu.Framework.Logging;
+using osu.Server.Spectator.Database;
+using StackExchange.Redis;
+using StatsdClient;
+using Timer = System.Timers.Timer;
+
+namespace osu.Server.Spectator.Hubs;
+
+public sealed class ScoreProcessedSubscriber : IScoreProcessedSubscriber, IDisposable
+{
+    /// <summary>
+    /// The maximum amount of time to wait for a <see cref="ScoreProcessed"/> message for a given score in milliseconds.
+    /// </summary>
+    private const int timeout_interval_ms = 30_000;
+
+    private const string statsd_prefix = "subscribers.score-processed";
+
+    private readonly IDatabaseFactory databaseFactory;
+    private readonly ISubscriber? subscriber;
+
+    private readonly ConcurrentDictionary<long, ScoreProcessedSubscription> subscriptions = new ConcurrentDictionary<long, ScoreProcessedSubscription>();
+    private readonly Timer timer;
+    private readonly Logger logger;
+
+    public ScoreProcessedSubscriber(
+        IDatabaseFactory databaseFactory,
+        IConnectionMultiplexer redis)
+    {
+        this.databaseFactory = databaseFactory;
+
+        timer = new Timer(1000);
+        timer.AutoReset = true;
+        timer.Elapsed += (_, _) => Task.Run(purgeTimedOutSubscriptions);
+        timer.Start();
+
+        subscriber = redis.GetSubscriber();
+        subscriber.Subscribe("osu-channel:score:processed", (_, message) => onMessageReceived(message));
+
+        logger = Logger.GetLogger(nameof(ScoreProcessedSubscriber));
+    }
+
+    private void onMessageReceived(string message)
+    {
+        try
+        {
+            var scoreProcessed = JsonConvert.DeserializeObject<ScoreProcessed>(message);
+
+            if (scoreProcessed == null)
+                return;
+
+            if (subscriptions.TryRemove(scoreProcessed.ScoreId, out var subscription))
+            {
+                using (subscription)
+                    subscription.InvokeAsync().Wait();
+            }
+
+            DogStatsd.Increment($"{statsd_prefix}.messages.delivered");
+        }
+        catch (Exception ex)
+        {
+            logger.Add($"Failed to process message {message}", LogLevel.Error, ex);
+            DogStatsd.Increment($"{statsd_prefix}.messages.dropped");
+        }
+    }
+
+    public async Task RegisterForNotificationAsync(string receiverConnectionId, int userId, long scoreToken, ScoreProcessedAsyncCallback callback)
+    {
+        try
+        {
+            using var db = databaseFactory.GetInstance();
+
+            long? scoreId = await db.GetScoreIdFromToken(scoreToken);
+
+            if (scoreId == null)
+            {
+                DogStatsd.Increment($"{statsd_prefix}.subscriptions.dropped");
+                return;
+            }
+
+            var subscription = new ScoreProcessedSubscription(receiverConnectionId, userId, scoreId.Value, callback);
+
+            // because the score submission flow happens concurrently with the spectator play finished flow,
+            // it is theoretically possible for the score processing to complete before the spectator hub had a chance to register for notifications.
+            // to cover off this possibility, check the database directly once.
+            if (await db.IsScoreProcessedAsync(scoreId.Value))
+            {
+                using (subscription)
+                    await subscription.InvokeAsync();
+                DogStatsd.Increment($"{statsd_prefix}.messages.delivered-immediately");
+                return;
+            }
+
+            subscriptions.TryAdd(scoreId.Value, subscription);
+            DogStatsd.Gauge($"{statsd_prefix}.subscriptions.total", subscriptions.Count);
+        }
+        catch (Exception ex)
+        {
+            logger.Add($"Failed to register connection {receiverConnectionId} for info about score {userId}:{scoreToken}", LogLevel.Error, ex);
+            DogStatsd.Increment($"{statsd_prefix}.subscriptions.failed");
+        }
+    }
+
+    private void purgeTimedOutSubscriptions()
+    {
+        var scoreIds = subscriptions.Keys.ToArray();
+        int purgedCount = 0;
+
+        foreach (var scoreId in scoreIds)
+        {
+            if (subscriptions.TryGetValue(scoreId, out var subscription) && subscription.TimedOut)
+            {
+                subscription.Dispose();
+
+                if (subscriptions.TryRemove(scoreId, out _))
+                    purgedCount += 1;
+            }
+        }
+
+        if (purgedCount > 0)
+        {
+            DogStatsd.Gauge($"{statsd_prefix}.subscriptions.total", subscriptions.Count);
+            DogStatsd.Increment($"{statsd_prefix}.subscriptions.timed-out", purgedCount);
+        }
+
+        if (!disposed)
+            timer.Start();
+    }
+
+    private bool disposed;
+
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+
+        disposed = true;
+
+        subscriber?.UnsubscribeAll();
+    }
+
+    private record ScoreProcessed(long ScoreId);
+
+    private class ScoreProcessedSubscription : IDisposable
+    {
+        private readonly string receiverConnectionId;
+        private readonly int userId;
+        private readonly long scoreId;
+        private readonly ScoreProcessedAsyncCallback callback;
+
+        private readonly CancellationTokenSource cancellationTokenSource;
+        public bool TimedOut => cancellationTokenSource.IsCancellationRequested;
+
+        public ScoreProcessedSubscription(string receiverConnectionId, int userId, long scoreId, ScoreProcessedAsyncCallback callback)
+        {
+            this.receiverConnectionId = receiverConnectionId;
+            this.userId = userId;
+            this.scoreId = scoreId;
+            this.callback = callback;
+
+            cancellationTokenSource = new CancellationTokenSource(timeout_interval_ms);
+        }
+
+        public Task InvokeAsync() => callback.Invoke(receiverConnectionId, userId, scoreId);
+
+        public void Dispose() => cancellationTokenSource.Dispose();
+    }
+}

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -126,8 +126,7 @@ namespace osu.Server.Spectator.Hubs
                     score.ScoreInfo.Date = DateTimeOffset.UtcNow;
 
                     scoreUploader.Enqueue(scoreToken.Value, score);
-                    await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, CurrentContextUserId, scoreToken.Value,
-                        (connectionId, userId, scoreId) => Clients.Client(connectionId).UserScoreProcessed(userId, scoreId));
+                    await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, CurrentContextUserId, scoreToken.Value);
                 }
                 finally
                 {

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -126,6 +126,8 @@ namespace osu.Server.Spectator.Hubs
                     score.ScoreInfo.Date = DateTimeOffset.UtcNow;
 
                     scoreUploader.Enqueue(scoreToken.Value, score);
+                    await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, CurrentContextUserId, scoreToken.Value,
+                        (connectionId, userId, scoreId) => Clients.Client(connectionId).UserScoreProcessed(userId, scoreId));
                 }
                 finally
                 {

--- a/osu.Server.Spectator/Hubs/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/SpectatorHub.cs
@@ -20,12 +20,19 @@ namespace osu.Server.Spectator.Hubs
 
         private readonly IDatabaseFactory databaseFactory;
         private readonly ScoreUploader scoreUploader;
+        private readonly IScoreProcessedSubscriber scoreProcessedSubscriber;
 
-        public SpectatorHub(IDistributedCache cache, EntityStore<SpectatorClientState> users, IDatabaseFactory databaseFactory, ScoreUploader scoreUploader)
+        public SpectatorHub(
+            IDistributedCache cache,
+            EntityStore<SpectatorClientState> users,
+            IDatabaseFactory databaseFactory,
+            ScoreUploader scoreUploader,
+            IScoreProcessedSubscriber scoreProcessedSubscriber)
             : base(cache, users)
         {
             this.databaseFactory = databaseFactory;
             this.scoreUploader = scoreUploader;
+            this.scoreProcessedSubscriber = scoreProcessedSubscriber;
         }
 
         public async Task BeginPlaySession(long? scoreToken, SpectatorState state)

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.101.34" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.101.44" />
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
@@ -15,13 +15,13 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1202.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="3.24.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1225.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1225.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1225.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1225.1" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1225.1" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
+        <PackageReference Include="Sentry.AspNetCore" Version="3.25.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Continuation of https://github.com/ppy/osu/issues/18877
- [x] Depends on https://github.com/ppy/osu/pull/21738
- [x] Depends on game package bump
- [x] Soft-depends on https://github.com/ppy/osu/pull/21753 (for correct delivery of notifications for aborted scores)

**Note:** This is an RFC. It has been tested _very_ lightly. The happy path seems to work, but I'm not sure about the multitude of sad paths. I'm PRing this now to get it out for comments and see how many WTFs I get, as I'm not confident about almost everything in this diff, so I wouldn't necessarily advise to hurry this one up too much.

Testing procedure, for whoever is inclined:

- Begin with a working full-stack `osu` + `osu-web` + `osu-server-spectator` setup
- In `osu`, check out pull mentioned above
- In `osu-server-spectator`, switch to local checkout
- Set up & launch `osu-queue-score-statistics` so that it can pick up scores placed in redis by `osu-web`
- At this point messages will flow, but there will be no visible effect game-side. To make one happen, the following crude patch can be applied:

<details>
<summary>patch to apply to game</summary>

```diff
diff --git a/osu.Game/OsuGame.cs b/osu.Game/OsuGame.cs
index a0a45e18a8..45c94b73d2 100644
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -990,6 +990,11 @@ protected override void LoadComplete()
 
             // Importantly, this should be run after binding PostNotification to the import handlers so they can present the import after game startup.
             handleStartupImport();
+
+            SpectatorClient.OnUserScoreProcessed += (userId, scoreId) =>
+            {
+                Notifications.Post(new SimpleNotification { Text = $"OnUserScoreProcessed (userId: {userId}, scoreId: {scoreId})" });
+            };
         }
 
         private void handleStartupImport()
diff --git a/osu.Game/OsuGameBase.cs b/osu.Game/OsuGameBase.cs
index 7586dc6407..468bc61696 100644
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -188,7 +188,7 @@ public virtual string Version
 
         private RulesetConfigCache rulesetConfigCache;
 
-        private SpectatorClient spectatorClient;
+        protected SpectatorClient SpectatorClient { get; private set; }
 
         protected MultiplayerClient MultiplayerClient { get; private set; }
 
@@ -298,7 +298,7 @@ private void load(ReadableKeyCombinationProvider keyCombinationProvider)
 
             // TODO: OsuGame or OsuGameBase?
             dependencies.CacheAs(beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage));
-            dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
+            dependencies.CacheAs(SpectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(MultiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
 
@@ -343,7 +343,7 @@ private void load(ReadableKeyCombinationProvider keyCombinationProvider)
             if (API is APIAccess apiAccess)
                 AddInternal(apiAccess);
 
-            AddInternal(spectatorClient);
+            AddInternal(SpectatorClient);
             AddInternal(MultiplayerClient);
             AddInternal(metadataClient);
 
```

</details>

At this point, every completed play should result in a notification being fired. Aborted plays won't always fire the notification. I'm not sure why yet, I'm going to look into that a bit more still tomorrow if this approach doesn't just get dumpstered immediately.

I'll be adding some self-commentary review comments shortly.