### PR TITLE
Force all non-spectators to play even when not explicitly "Ready"

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownStartsWhenMatchStarts()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             await Hub.StartMatch();
 
@@ -29,7 +29,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownStopsWhenAllPlayersAbort()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             await Hub.StartMatch();
             await Hub.AbortGameplay();
@@ -42,7 +42,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task LoadingUsersAbortWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
 
             await skipToEndOfCountdown();
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task LoadedUsersStartWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
 
@@ -87,11 +87,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task ReadyAndLoadedUsersStartWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             // User 1 becomes ready for gameplay.
             SetUserContext(ContextUser);
@@ -123,7 +123,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownCannotBeStopped()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
 
             int countdownId;

--- a/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/AutomaticForceStartTest.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownStartsWhenMatchStarts()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             await Hub.StartMatch();
 
@@ -29,7 +29,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownStopsWhenAllPlayersAbort()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             await Hub.StartMatch();
             await Hub.AbortGameplay();
@@ -42,7 +42,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task LoadingUsersAbortWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             await skipToEndOfCountdown();
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task LoadedUsersStartWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
 
@@ -87,11 +87,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task ReadyAndLoadedUsersStartWhenCountdownEnds()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             // User 1 becomes ready for gameplay.
             SetUserContext(ContextUser);
@@ -123,7 +123,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CountdownCannotBeStopped()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             int countdownId;

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CanTransitionFromReadyToSpectating()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.ChangeState(MultiplayerUserState.Spectating);
         }
 
@@ -30,7 +30,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task SpectatingUserStateDoesNotChange()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
@@ -60,7 +60,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Hub.StartMatch();
@@ -71,7 +71,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task SpectatingUserReceivesLoadRequestedAfterGameplayStarted()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             Receiver.Verify(c => c.LoadRequested(), Times.Once);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task CanTransitionFromReadyToSpectating()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeState(MultiplayerUserState.Spectating);
         }
 
@@ -30,7 +30,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task SpectatingUserStateDoesNotChange()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
@@ -60,7 +60,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Hub.StartMatch();
@@ -71,7 +71,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task SpectatingUserReceivesLoadRequestedAfterGameplayStarted()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             Receiver.Verify(c => c.LoadRequested(), Times.Once);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchSpectatingTests.cs
@@ -39,7 +39,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
 
             await Hub.StartMatch();
-            GameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+            Receiver.Verify(c => c.LoadRequested(), Times.Once);
             Clients.Verify(clients => clients.Client(ContextUser2.Object.ConnectionId).UserStateChanged(USER_ID_2, MultiplayerUserState.WaitingForLoad), Times.Never);
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser);
             await Hub.StartMatch();
-            GameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+            Receiver.Verify(c => c.LoadRequested(), Times.Once);
         }
 
         [Fact]
@@ -73,8 +73,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            Receiver.Verify(c => c.LoadRequested(), Times.Never);
-            GameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+            Receiver.Verify(c => c.LoadRequested(), Times.Once);
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
@@ -82,8 +81,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Caller.Verify(c => c.LoadRequested(), Times.Once);
 
             // Ensure no other clients received LoadRequested().
-            Receiver.Verify(c => c.LoadRequested(), Times.Never);
-            GameplayReceiver.Verify(c => c.LoadRequested(), Times.Once);
+            Receiver.Verify(c => c.LoadRequested(), Times.Once);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -227,7 +227,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
 
             await MarkCurrentUserReadyAndAvailable();
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser, ContextUser2);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -246,7 +245,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 SetUserContext(ContextUser);
 
                 await MarkCurrentUserReadyAndAvailable();
-                await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
                 await Hub.StartMatch();
                 await LoadAndFinishGameplay(ContextUser);
                 await Hub.ChangeState(MultiplayerUserState.Idle);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -79,7 +79,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -126,7 +126,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "4444"
             });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -150,7 +150,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -226,7 +226,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser, ContextUser2);
@@ -245,7 +245,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 SetUserContext(ContextUser);
 
-                await MarkCurrentUserMarkReadyAndAvailable();
+                await MarkCurrentUserReadyAndAvailable();
                 await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
                 await Hub.StartMatch();
                 await LoadAndFinishGameplay(ContextUser);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -79,7 +79,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -126,7 +126,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "4444"
             });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -150,7 +150,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -222,9 +222,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // User is not allowed to add more items.
             await Assert.ThrowsAsync<InvalidStateException>(addItem);
 
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
+
             SetUserContext(ContextUser);
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser, ContextUser2);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -242,7 +245,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 SetUserContext(ContextUser);
 
-                await Hub.ChangeState(MultiplayerUserState.Ready);
+                await MarkCurrentUserMarkReadyAndAvailable();
+                await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
                 await Hub.StartMatch();
                 await LoadAndFinishGameplay(ContextUser);
                 await Hub.ChangeState(MultiplayerUserState.Idle);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersQueueTests.cs
@@ -201,7 +201,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await LoadAndFinishGameplay(ContextUser);
+            await LoadAndFinishGameplay(ContextUser, ContextUser2);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             // The first user should now be able to add another item.

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -291,9 +291,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Run gameplay.
             SetUserContext(user1Ctx);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             SetUserContext(user2Ctx);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             SetUserContext(user1Ctx);
 
             await Hub.StartMatch();
