### PR TITLE
Assign multiplayer star rating

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.621.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.621.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task AddingItemAppendsToQueue()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             long playlistItemId = (await Hub.JoinRoom(ROOM_ID)).Settings.PlaylistItemId;
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -74,7 +74,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task NewItemImmediatelySelectedWhenAllItemsExpired()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -108,8 +108,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task ItemsNotClearedWhenChangingToHostOnlyMode()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -181,7 +181,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserMayOnlyAddLimitedNumberOfItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -204,7 +204,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserMayOnlyAddLimitedNumberOfItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Server.Spectator.Database.Models;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests.Multiplayer
@@ -16,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task RoundRobinOrderingWithGameplay()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });
@@ -69,7 +70,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task RoundRobinOrderingWithManyUsers()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             CreateUser(1, out var contextUser1, out _);
             CreateUser(2, out var contextUser2, out _);
@@ -235,7 +236,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task OrderUpdatedOnRemoval()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayersRoundRobin });

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task GuestsCannotAddItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
             await Hub.JoinRoom(ROOM_ID);
 
             SetUserContext(ContextUser2);
@@ -32,7 +33,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task HostMayAddManyItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
@@ -112,7 +113,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task NewPlaylistNotAddedAfterMatchStartWithMultipleItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             // Add another item in free-for-all mode.
             await Hub.JoinRoom(ROOM_ID);
@@ -172,8 +173,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task ItemLastInQueueWhenChangingToAllPlayersMode()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.AddPlaylistItem(new MultiplayerPlaylistItem

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task AddNonExistentBeatmap()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync((string?)null);
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync((database_beatmap?)null);
 
             await Hub.JoinRoom(ROOM_ID);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
@@ -32,7 +32,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task AddCustomizedBeatmapThrows()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(9999)).ReturnsAsync("correct checksum");
+            Database.Setup(d => d.GetBeatmapAsync(9999)).ReturnsAsync(new database_beatmap { checksum = "correct checksum" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
@@ -73,7 +73,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task RoomStartsWithCorrectQueueingMode()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
             Database.Setup(db => db.GetRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(() => new multiplayer_room
@@ -104,7 +104,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task JoinedRoomContainsAllPlaylistItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             InitialiseRoom(ROOM_ID);
 
@@ -130,7 +130,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task GuestsCanRemoveTheirOwnItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -159,7 +159,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task GuestsCanNotRemoveOtherUsersItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -180,7 +180,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task HostCanRemoveGuestsItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -210,7 +210,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task ExternalItemsCanNotBeRemoved()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -228,7 +228,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task CurrentItemCanNotBeRemovedIfSingle()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -239,7 +239,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task CurrentItemCanBeRemovedIfNotSingle()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -266,7 +266,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task ExpiredItemsCanNotBeRemoved()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -296,8 +296,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task GuestsCanUpdateTheirOwnItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -335,8 +335,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task HostCanUpdateGuestsItems()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -375,8 +375,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task HostCanChangeItemsWhenMaxItemsReached()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -411,7 +411,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task ExpiredItemsCanNotBeChanged()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
@@ -432,8 +432,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task OwnerChangesWhenItemChanges()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
-            Database.Setup(d => d.GetBeatmapChecksumAsync(4444)).ReturnsAsync("4444");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
+            Database.Setup(d => d.GetBeatmapAsync(4444)).ReturnsAsync(new database_beatmap { checksum = "4444" });
 
             await Hub.JoinRoom(ROOM_ID);
             SetUserContext(ContextUser2);
@@ -484,7 +484,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task PlayersUnReadiedWhenCurrentItemIsEdited()
         {
-            Database.Setup(d => d.GetBeatmapChecksumAsync(3333)).ReturnsAsync("3333");
+            Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
 
             await Hub.JoinRoom(ROOM_ID);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -230,10 +230,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                     });
 
             Database.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                    .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (await Database.Object.GetBeatmapAsync(id))?.checksum });
-
-            Database.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                    .ReturnsAsync(new database_beatmap { checksum = "checksum" }); // doesn't matter if bogus, just needs to be non-empty.
+                    .ReturnsAsync(new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = "checksum" }); // doesn't matter if bogus, just needs to be non-empty.
 
             Database.Setup(db => db.GetPlaylistItemAsync(It.IsAny<long>(), It.IsAny<long>()))
                     .Returns<long, long>((roomId, playlistItemId) => Task.FromResult(playlistItems.Single(i => i.id == playlistItemId && i.room_id == roomId).Clone()));

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -230,10 +230,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                     });
 
             Database.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                    .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = await Database.Object.GetBeatmapChecksumAsync(id) });
