### PR TITLE
Fix issues with score upload logic

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -29,15 +29,13 @@ namespace osu.Server.Spectator.Tests
 
             mockStorage = new Mock<IScoreStorage>();
             uploader = new ScoreUploader(databaseFactory.Object, mockStorage.Object);
-            uploader.UploadInterval = 10000; // Set a high timer interval for testing purposes.
+            uploader.UploadInterval = 1000; // Set a high timer interval for testing purposes.
         }
 
         [Fact]
         public async Task ScoreUploadsEveryInterval()
         {
             enableUpload();
-
-            uploader.UploadInterval = 1000;
 
             // First score.
             uploader.Enqueue(1, new Score());

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -39,7 +39,7 @@ namespace osu.Server.Spectator.Hubs
             cancellationSource = new CancellationTokenSource();
             cancellationToken = cancellationSource.Token;
 
-            Task.Run(runFlushLoop);
+            Task.Factory.StartNew(runFlushLoop, TaskCreationOptions.LongRunning);
         }
 
         private void runFlushLoop()

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -9,7 +9,6 @@ using osu.Game.Scoring;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Storage;
-using Timer = System.Timers.Timer;
 
 namespace osu.Server.Spectator.Hubs
 {
@@ -18,11 +17,7 @@ namespace osu.Server.Spectator.Hubs
         /// <summary>
         /// Amount of time (in milliseconds) between checks for pending score uploads.
         /// </summary>
-        public double UploadInterval
-        {
-            get => timer.Interval;
-            set => timer.Interval = value;
-        }
+        public int UploadInterval { get; set; } = 50;
 
         /// <summary>
         /// Amount of time (in milliseconds) before any individual score times out if a score ID hasn't been set.
@@ -33,22 +28,29 @@ namespace osu.Server.Spectator.Hubs
         private readonly ConcurrentQueue<UploadItem> queue = new ConcurrentQueue<UploadItem>();
         private readonly IDatabaseFactory databaseFactory;
         private readonly IScoreStorage scoreStorage;
-        private readonly Timer timer;
-        private readonly CancellationTokenSource timerCancellationSource;
-        private readonly CancellationToken timerCancellationToken;
+        private readonly CancellationTokenSource cancellationSource;
+        private readonly CancellationToken cancellationToken;
 
         public ScoreUploader(IDatabaseFactory databaseFactory, IScoreStorage scoreStorage)
         {
             this.databaseFactory = databaseFactory;
             this.scoreStorage = scoreStorage;
 
-            timerCancellationSource = new CancellationTokenSource();
-            timerCancellationToken = timerCancellationSource.Token;
+            cancellationSource = new CancellationTokenSource();
+            cancellationToken = cancellationSource.Token;
 
-            timer = new Timer(50);
-            timer.AutoReset = false;
-            timer.Elapsed += (_, _) => Task.Run(Flush);
-            timer.Start();
+            Task.Run(runFlushLoop);
+        }
+
+        private void runFlushLoop()
+        {
+            while (!queue.IsEmpty || !cancellationToken.IsCancellationRequested)
+            {
+                // ReSharper disable once MethodSupportsCancellation
+                // We don't want flush to be cancelled as it needs to finish uploading.
+                Flush().Wait();
+                Thread.Sleep(UploadInterval);
+            }
         }
 
         /// <summary>
@@ -76,12 +78,10 @@ namespace osu.Server.Spectator.Hubs
         {
             try
             {
-                timer.Stop();
-
                 if (queue.IsEmpty)
                     return;
 
-                Console.WriteLine($"Beginning upload of {queue.Count} scores");
+                Console.WriteLine($"Flushing upload queue with {queue.Count} scores");
 
                 using (var db = databaseFactory.GetInstance())
                 {
@@ -124,19 +124,12 @@ namespace osu.Server.Spectator.Hubs
             {
                 Console.WriteLine($"Error during score upload: {e}");
             }
-            finally
-            {
-                if (timerCancellationToken.IsCancellationRequested)
-                    timer.Dispose();
-                else
-                    timer.Start();
-            }
         }
 
         public void Dispose()
         {
-            timerCancellationSource.Cancel();
-            timerCancellationSource.Dispose();
+            cancellationSource.Cancel();
+            cancellationSource.Dispose();
         }
 
         private record UploadItem(long Token, Score Score, CancellationTokenSource Cancellation) : IDisposable

--- a/osu.Server.Spectator/S3.cs
+++ b/osu.Server.Spectator/S3.cs
@@ -32,7 +32,6 @@ namespace osu.Server.Spectator
                 {
                     BucketName = bucket,
                     Key = key,
-                    CannedACL = S3CannedACL.PublicRead,
                     Headers =
                     {
                         ContentLength = contentLength,


### PR DESCRIPTION
-  Rewrite `ScoreUploader` timing logic to avoid multiple unexpected concurrent flush runs
- Don't specify ACL when uploading to S3

Would probably be nice to have test logic covering uploads arriving during shutdown (aka disposal) but a bit hard to make competent tests timing-wise.