@@ -323,11 +323,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         private async Task runGameplay()
         {
             SetUserContext(ContextUser2);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
 
             SetUserContext(ContextUser);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -292,16 +292,19 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(user1Ctx);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
-            await LoadAndFinishGameplay(user1Ctx);
-            await Hub.ChangeState(MultiplayerUserState.Idle);
+            await LoadAndFinishGameplay(user1Ctx, user2Ctx);
+			await Hub.ChangeState(MultiplayerUserState.Idle);
+			SetUserContext(user2Ctx);
+			await Hub.ChangeState(MultiplayerUserState.Idle);
 
-            // Queue: [ 4, 2, 3 ]
-            // List: [ 1, 2, 3, 4 ]
+			// Queue: [ 4, 2, 3 ]
+			// List: [ 1, 2, 3, 4 ]
 
-            // Now we'll remove item 2.
-            // Notice that while item 4 is at the front of the queue, it is also at the _end_ of the playlist.
-            // Item 3 will have its playlist order updated, which may crash if the current item isn't updated to not reference beyond the end of the list.
-            await Hub.RemovePlaylistItem(2);
+			// Now we'll remove item 2.
+			// Notice that while item 4 is at the front of the queue, it is also at the _end_ of the playlist.
+			// Item 3 will have its playlist order updated, which may crash if the current item isn't updated to not reference beyond the end of the list.
+			SetUserContext(user1Ctx);
+			await Hub.RemovePlaylistItem(2);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -293,18 +293,18 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
             await LoadAndFinishGameplay(user1Ctx, user2Ctx);
-			await Hub.ChangeState(MultiplayerUserState.Idle);
-			SetUserContext(user2Ctx);
-			await Hub.ChangeState(MultiplayerUserState.Idle);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
+            SetUserContext(user2Ctx);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
 
-			// Queue: [ 4, 2, 3 ]
-			// List: [ 1, 2, 3, 4 ]
+            // Queue: [ 4, 2, 3 ]
+            // List: [ 1, 2, 3, 4 ]
 
-			// Now we'll remove item 2.
-			// Notice that while item 4 is at the front of the queue, it is also at the _end_ of the playlist.
-			// Item 3 will have its playlist order updated, which may crash if the current item isn't updated to not reference beyond the end of the list.
-			SetUserContext(user1Ctx);
-			await Hub.RemovePlaylistItem(2);
+            // Now we'll remove item 2.
+            // Notice that while item 4 is at the front of the queue, it is also at the _end_ of the playlist.
+            // Item 3 will have its playlist order updated, which may crash if the current item isn't updated to not reference beyond the end of the list.
+            SetUserContext(user1Ctx);
+            await Hub.RemovePlaylistItem(2);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -290,7 +290,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Run gameplay.
             SetUserContext(user1Ctx);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            SetUserContext(user2Ctx);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            SetUserContext(user1Ctx);
+
             await Hub.StartMatch();
             await LoadAndFinishGameplay(user1Ctx, user2Ctx);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -318,10 +322,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         private async Task runGameplay()
         {
             SetUserContext(ContextUser2);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
 
             SetUserContext(ContextUser);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
 
             await LoadAndFinishGameplay(ContextUser, ContextUser2);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerAllPlayersRoundRobinQueueTests.cs
@@ -324,11 +324,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             SetUserContext(ContextUser2);
             await MarkCurrentUserReadyAndAvailable();
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
 
             SetUserContext(ContextUser);
             await MarkCurrentUserReadyAndAvailable();
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
 
             await LoadAndFinishGameplay(ContextUser, ContextUser2);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             // some users enter a ready state.
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -117,9 +117,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // both users become ready.
             SetUserContext(ContextUser);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             SetUserContext(ContextUser2);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -212,9 +212,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             SetUserContext(ContextUser);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
             SetUserContext(ContextUser2);
@@ -228,7 +228,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Restart gameplay with just host being ready.
             SetUserContext(ContextUser);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
 
             // Both Host and second user receive it twice.

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -39,7 +39,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.StartMatch();
 
             // server requests the all users start loading.
-            GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+            Receiver.Verify(r => r.LoadRequested(), Times.Once);
             Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.WaitingForLoad), Times.Once);
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
@@ -132,7 +132,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.StartMatch();
 
             // server requests the all users start loading.
-            GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+            Receiver.Verify(r => r.LoadRequested(), Times.Once);
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -206,7 +206,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task SecondUserDoesNotReceiveLoadRequestWhenMatchRestartedAndNotReady()
+        public async Task SecondUserDoesReceiveLoadRequestWhenMatchRestartedAndNotReady()
         {
             // Start the match initially with both users entering gameplay.
             await Hub.JoinRoom(ROOM_ID);
@@ -226,14 +226,14 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser);
             await Hub.AbortGameplay();
 
-            // Restart gameplay for the host user _only_.
+            // Restart gameplay with just host being ready.
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();
 
-            // Host receives load requested twice total, second user only receives it once.
+            // Both Host and second user receive it twice.
             UserReceiver.Verify(r => r.LoadRequested(), Times.Exactly(2));
-            User2Receiver.Verify(r => r.LoadRequested(), Times.Once);
+            User2Receiver.Verify(r => r.LoadRequested(), Times.Exactly(2));
         }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             // some users enter a ready state.
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -117,9 +117,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // both users become ready.
             SetUserContext(ContextUser);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             SetUserContext(ContextUser2);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -212,9 +212,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             SetUserContext(ContextUser);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
             SetUserContext(ContextUser2);
