### PR TITLE
Adjust end match database query in line with multiplayer score storage changes

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -240,6 +240,8 @@ namespace osu.Server.Spectator.Database
                 "DELETE FROM multiplayer_playlist_items p"
                 + " WHERE p.room_id = @RoomID"
                 + " AND p.expired = 0"
+                + " AND (SELECT COUNT(*) FROM multiplayer_score_links l WHERE l.playlist_item_id = p.id) = 0"
+                // condition below can be removed once scores are fully moved to multiplayer_score_links
                 + " AND (SELECT COUNT(*) FROM multiplayer_scores s WHERE s.playlist_item_id = p.id) = 0",
                 new
                 {


### PR DESCRIPTION
With https://github.com/ppy/osu-web/pull/10437, scores go into the `multiplayer_score_links` table, rather than the `multiplayer_scores` table.

The primary case impacted by this change is when a user suddenly disconnects from an open room in which they are alone. In such a case, without this change, the `expired` check would fail (since the item, at the time of the sole player's exit, is not yet finished / expired), and as such due to not checking the new multiplayer score table, spectator server would consider the relevant playlist item unplayed and delete it, leaving behind a `multiplayer_score_links` record with `playlist_item_id` leading into the void.