### PR TITLE
Adjust `FileScoreStorage` to be able to interoperate with local `osu-web` instance

### DIFF
--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
@@ -44,9 +43,6 @@ namespace osu.Server.Spectator.Tests
 
         public SpectatorHubTest()
         {
-            if (Directory.Exists(SpectatorHub.REPLAYS_PATH))
-                Directory.Delete(SpectatorHub.REPLAYS_PATH, true);
-
             // not used for now, but left here for potential future usage.
             MemoryDistributedCache cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
 

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -8,15 +8,27 @@ namespace osu.Server.Spectator
     public static class AppSettings
     {
         public static bool SaveReplays { get; set; }
+
+        #region For use with FileScoreStorage
+
+        public static string ReplaysPath { get; set; }
+
+        #endregion
+
+        #region For use with S3ScoreStorage
+
         public static string S3Key { get; }
         public static string S3Secret { get; }
         public static string ReplaysBucket { get; }
+
+        #endregion
 
         public static string RedisHost { get; }
 
         static AppSettings()
         {
             SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
+            ReplaysPath = Environment.GetEnvironmentVariable("REPLAYS_PATH") ?? "replays";
             S3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? string.Empty;
             S3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? string.Empty;
             ReplaysBucket = Environment.GetEnvironmentVariable("REPLAYS_BUCKET") ?? string.Empty;

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -17,8 +17,6 @@ namespace osu.Server.Spectator.Hubs.Spectator
 {
     public class SpectatorHub : StatefulUserHub<ISpectatorClient, SpectatorClientState>, ISpectatorServer
     {
-        public const string REPLAYS_PATH = "replays";
-
         /// <summary>
         /// Minimum beatmap status to save replays for.
         /// </summary>

--- a/osu.Server.Spectator/Storage/FileScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/FileScoreStorage.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Threading.Tasks;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
-using osu.Server.Spectator.Hubs.Spectator;
 
 namespace osu.Server.Spectator.Storage
 {
@@ -14,18 +13,13 @@ namespace osu.Server.Spectator.Storage
     {
         public Task WriteAsync(Score score)
         {
-            var scoreInfo = score.ScoreInfo;
             var legacyEncoder = new LegacyScoreEncoder(score, null);
 
-            string path = Path.Combine(SpectatorHub.REPLAYS_PATH, scoreInfo.Date.Year.ToString(), scoreInfo.Date.Month.ToString(), scoreInfo.Date.Day.ToString());
-
-            Directory.CreateDirectory(path);
-
-            string filename = $"replay-{scoreInfo.Ruleset.ShortName}_{scoreInfo.BeatmapInfo!.OnlineID}_{score.ScoreInfo.OnlineID}.osr";
+            string filename = score.ScoreInfo.OnlineID.ToString();
 
             Console.WriteLine($"Writing replay for score {score.ScoreInfo.OnlineID} to {filename}");
 
-            using (var outStream = File.Create(Path.Combine(path, filename)))
+            using (var outStream = File.Create(Path.Combine(AppSettings.ReplaysPath, filename)))
                 legacyEncoder.Encode(outStream);
 
             return Task.CompletedTask;


### PR DESCRIPTION
This is something I made to test out changes related to ppy/osu#24229 locally. Doesn't need to be merged, but maybe a nice-to-have?

This change makes it possible to set up `osu-server-spectator` locally such that a local neighbouring `osu-web` instance can pick up replays stored to disk via `FileScoreStorage` (currently unused). Setting this up entails something like the following:

```diff
diff --git a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs index 1100f64..403f1f6 100644
--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs +++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs @@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
-                                    .AddSingleton<IScoreStorage, S3ScoreStorage>()
+                                    .AddSingleton<IScoreStorage, FileScoreStorage>()
                                     .AddSingleton<ScoreUploader>()
                                     .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>();
         }
diff --git a/osu.Server.Spectator/Properties/launchSettings.json b/osu.Server.Spectator/Properties/launchSettings.json
index 133a303..bdf3f20 100644
--- a/osu.Server.Spectator/Properties/launchSettings.json
+++ b/osu.Server.Spectator/Properties/launchSettings.json
@@ -15,7 +15,9 @@
       "launchUrl": "spectator",
       "applicationUrl": "http://localhost:5009",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "SAVE_REPLAYS": "1",
+        "REPLAYS_PATH": "${OSU_WEB_DIRECTORY}/public/uploads-solo-replay"
       }
     }
   }

```

wherein `${OSU_WEB_DIRECTORY}` points to the root of the `osu-web` repository.

With the above changes applied, and `SCORE_REPLAYS_STORAGE=local` set in `.env` on the `osu-web` side, replays recorded and saved by the `osu-server-spectator` instance can be downloaded from the `osu-web` instance.

Notably, `SpectatorHub.REPLAYS_PATH` is deleted entirely, as its only two usages were: `FileScoreStorage` (now replaced with the `REPLAYS_PATH` envvar), and `SpectatorHubTest`, which used it to nuke the replays folder - but that makes little sense, since the test uses a mock, so it doesn't actually ever interact with the filesystem anymore.