@@ -228,7 +228,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Restart gameplay with just host being ready.
             SetUserContext(ContextUser);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             // Both Host and second user receive it twice.

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -83,7 +83,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // And a second time...
             await Hub.ChangeState(MultiplayerUserState.Idle);
             await MarkCurrentUserReadyAndAvailable();
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -150,7 +149,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             // Play the second item in host-only mode.
             await Hub.ChangeState(MultiplayerUserState.Idle);
             await MarkCurrentUserReadyAndAvailable();
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -52,7 +52,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -81,7 +81,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // And a second time...
             await Hub.ChangeState(MultiplayerUserState.Idle);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -125,7 +126,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Play the first item in host-only mode.
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -147,7 +148,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Play the second item in host-only mode.
             await Hub.ChangeState(MultiplayerUserState.Idle);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -182,7 +184,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerHostOnlyQueueTests.cs
@@ -53,7 +53,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -82,7 +82,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // And a second time...
             await Hub.ChangeState(MultiplayerUserState.Idle);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
@@ -127,7 +127,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Play the first item in host-only mode.
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.HostOnly });
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
 
@@ -149,7 +149,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             // Play the second item in host-only mode.
             await Hub.ChangeState(MultiplayerUserState.Idle);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
@@ -185,7 +185,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerMatchStartCountdownTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerMatchStartCountdownTest.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.Null(room.FindCountdownOfType<MatchStartCountdown>());
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+                Receiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
 
@@ -85,7 +85,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 MultiplayerCountdown? countdown = room.FindCountdownOfType<MatchStartCountdown>();
                 Assert.NotNull(countdown);
                 Assert.InRange(countdown.TimeRemaining.TotalSeconds, 30, 60);
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Never);
+                Receiver.Verify(r => r.LoadRequested(), Times.Never);
             }
 
             await skipToEndOfCountdown();
@@ -96,7 +96,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.Null(room.FindCountdownOfType<MatchStartCountdown>());
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+                Receiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
 
@@ -122,7 +122,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 Assert.Null(room.FindCountdownOfType<MatchStartCountdown>());
                 Receiver.Verify(r => r.MatchEvent(It.IsAny<CountdownStoppedEvent>()), Times.Exactly(1));
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Never);
+                Receiver.Verify(r => r.LoadRequested(), Times.Never);
             }
         }
 
@@ -173,7 +173,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 Receiver.Verify(r => r.MatchEvent(It.IsAny<CountdownStartedEvent>()), Times.Exactly(2));
                 Receiver.Verify(r => r.MatchEvent(It.Is<CountdownStoppedEvent>(e => e.ID == firstCountdown.ID)), Times.Once);
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Never);
+                Receiver.Verify(r => r.LoadRequested(), Times.Never);
             }
 
             await skipToEndOfCountdown();
@@ -185,7 +185,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 Assert.Null(room.FindCountdownOfType<MatchStartCountdown>());
                 Receiver.Verify(r => r.MatchEvent(It.Is<CountdownStoppedEvent>(e => e.ID == secondCountdown.ID)), Times.Once);
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+                Receiver.Verify(r => r.LoadRequested(), Times.Once);
             }
         }
 
@@ -257,7 +257,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotNull(usage.Item!.FindCountdownOfType<MatchStartCountdown>());
 
             await skipToEndOfCountdown();
-            GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+            Receiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
         [Fact(Timeout = test_timeout)]
@@ -274,7 +274,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotNull(usage.Item!.FindCountdownOfType<MatchStartCountdown>());
 
             await skipToEndOfCountdown();
-            GameplayReceiver.Verify(r => r.LoadRequested(), Times.Once);
+            Receiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
         [Fact(Timeout = test_timeout)]
@@ -310,7 +310,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Debug.Assert(room != null);
 
                 Assert.Single(room.Playlist.Where(p => p.Expired));
-                GameplayReceiver.Verify(r => r.LoadRequested(), Times.Never);
+                Receiver.Verify(r => r.LoadRequested(), Times.Never);
             }
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -437,7 +437,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -283,7 +283,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -416,7 +416,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -473,12 +473,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
-            await Assert.ThrowsAsync<InvalidStateException>(() => Hub.ChangeState(MultiplayerUserState.Ready));
+            await Assert.ThrowsAsync<InvalidStateException>(MarkCurrentUserMarkReadyAndAvailable);
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await MarkCurrentUserMarkReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Hub.EditPlaylistItem(new MultiplayerPlaylistItem

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -283,7 +283,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "3333"
             });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -416,7 +416,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
