### PR TITLE
Fix compile failures after game-side ScoreV2 changes

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.511.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/Program.cs
+++ b/SampleSpectatorClient/Program.cs
@@ -12,6 +12,7 @@ using osu.Framework.Utils;
 using osu.Game.Online;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace SampleSpectatorClient
@@ -38,10 +39,12 @@ namespace SampleSpectatorClient
 
                 for (int i = 0; i < 50; i++)
                 {
-                    await sendingClient.SendFrames(new FrameDataBundle(new ScoreInfo(), new[]
-                    {
-                        new LegacyReplayFrame(i, RNG.Next(0, 512), RNG.Next(0, 512), ReplayButtonState.None)
-                    }));
+                    await sendingClient.SendFrames(new FrameDataBundle(
+                        new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
+                        new[]
+                        {
+                            new LegacyReplayFrame(i, RNG.Next(0, 512), RNG.Next(0, 512), ReplayButtonState.None)
+                        }));
                     Thread.Sleep(50);
                 }
 

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.511.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -12,6 +12,7 @@ using Moq;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
@@ -92,7 +93,9 @@ namespace osu.Server.Spectator.Tests
             mockClients.Verify(clients => clients.All, Times.Once);
             mockReceiver.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state))), Times.Once());
 
-            var data = new FrameDataBundle(new ScoreInfo(), new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) });
+            var data = new FrameDataBundle(
+                new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) });
 
             // check streaming data is propagating to watchers
             await hub.SendFrameData(data);
@@ -120,7 +123,9 @@ namespace osu.Server.Spectator.Tests
             mockDatabase.Setup(db => db.GetScoreIdFromToken(1234)).Returns(Task.FromResult<long?>(456));
 
             await hub.BeginPlaySession(1234, state);
-            await hub.SendFrameData(new FrameDataBundle(new ScoreInfo(), new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+            await hub.SendFrameData(new FrameDataBundle(
+                new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
             await hub.EndPlaySession(state);
 
             await scoreUploader.Flush();
@@ -267,7 +272,9 @@ namespace osu.Server.Spectator.Tests
             })!);
 
             await hub.BeginPlaySession(1234, state);
-            await hub.SendFrameData(new FrameDataBundle(new ScoreInfo(), new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+            await hub.SendFrameData(new FrameDataBundle(
+                new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
             await hub.EndPlaySession(state);
 
             await scoreUploader.Flush();

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,22 +6,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.103.36" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.104.27" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.511.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.511.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.511.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.511.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.511.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.605.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="3.29.1" />
+        <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- [x] Depends on new game packages

Stumbled upon this today when attempting to full-stack-test https://github.com/ppy/osu/pull/23551 + https://github.com/ppy/osu-server-spectator/pull/169. The [game-side changes](https://github.com/ppy/osu/pull/23638/files#diff-8672e012f2198095c976c3344a4a1d2809ffcd7cbe543605389265ea15e16bff) applied to `FrameDataBundle` caused a few compile failures here in and around tests.

I briefly considered continuing to use the `FrameDataBundle(ScoreInfo, ScoreProcessor, IList<LegacyReplayFrame>)` overload, but `ScoreProcessor` can't be instantiated without giving it a `Ruleset` too, so this felt less bad™.