+                    .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (await Database.Object.GetBeatmapAsync(id))?.checksum });
 
-            Database.Setup(db => db.GetBeatmapChecksumAsync(It.IsAny<int>()))
-                    .ReturnsAsync("checksum"); // doesn't matter if bogus, just needs to be non-empty.
+            Database.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
+                    .ReturnsAsync(new database_beatmap { checksum = "checksum" }); // doesn't matter if bogus, just needs to be non-empty.
 
             Database.Setup(db => db.GetPlaylistItemAsync(It.IsAny<long>(), It.IsAny<long>()))
                     .Returns<long, long>((roomId, playlistItemId) => Task.FromResult(playlistItems.Single(i => i.id == playlistItemId && i.room_id == roomId).Clone()));

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -52,10 +52,10 @@ namespace osu.Server.Spectator.Tests
 
             mockDatabase = new Mock<IDatabaseAccess>();
             mockDatabase.Setup(db => db.GetUsernameAsync(streamer_id)).ReturnsAsync(() => "user");
-            mockDatabase.Setup(db => db.GetBeatmapChecksumAsync(beatmap_id)).ReturnsAsync(() => "d2a97fb2fa4529a5e857fe0466dc1daf");
+            mockDatabase.Setup(db => db.GetBeatmapAsync(beatmap_id)).ReturnsAsync(() => new database_beatmap { checksum = "d2a97fb2fa4529a5e857fe0466dc1daf" });
 
             mockDatabase.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                        .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = await mockDatabase.Object.GetBeatmapChecksumAsync(id) });
+                        .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (await mockDatabase.Object.GetBeatmapAsync(id))?.checksum });
 
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -52,10 +52,9 @@ namespace osu.Server.Spectator.Tests
 
             mockDatabase = new Mock<IDatabaseAccess>();
             mockDatabase.Setup(db => db.GetUsernameAsync(streamer_id)).ReturnsAsync(() => "user");
-            mockDatabase.Setup(db => db.GetBeatmapAsync(beatmap_id)).ReturnsAsync(() => new database_beatmap { checksum = "d2a97fb2fa4529a5e857fe0466dc1daf" });
 
             mockDatabase.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                        .Returns<int>(async id => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (await mockDatabase.Object.GetBeatmapAsync(id))?.checksum });
+                        .Returns<int>(async id => await Task.Run(() => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (id == beatmap_id ? "d2a97fb2fa4529a5e857fe0466dc1daf" : string.Empty) }));
 
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -54,7 +54,11 @@ namespace osu.Server.Spectator.Tests
             mockDatabase.Setup(db => db.GetUsernameAsync(streamer_id)).ReturnsAsync(() => "user");
 
             mockDatabase.Setup(db => db.GetBeatmapAsync(It.IsAny<int>()))
-                        .Returns<int>(async id => await Task.Run(() => new database_beatmap { approved = BeatmapOnlineStatus.Ranked, checksum = (id == beatmap_id ? "d2a97fb2fa4529a5e857fe0466dc1daf" : string.Empty) }));
+                        .ReturnsAsync((int id) => new database_beatmap
+                        {
+                            approved = BeatmapOnlineStatus.Ranked,
+                            checksum = (id == beatmap_id ? "d2a97fb2fa4529a5e857fe0466dc1daf" : string.Empty)
+                        });
 
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -67,11 +67,6 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task<string?> GetBeatmapChecksumAsync(int beatmapId)
-        {
-            return (await GetBeatmapAsync(beatmapId))?.checksum;
-        }
-
         public async Task MarkRoomActiveAsync(MultiplayerRoom room)
         {
             var connection = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -40,11 +40,6 @@ namespace osu.Server.Spectator.Database
         Task<database_beatmap?> GetBeatmapAsync(int beatmapId);
 
         /// <summary>
-        /// Returns the checksum of the beatmap with the given <paramref name="beatmapId"/>.
-        /// </summary>
-        Task<string?> GetBeatmapChecksumAsync(int beatmapId);
-
-        /// <summary>
         /// Marks the given <paramref name="room"/> as active and accepting new players.
         /// </summary>
         Task MarkRoomActiveAsync(MultiplayerRoom room);

--- a/osu.Server.Spectator/Database/Models/database_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/database_beatmap.cs
@@ -13,5 +13,6 @@ namespace osu.Server.Spectator.Database.Models
     {
         public string? checksum { get; set; }
         public BeatmapOnlineStatus approved { get; set; }
+        public double difficultyrating { get; set; }
     }
 }