@@ -473,12 +473,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers });
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await LoadAndFinishGameplay(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
-            await Assert.ThrowsAsync<InvalidStateException>(MarkCurrentUserMarkReadyAndAvailable);
+            await Assert.ThrowsAsync<InvalidStateException>(MarkCurrentUserReadyAndAvailable);
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Hub.EditPlaylistItem(new MultiplayerPlaylistItem

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
@@ -183,6 +184,12 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// </summary>
         /// <param name="context">The user context.</param>
         protected void SetUserContext(Mock<HubCallerContext> context) => Hub.Context = context.Object;
+
+        protected async Task MarkCurrentUserMarkReadyAndAvailable()
+        {
+            await Hub.ChangeState(MultiplayerUserState.Ready);
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
+        }
 
         protected async Task LoadAndFinishGameplay(params Mock<HubCallerContext>[] users)
         {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -155,30 +155,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         /// <summary>
-        /// Verifies that the given user context was either added or not added to the gameplay group.
-        /// </summary>
-        /// <param name="context">The user context.</param>
-        /// <param name="roomId">The room ID.</param>
-        /// <param name="addedTimes">Number of times that the user context was supposed to be added.</param>
-        protected void VerifyAddedToGameplayGroup(Mock<HubCallerContext> context, long roomId, int addedTimes = 1)
-            => Groups.Verify(groups => groups.AddToGroupAsync(
-                context.Object.ConnectionId,
-                MultiplayerHub.GetGroupId(roomId),
-                It.IsAny<CancellationToken>()), Times.Exactly(addedTimes));
-
-        /// <summary>
-        /// Verifies that the given user context was either removed or not removed from the gameplay group.
-        /// </summary>
-        /// <param name="context">The user context.</param>
-        /// <param name="roomId">The room ID.</param>
-        /// <param name="removedTimes">Number of times that the user context was supposed to be removed.</param>
-        protected void VerifyRemovedFromGameplayGroup(Mock<HubCallerContext> context, long roomId, int removedTimes = 1)
-            => Groups.Verify(groups => groups.RemoveFromGroupAsync(
-                context.Object.ConnectionId,
-                MultiplayerHub.GetGroupId(roomId),
-                It.IsAny<CancellationToken>()), Times.Exactly(removedTimes));
-
-        /// <summary>
         /// Sets the multiplayer hub's current user context.
         /// </summary>
         /// <param name="context">The user context.</param>

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -120,7 +120,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                   });
 
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID))).Returns(Receiver.Object);
-            Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID))).Returns(Receiver.Object);
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID_2))).Returns(Receiver2.Object);
             Clients.Setup(client => client.Caller).Returns(Caller.Object);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -160,7 +160,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// <param name="context">The user context.</param>
         protected void SetUserContext(Mock<HubCallerContext> context) => Hub.Context = context.Object;
 
-        protected async Task MarkCurrentUserMarkReadyAndAvailable()
+        protected async Task MarkCurrentUserReadyAndAvailable()
         {
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -166,11 +166,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// <param name="context">The user context.</param>
         /// <param name="roomId">The room ID.</param>
         /// <param name="wasAdded">Whether to verify that the user context was added, otherwise verify not.</param>
-        protected void VerifyAddedToGameplayGroup(Mock<HubCallerContext> context, long roomId, bool wasAdded = true)
+        protected void VerifyAddedToGameplayGroup(Mock<HubCallerContext> context, long roomId, int addedTimes = 1)
             => Groups.Verify(groups => groups.AddToGroupAsync(
                 context.Object.ConnectionId,
                 MultiplayerHub.GetGroupId(roomId, true),
-                It.IsAny<CancellationToken>()), wasAdded ? Times.Once : Times.Never);
+                It.IsAny<CancellationToken>()), Times.Exactly(addedTimes));
 
         /// <summary>
         /// Verifies that the given user context was either removed or not removed from the gameplay group.
@@ -178,11 +178,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// <param name="context">The user context.</param>
         /// <param name="roomId">The room ID.</param>
         /// <param name="wasRemoved">Whether to verify that the user context was removed, otherwise verify not.</param>
-        protected void VerifyRemovedFromGameplayGroup(Mock<HubCallerContext> context, long roomId, bool wasRemoved = true)
+        protected void VerifyRemovedFromGameplayGroup(Mock<HubCallerContext> context, long roomId, int removedTimes = 1)
             => Groups.Verify(groups => groups.RemoveFromGroupAsync(
                 context.Object.ConnectionId,
                 MultiplayerHub.GetGroupId(roomId, true),
-                It.IsAny<CancellationToken>()), wasRemoved ? Times.Once : Times.Never);
+                It.IsAny<CancellationToken>()), Times.Exactly(removedTimes));
 
         /// <summary>
         /// Sets the multiplayer hub's current user context.

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -165,7 +165,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// </summary>
         /// <param name="context">The user context.</param>
         /// <param name="roomId">The room ID.</param>
-        /// <param name="wasAdded">Whether to verify that the user context was added, otherwise verify not.</param>
+        /// <param name="addedTimes">Number of times that the user context was supposed to be added.</param>
         protected void VerifyAddedToGameplayGroup(Mock<HubCallerContext> context, long roomId, int addedTimes = 1)
             => Groups.Verify(groups => groups.AddToGroupAsync(
                 context.Object.ConnectionId,
@@ -177,7 +177,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         /// </summary>
         /// <param name="context">The user context.</param>
         /// <param name="roomId">The room ID.</param>
-        /// <param name="wasRemoved">Whether to verify that the user context was removed, otherwise verify not.</param>
+        /// <param name="removedTimes">Number of times that the user context was supposed to be removed.</param>
         protected void VerifyRemovedFromGameplayGroup(Mock<HubCallerContext> context, long roomId, int removedTimes = 1)
             => Groups.Verify(groups => groups.RemoveFromGroupAsync(
                 context.Object.ConnectionId,

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.StartMatch();
 
             UserReceiver.Verify(r => r.LoadRequested(), Times.Once);
-            User2Receiver.Verify(r => r.LoadRequested(), Times.Never);
+            User2Receiver.Verify(r => r.LoadRequested(), Times.Once);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
@@ -72,7 +72,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
             }
 
-            // Check that users have been removed from groups by attempting to start gameplay, and making sure the second user does not start while in an idle state.
+            // Check that users have been removed from groups by attempting to start gameplay, and making sure the second user also starts while in an idle state.
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomSettingsTests.cs
@@ -72,7 +72,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.All(room.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
             }
 
-            // Check that users have been removed from groups by attempting to start gameplay, and making sure the second user also starts while in an idle state.
+            // Check that both users start gameplay - the second user also starts despite being in an idle state.
             SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
             await Hub.StartMatch();

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -122,21 +122,21 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotNull(room.Item);
 
                 Assert.Equal(MultiplayerRoomState.WaitingForLoad, room.Item.State);
-				Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.WaitingForLoad).Count());
-			}
+                Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.WaitingForLoad).Count());
+            }
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
             await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
