### PR TITLE
Fix "Create Sentry release" deploy step failing

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -100,6 +100,11 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          # the "Create Sentry release" step relies on accessing git history
+          # to find the SHA of the previous release and set the range of new commits in the release being deployed.
+          # do a full clone rather than a shallow one to allow it to do that.
+          fetch-depth: 0
       -
         name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
See: https://github.com/ppy/osu-server-spectator/actions/runs/5972074156/job/16202100558#step:5:15

The "Create Sentry release" step relies on accessing git history in order to find the SHA of the previous release and set the range of new commits in the release being deployed.

Do a full clone rather than a shallow one to allow it to do that.

Option used is documented over at https://github.com/actions/checkout#usage.

---

For reference, I also wanted to fix the various deprecation warnings in the log:

![1692947013](https://github.com/ppy/osu-server-spectator/assets/20418176/29c8486f-0cc9-4a44-b2ea-1098cc58544a)

by bumping actions' versions. It was going great until https://github.com/docker/build-push-action, which has gone up 2 major versions since: v3 that should fix the deprecation warnings, and v4 that enables [some sort of provenance thing](https://github.com/docker/build-push-action/releases/tag/v4.1.1). I don't know if that's something we can safely enable, so my solution for now is to back away slowly and wait for someone smarter than me to figure that part out.