### PR TITLE
Fix total score not being populated in stored replays

### DIFF
--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -113,7 +113,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 score.ScoreInfo.Statistics = data.Header.Statistics;
                 score.ScoreInfo.MaxCombo = data.Header.MaxCombo;
                 score.ScoreInfo.Combo = data.Header.Combo;
-                // TODO: TotalScore should probably be populated as well, but needs beatmap max combo.
+                score.ScoreInfo.TotalScore = data.Header.TotalScore;
 
                 score.Replay.Frames.AddRange(data.Frames);
 


### PR DESCRIPTION
Fixes at least part of https://github.com/ppy/osu/issues/24643

Obviously this does nothing for existing lazer replays recorded via server spectator, but I'm thinking those would be subject to a wipe anyways, so doing anything for those would be wasted effort?