-			SetUserContext(ContextUser2);
-			await Hub.ChangeState(MultiplayerUserState.Loaded);
-			await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
+            SetUserContext(ContextUser2);
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
-			using (var room = await Rooms.GetForUse(ROOM_ID))
+            using (var room = await Rooms.GetForUse(ROOM_ID))
             {
                 Assert.NotNull(room.Item);
-				Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.Playing).Count());
-			}
+                Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.Playing).Count());
+            }
         }
 
         [Fact]
@@ -233,20 +233,20 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Loaded);
             await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
-			SetUserContext(ContextUser2);
-			await Hub.ChangeState(MultiplayerUserState.Loaded);
-			await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
+            SetUserContext(ContextUser2);
+            await Hub.ChangeState(MultiplayerUserState.Loaded);
+            await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
-			VerifyAddedToGameplayGroup(ContextUser, ROOM_ID);
+            VerifyAddedToGameplayGroup(ContextUser, ROOM_ID);
             VerifyAddedToGameplayGroup(ContextUser2, ROOM_ID);
 
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-			SetUserContext(ContextUser);
+            SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
 
-			VerifyRemovedFromGameplayGroup(ContextUser, ROOM_ID);
-			VerifyRemovedFromGameplayGroup(ContextUser2, ROOM_ID);
-		}
+            VerifyRemovedFromGameplayGroup(ContextUser, ROOM_ID);
+            VerifyRemovedFromGameplayGroup(ContextUser2, ROOM_ID);
+        }
 
         [Fact]
         public async Task IdleUsersDoGetLoadRequest()
@@ -405,7 +405,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.Idle);
             await Hub.ChangeState(MultiplayerUserState.Ready);
 
-			SetUserContext(ContextUser);
+            SetUserContext(ContextUser);
             await Hub.StartMatch();
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
@@ -416,15 +416,15 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.ChangeState(MultiplayerUserState.ReadyForGameplay);
 
             await Hub.ChangeState(MultiplayerUserState.FinishedPlay);
-			SetUserContext(ContextUser);
+            SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Idle);
 
             VerifyRemovedFromGameplayGroup(ContextUser, ROOM_ID, 0);
             VerifyRemovedFromGameplayGroup(ContextUser2, ROOM_ID);
             
-			await Hub.ChangeState(MultiplayerUserState.Idle);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
             SetUserContext(ContextUser2);
-			await Hub.ChangeState(MultiplayerUserState.Idle);
+            await Hub.ChangeState(MultiplayerUserState.Idle);
 
             VerifyAddedToGameplayGroup(ContextUser, ROOM_ID, 1);
             VerifyAddedToGameplayGroup(ContextUser2, ROOM_ID, 2);
@@ -434,7 +434,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.ChangeState(MultiplayerUserState.Spectating);
 
-			SetUserContext(ContextUser);
+            SetUserContext(ContextUser);
             await Hub.ChangeState(MultiplayerUserState.Ready);
 
             await Hub.StartMatch();

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -122,7 +122,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotNull(room.Item);
 
                 Assert.Equal(MultiplayerRoomState.WaitingForLoad, room.Item.State);
-                Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.WaitingForLoad).Count());
+                Assert.Equal(2, room.Item.Users.Count(u => u.State == MultiplayerUserState.WaitingForLoad));
             }
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
@@ -135,7 +135,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
                 Assert.NotNull(room.Item);
-                Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.Playing).Count());
+                Assert.Equal(2, room.Item.Users.Count(u => u.State == MultiplayerUserState.Playing));
             }
         }
 
@@ -214,7 +214,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
                 Assert.NotNull(room.Item);
-                Assert.Equal(2, room.Item.Users.Where(u => u.State == MultiplayerUserState.Results).Count());
+                Assert.Equal(2, room.Item.Users.Count(u => u.State == MultiplayerUserState.Results));
             }
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             Receiver.Verify(r => r.UserStateChanged(USER_ID, MultiplayerUserState.Ready), Times.Once);
         }
 
@@ -46,7 +46,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.StartMatch());
@@ -57,7 +57,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -84,10 +84,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
@@ -115,7 +115,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task UsersWithoutBeatmapWillNotEnterGameplay(DownloadState? state)
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             // user 2 is not ready and doesn't have the beatmap.
             SetUserContext(ContextUser2);
@@ -151,7 +151,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task BothReadyAndIdleUsersTransitionToPlay()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             // user 2 is not ready but has the beatmap. should join gameplay.
             SetUserContext(ContextUser2);
@@ -187,11 +187,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task UserDisconnectsDuringGameplayUpdatesRoomState()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser);
             await Hub.StartMatch();
