### PR TITLE
Update dependencies

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.207.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.301.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.207.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.301.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,22 +6,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.103.4" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.103.21" />
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.207.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.207.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.301.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.301.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.301.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.301.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.301.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="3.27.1" />
+        <PackageReference Include="Sentry.AspNetCore" Version="3.28.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Mostly doing this [because of new mod settings](https://discord.com/channels/188630481301012481/188630652340404224/1081621721087496372).

Of note:

* The key bump here is the game and ruleset package bump.
* The bump above necessitates bumping SignalR packages to 7.0.x because they were bumped to 7.0.x client-side in https://github.com/ppy/osu/pull/22608, and therefore not bumping here causes a transitive dependency conflict.
* `Microsoft.AspNetCore.Authentication.JwtBearer` is intentionally kept back to 6.0.x, because 7.0.x versions of that package are weirdly only compatible with the `net7.0` TFM.
* `Microsoft.NET.Test.Sdk`, `AWSSDK.S3`, and `Sentry.AspNetCore` are bumped just because I might as well.

Seems to work alright in brief local testing (tested multiplayer & spectator, did not test metadata, score upload, user stats delivery).

I was going to go out of my way and bump the project to `net7.0` as well, and [I even have the changes written for it (warning: very untested)](https://github.com/ppy/osu-server-spectator/compare/master...bdach:osu-server-spectator:dotnet-7?expand=1), but as it turns out, [there seems to be a debilitating issue with rider + ubuntu + .NET 7 that prevents me from being able to run anything from within rider and which I cannot seem to fix](https://youtrack.jetbrains.com/issue/RIDER-82361/Rider-cannot-run-apps-and-unable-to-detect-.Net-Core-but-dotnet-command-shows-correct-info), so therefore from a sample size of one I proclaim .NET 7 underbaked until this is sorted out.