### PR TITLE
Switch BouncyCastle to BouncyCastle.NetCore

### DIFF
--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.36" />
-        <PackageReference Include="BouncyCastle" Version="1.8.9" />
+        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.4" />


### PR DESCRIPTION
Currently a deprecated [BouncyCastle](https://www.nuget.org/packages/BouncyCastle) package is being used which only supports .NET Framework, so it can only be used on Windows.

This PR makes a switch to [BouncyCastle.NetCore](https://www.nuget.org/packages/BouncyCastle.NetCore) which makes this project cross-platform.