@@ -242,7 +242,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task OnlyFinishedUsersTransitionToResults()
         {
             await Hub.JoinRoom(ROOM_ID);
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             SetUserContext(ContextUser2);
             await Hub.JoinRoom(ROOM_ID);
@@ -278,7 +278,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             // one user enters a ready state.
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
 
             using (var room = await Rooms.GetForUse(ROOM_ID))
             {
@@ -306,7 +306,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             await Hub.JoinRoom(ROOM_ID);
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
 
             // Test during WaitingForLoad state.
@@ -346,7 +346,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
 
             // Test during WaitingForLoad state.
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.AbortGameplay();
 
@@ -358,7 +358,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             }
 
             // Test during Playing state.
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Hub.StartMatch();
             await Hub.ChangeState(MultiplayerUserState.Loaded);
             await Hub.AbortGameplay();
@@ -377,7 +377,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             await Hub.JoinRoom(ROOM_ID);
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AbortGameplay());
 
-            await MarkCurrentUserMarkReadyAndAvailable();
+            await MarkCurrentUserReadyAndAvailable();
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AbortGameplay());
         }
 

--- a/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/UserStateManagementTests.cs
@@ -106,7 +106,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task OnlyReadiedUpUsersTransitionToPlay()
+        public async Task BothReadiedUpAndIdleUsersTransitionToPlay()
         {
             await Hub.JoinRoom(ROOM_ID);
             await Hub.ChangeState(MultiplayerUserState.Ready);
@@ -124,7 +124,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.Equal(MultiplayerRoomState.WaitingForLoad, room.Item.State);
 
                 Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.WaitingForLoad);
-                Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.Idle);
+                Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.WaitingForLoad);
             }
 
             await Hub.ChangeState(MultiplayerUserState.Loaded);
@@ -134,7 +134,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             {
                 Assert.NotNull(room.Item);
                 Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.Playing);
-                Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.Idle);
+                Assert.Single(room.Item.Users, u => u.State == MultiplayerUserState.Playing);
             }
         }
 

--- a/osu.Server.Spectator/Hubs/IMultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/IMultiplayerHubContext.cs
@@ -61,7 +61,8 @@ namespace osu.Server.Spectator.Hubs
         /// </remarks>
         /// <param name="room">The room to send the event to.</param>
         /// <param name="item">The changed item.</param>
-        Task NotifyPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item);
+        /// <param name="beatmapChanged">Whether the beatmap changed.</param>
+        Task NotifyPlaylistItemChanged(ServerMultiplayerRoom room, MultiplayerPlaylistItem item, bool beatmapChanged);
 
         /// <summary>
         /// Notifies users in a room that the room's settings have changed.
@@ -70,7 +71,8 @@ namespace osu.Server.Spectator.Hubs
         /// Adjusts user mod selections to ensure mod validity, unreadies all users, and stops the current countdown.
         /// </remarks>
         /// <param name="room">The room to send the event to.</param>
-        Task NotifySettingsChanged(ServerMultiplayerRoom room);
+        /// <param name="playlistItemChanged">Whether the current playlist item changed.</param>
+        Task NotifySettingsChanged(ServerMultiplayerRoom room, bool playlistItemChanged);
 
         /// <summary>
         /// Retrieves a <see cref="ServerMultiplayerRoom"/> usage.
@@ -85,7 +87,8 @@ namespace osu.Server.Spectator.Hubs
         /// Stops the current countdown.
         /// </remarks>
         /// <param name="room">The room to unready users in.</param>
-        Task UnreadyAllUsers(ServerMultiplayerRoom room);
+        /// <param name="resetBeatmapAvailability">Whether to reset availabilities (ie. if the beatmap changed).</param>
+        Task UnreadyAllUsers(ServerMultiplayerRoom room, bool resetBeatmapAvailability);
 
         /// <summary>
         /// Adjusts user mod selections to ensure they're valid for the current playlist item.
@@ -109,6 +112,14 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="user">The user.</param>
         /// <param name="state">The new state.</param>
         Task ChangeAndBroadcastUserState(ServerMultiplayerRoom room, MultiplayerRoomUser user, MultiplayerUserState state);
+
+        /// <summary>
+        /// Changes a user's beatmap availability for the current playlist item.
+        /// </summary>
+        /// <param name="room">The room containing the user.</param>
+        /// <param name="user">The user.</param>
+        /// <param name="availability">The new availability.</param>
+        Task ChangeAndBroadcastUserBeatmapAvailability(ServerMultiplayerRoom room, MultiplayerRoomUser user, BeatmapAvailability availability);
 
         /// <summary>
         /// Changes a room's state.

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -108,9 +108,12 @@ namespace osu.Server.Spectator.Hubs
                         room.UpdateForRetrieval();
 
                         await addDatabaseUser(room, roomUser);
-                        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
+						await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
 
-                        Log(room, "User joined");
+                        // add user to gameplay group because we want idle players to start playing as well
+						await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId, true));
+
+						Log(room, "User joined");
                     }
                     catch
                     {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -110,9 +110,6 @@ namespace osu.Server.Spectator.Hubs
                         await addDatabaseUser(room, roomUser);
                         await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
 
-                        // add user to gameplay group because we want idle players to start playing as well
-                        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId, true));
-
                         Log(room, "User joined");
                     }
                     catch
@@ -617,8 +614,7 @@ namespace osu.Server.Spectator.Hubs
         /// Get the group ID to be used for multiplayer messaging.
         /// </summary>
         /// <param name="roomId">The databased room ID.</param>