--- a/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_playlist_item.cs
@@ -65,19 +65,25 @@ namespace osu.Server.Spectator.Database.Models
             played_at = item.PlayedAt;
         }
 
-        public async Task<MultiplayerPlaylistItem> ToMultiplayerPlaylistItem(IDatabaseAccess db) => new MultiplayerPlaylistItem
+        public async Task<MultiplayerPlaylistItem> ToMultiplayerPlaylistItem(IDatabaseAccess db)
         {
-            ID = id,
-            OwnerID = owner_id,
-            BeatmapID = beatmap_id,
-            BeatmapChecksum = (await db.GetBeatmapChecksumAsync(beatmap_id)) ?? string.Empty,
-            RulesetID = ruleset_id,
-            RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(required_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
-            AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
-            Expired = expired,
-            PlaylistOrder = playlist_order ?? 0,
-            PlayedAt = played_at,
-        };
+            var beatmap = await db.GetBeatmapAsync(beatmap_id);
+            var playlistItem = new MultiplayerPlaylistItem
+            {
+                ID = id,
+                OwnerID = owner_id,
+                BeatmapID = beatmap_id,
+                BeatmapChecksum = beatmap?.checksum ?? string.Empty,
+                RulesetID = ruleset_id,
+                RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(required_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
+                AllowedMods = JsonConvert.DeserializeObject<APIMod[]>(allowed_mods ?? string.Empty) ?? Array.Empty<APIMod>(),
+                Expired = expired,
+                PlaylistOrder = playlist_order ?? 0,
+                PlayedAt = played_at,
+                StarRating = beatmap?.difficultyrating ?? 0.0
+            };
+            return playlistItem;
+        }
 
         public multiplayer_playlist_item Clone() => (multiplayer_playlist_item)MemberwiseClone();
     }

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -122,12 +122,12 @@ namespace osu.Server.Spectator.Hubs
 
             using (var db = dbFactory.GetInstance())
             {
-                string? beatmapChecksum = await db.GetBeatmapChecksumAsync(item.BeatmapID);
+                var beatmap = await db.GetBeatmapAsync(item.BeatmapID);
 
-                if (beatmapChecksum == null)
+                if (beatmap == null)
                     throw new InvalidStateException("Attempted to add a beatmap which does not exist online.");
 
-                if (item.BeatmapChecksum != beatmapChecksum)
+                if (item.BeatmapChecksum != beatmap.checksum)
                     throw new InvalidStateException("Attempted to add a beatmap which has been modified.");
 
                 if (item.RulesetID < 0 || item.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
@@ -135,6 +135,7 @@ namespace osu.Server.Spectator.Hubs
 
                 item.EnsureModsValid();
                 item.OwnerID = user.UserID;
+                item.StarRating = beatmap.difficultyrating;
 
                 await addItem(db, item);
                 await updateCurrentItem();
@@ -147,12 +148,12 @@ namespace osu.Server.Spectator.Hubs
 
             using (var db = dbFactory.GetInstance())
             {
-                string? beatmapChecksum = await db.GetBeatmapChecksumAsync(item.BeatmapID);
+                var beatmap = await db.GetBeatmapAsync(item.BeatmapID);
 
-                if (beatmapChecksum == null)
+                if (beatmap == null)
                     throw new InvalidStateException("Attempted to add a beatmap which does not exist online.");
 
-                if (item.BeatmapChecksum != beatmapChecksum)
+                if (item.BeatmapChecksum != beatmap.checksum)
                     throw new InvalidStateException("Attempted to add a beatmap which has been modified.");
 
                 if (item.RulesetID < 0 || item.RulesetID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
@@ -160,6 +161,7 @@ namespace osu.Server.Spectator.Hubs
 
                 item.EnsureModsValid();
                 item.OwnerID = user.UserID;
+                item.StarRating = beatmap.difficultyrating;
 
                 var existingItem = room.Playlist.SingleOrDefault(i => i.ID == item.ID);
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.605.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.605.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.605.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.621.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.621.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
     </ItemGroup>


### PR DESCRIPTION
- [x] Depends on ppy/osu/pull/23551 & a game package with said PR
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/174 by necessity

This retrieves beatmap's `difficultyrating` from the db and uses it to populate `MultiplayerPlaylistItem` which is then used by the client to show latest information about room's star rating .