### PR TITLE
Change to official BouncyCastle package

### DIFF
--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.36" />
-        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.4" />


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu-server-spectator/pull/168, I have security concerns about using a fork that is poorly maintained to the point that there's no branch for the latest version (1.9.0). Especially when cryptography is the target medium.

Although `BouncyCastle.Cryptography` has fewer downloads on nuget.org, this is the mainline package (https://github.com/bcgit/bc-csharp).