-        /// <param name="gameplay">Whether the group ID should be for active gameplay, or room control messages.</param>
-        public static string GetGroupId(long roomId, bool gameplay = false) => $"room:{roomId}:{gameplay}";
+        public static string GetGroupId(long roomId) => $"room:{roomId}";
 
         private async Task updateDatabaseSettings(MultiplayerRoom room)
         {
@@ -833,7 +829,6 @@ namespace osu.Server.Spectator.Hubs
 
             Log(room, wasKick ? "User kicked" : "User left");
 
-            await Groups.RemoveFromGroupAsync(state.ConnectionId, GetGroupId(room.RoomID, true));
             await Groups.RemoveFromGroupAsync(state.ConnectionId, GetGroupId(room.RoomID));
 
             var user = room.Users.FirstOrDefault(u => u.UserID == state.UserId);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -458,8 +458,7 @@ namespace osu.Server.Spectator.Hubs
                 if (room.Host != null && room.Host.State != MultiplayerUserState.Spectating && room.Host.State != MultiplayerUserState.Ready)
                     throw new InvalidStateException("Can't start match when the host is not ready.");
 
-                var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray();
-                if (readyUsers.Length == 0)
+                if (room.Users.All(u => u.State != MultiplayerUserState.Ready))
                     throw new InvalidStateException("Can't start match when no users are ready.");
 
                 await HubContext.StartMatch(room);

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -108,12 +108,12 @@ namespace osu.Server.Spectator.Hubs
                         room.UpdateForRetrieval();
 
                         await addDatabaseUser(room, roomUser);
-						await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
+                        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId));
 
                         // add user to gameplay group because we want idle players to start playing as well
-						await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId, true));
+                        await Groups.AddToGroupAsync(Context.ConnectionId, GetGroupId(roomId, true));
 
-						Log(room, "User joined");
+                        Log(room, "User joined");
                     }
                     catch
                     {

--- a/osu.Server.Spectator/Hubs/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHub.cs
@@ -364,12 +364,7 @@ namespace osu.Server.Spectator.Hubs
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
 
-                if (user.BeatmapAvailability.Equals(newBeatmapAvailability))
-                    return;
-
-                user.BeatmapAvailability = newBeatmapAvailability;
-
-                await Clients.Group(GetGroupId(room.RoomID)).UserBeatmapAvailabilityChanged(CurrentContextUserId, newBeatmapAvailability);
+                await HubContext.ChangeAndBroadcastUserBeatmapAvailability(room, user, newBeatmapAvailability);
             }
         }
 
@@ -604,7 +599,7 @@ namespace osu.Server.Spectator.Hubs
                     Log(room, $"Switching queue mode to {settings.QueueMode}");
                 }
 
-                await HubContext.NotifySettingsChanged(room);
+                await HubContext.NotifySettingsChanged(room, false);
 
                 await updateRoomStateIfRequired(room);
             }

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -137,12 +137,12 @@ namespace osu.Server.Spectator.Hubs
                 switch (state)
                 {
                     case MultiplayerUserState.FinishedPlay:
-                    case MultiplayerUserState.Idle:
                         await context.Groups.RemoveFromGroupAsync(connectionId, MultiplayerHub.GetGroupId(room.RoomID, true));
                         break;
 
                     case MultiplayerUserState.Ready:
                     case MultiplayerUserState.Spectating:
+                    case MultiplayerUserState.Idle:
                         await context.Groups.AddToGroupAsync(connectionId, MultiplayerHub.GetGroupId(room.RoomID, true));
                         break;
                 }
@@ -166,7 +166,7 @@ namespace osu.Server.Spectator.Hubs
             if (room.Queue.CurrentItem.Expired)
                 throw new InvalidStateException("Cannot start an expired playlist item.");
 
-            var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray();
+            var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle).ToArray();
 
             // If no users are ready, skip the current item in the queue.
             if (readyUsers.Length == 0)

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -128,18 +128,7 @@ namespace osu.Server.Spectator.Hubs
         {
             log(room, user, $"User state changed from {user.State} to {state}");
 
-            var previousState = user.State;
             user.State = state;
-
-            string? connectionId = users.GetConnectionIdForUser(user.UserID);
-
-            if (connectionId != null)
-            {
-                if (state == MultiplayerUserState.FinishedPlay)
-                    await context.Groups.RemoveFromGroupAsync(connectionId, MultiplayerHub.GetGroupId(room.RoomID, true));
-                else if (previousState == MultiplayerUserState.Results)
-                    await context.Groups.AddToGroupAsync(connectionId, MultiplayerHub.GetGroupId(room.RoomID, true));
-            }
 
             await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMultiplayerClient.UserStateChanged), user.UserID, user.State);
         }
@@ -173,7 +162,7 @@ namespace osu.Server.Spectator.Hubs
 
             await ChangeRoomState(room, MultiplayerRoomState.WaitingForLoad);
 
-            await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID, true)).SendAsync(nameof(IMultiplayerClient.LoadRequested));
+            await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMultiplayerClient.LoadRequested));
 
             await room.StartCountdown(new ForceGameplayStartCountdown { TimeRemaining = gameplay_load_timeout }, StartOrStopGameplay);
         }

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -176,7 +176,10 @@ namespace osu.Server.Spectator.Hubs
                 return;
             }
 
