### PR TITLE
Fix default db username settings

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -324,7 +324,7 @@ namespace osu.Server.Spectator.Database
                 return openConnection;
 
             string host = Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost";
-            string user = Environment.GetEnvironmentVariable("DB_USER") ?? "root";
+            string user = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             string port = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
 
             DapperExtensions.InstallDateTimeOffsetMapper();

--- a/osu.Server.Spectator/Properties/launchSettings.json
+++ b/osu.Server.Spectator/Properties/launchSettings.json
@@ -15,7 +15,6 @@
       "launchUrl": "spectator",
       "applicationUrl": "http://localhost:5009",
       "environmentVariables": {
-        "DB_USER": "osuweb",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }


### PR DESCRIPTION
`DB_USER` configured in `launchSettings.json` overrides user specified env effectively hardcoding it.

I updated the default to match as I don't think the `root` default is ever used.