-            var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle).ToArray();
+            var readyUsers = room.Users.Where(u =>
+                u.BeatmapAvailability.State == DownloadState.LocallyAvailable
+                && (u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle)
+            ).ToArray();
 
             foreach (var u in readyUsers)
                 await ChangeAndBroadcastUserState(room, u, MultiplayerUserState.WaitingForLoad);

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -130,8 +130,8 @@ namespace osu.Server.Spectator.Hubs
 
             string? connectionId = users.GetConnectionIdForUser(user.UserID);
 
-			if (connectionId != null)
-			{
+            if (connectionId != null)
+            {
                 if (state == MultiplayerUserState.FinishedPlay)
                 {
                     // when entering FinishedPlay state, we can be confident that player can be removed from group
@@ -145,11 +145,11 @@ namespace osu.Server.Spectator.Hubs
                         await context.Groups.AddToGroupAsync(connectionId, MultiplayerHub.GetGroupId(room.RoomID, true));
                     }
                 }
-			}
+            }
 
             user.State = state;
 
-			await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMultiplayerClient.UserStateChanged), user.UserID, user.State);
+            await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMultiplayerClient.UserStateChanged), user.UserID, user.State);
         }
 
         public async Task ChangeRoomState(ServerMultiplayerRoom room, MultiplayerRoomState newState)
@@ -167,15 +167,15 @@ namespace osu.Server.Spectator.Hubs
             if (room.Queue.CurrentItem.Expired)
                 throw new InvalidStateException("Cannot start an expired playlist item.");
 
-			if (!room.Users.Any(u => u.State == MultiplayerUserState.Ready))
-			{
-				await room.Queue.FinishCurrentItem();
-				return;
-			}
+            if (!room.Users.Any(u => u.State == MultiplayerUserState.Ready))
+            {
+                await room.Queue.FinishCurrentItem();
+                return;
+            }
 
-			var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle).ToArray();
+            var readyUsers = room.Users.Where(u => u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle).ToArray();
 
-			foreach (var u in readyUsers)
+            foreach (var u in readyUsers)
                 await ChangeAndBroadcastUserState(room, u, MultiplayerUserState.WaitingForLoad);
 
             await ChangeRoomState(room, MultiplayerRoomState.WaitingForLoad);

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -167,6 +167,7 @@ namespace osu.Server.Spectator.Hubs
             if (room.Queue.CurrentItem.Expired)
                 throw new InvalidStateException("Cannot start an expired playlist item.");
 
+            // If no users are ready, skip the current item in the queue.
             if (!room.Users.Any(u => u.State == MultiplayerUserState.Ready))
             {
                 await room.Queue.FinishCurrentItem();

--- a/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerHubContext.cs
@@ -160,7 +160,7 @@ namespace osu.Server.Spectator.Hubs
                 throw new InvalidStateException("Cannot start an expired playlist item.");
 
             // If no users are ready, skip the current item in the queue.
-            if (!room.Users.Any(u => u.State == MultiplayerUserState.Ready))
+            if (room.Users.All(u => u.State != MultiplayerUserState.Ready))
             {
                 await room.Queue.FinishCurrentItem();
                 return;

--- a/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/MultiplayerQueue.cs
@@ -85,7 +85,7 @@ namespace osu.Server.Spectator.Hubs
                 await db.MarkPlaylistItemAsPlayedAsync(room.RoomID, CurrentItem.ID);
                 room.Playlist[currentIndex] = await (await db.GetPlaylistItemAsync(room.RoomID, CurrentItem.ID)).ToMultiplayerPlaylistItem(db);
 
-                await hub.NotifyPlaylistItemChanged(room, CurrentItem);
+                await hub.NotifyPlaylistItemChanged(room, CurrentItem, true);
                 await updatePlaylistOrder(db);
 
                 // In host-only mode, duplicate the playlist item for the next round if no other non-expired items exist.
@@ -177,7 +177,7 @@ namespace osu.Server.Spectator.Hubs
                 await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
                 room.Playlist[room.Playlist.IndexOf(existingItem)] = item;
 
-                await hub.NotifyPlaylistItemChanged(room, item);
+                await hub.NotifyPlaylistItemChanged(room, item, existingItem.BeatmapChecksum != item.BeatmapChecksum);
             }
         }
 
@@ -263,7 +263,7 @@ namespace osu.Server.Spectator.Hubs
             room.Settings.PlaylistItemId = nextItem.ID;
 
             if (nextItem.ID != lastItemID)
-                await hub.NotifySettingsChanged(room);
+                await hub.NotifySettingsChanged(room, true);
         }
 
         /// <summary>
@@ -321,7 +321,7 @@ namespace osu.Server.Spectator.Hubs
                 item.PlaylistOrder = (ushort)i;
 
                 await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
-                await hub.NotifyPlaylistItemChanged(room, item);
+                await hub.NotifyPlaylistItemChanged(room, item, false);
             }
         }
     }


### PR DESCRIPTION
Implements ppy/osu/issues/22090

It has been previously decided that players who don't press the ready button in multiplayer should still be pushed into gameplay when match starts. This is what this PR achieves. The actual implementation was fairly simple, but i had to handle a lot of changes in tests. I also wrote a new one in order to ensure that `MultiplayerHubContext.ChangeAndBroadcastUserState` doesn't add user to or remove them from gameplay group multiple times which would cause a memory leak & trigger certain events multiple times.

- [x] Depends on https://github.com/ppy/osu/pull/24071
- [x] Depends on `osu.Game` package bump