### PR TITLE
Don't upload replays for failed scores

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -295,14 +295,15 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task<long?> GetScoreIdFromToken(long token)
+        public async Task<SoloScore?> GetScoreFromToken(long token)
         {
             var connection = await getConnectionAsync();
 
-            return await connection.QuerySingleOrDefaultAsync<long?>("SELECT `score_id` FROM `solo_score_tokens` WHERE `id` = @Id", new
-            {
-                Id = token
-            });
+            return await connection.QuerySingleOrDefaultAsync<SoloScore?>(
+                "SELECT * FROM `solo_scores` WHERE `id` = (SELECT `score_id` FROM `solo_score_tokens` WHERE `id` = @Id)", new
+                {
+                    Id = token
+                });
         }
 
         public async Task<bool> IsScoreProcessedAsync(long scoreId)

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -121,11 +121,11 @@ namespace osu.Server.Spectator.Database
         Task MarkScoreHasReplay(Score score);
 
         /// <summary>
-        /// Retrieves the score ID for a given score token. Will return null while the score has not yet been submitted.
+        /// Retrieves the <see cref="SoloScore"/> for a given score token. Will return null while the score has not yet been submitted.
         /// </summary>
         /// <param name="token">The score token.</param>
-        /// <returns>The score ID.</returns>
-        Task<long?> GetScoreIdFromToken(long token);
+        /// <returns>The <see cref="SoloScore"/>.</returns>
+        Task<SoloScore?> GetScoreFromToken(long token);
 
         /// <summary>
         /// Returns <see langword="true"/> if the score with the supplied <paramref name="scoreId"/> has been successfully processed.

--- a/osu.Server.Spectator/Database/Models/SoloScore.cs
+++ b/osu.Server.Spectator/Database/Models/SoloScore.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Server.Spectator.Database.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("solo_scores")]
+    public class SoloScore
+    {
+        public ulong id { get; set; }
+
+        public int user_id { get; set; }
+
+        public int beatmap_id { get; set; }
+
+        public int ruleset_id { get; set; }
+
+        public string data
+        {
+            get => JsonConvert.SerializeObject(ScoreInfo);
+            set
+            {
+                var scoreInfo = JsonConvert.DeserializeObject<SoloScoreInfo>(value);
+
+                if (scoreInfo == null)
+                    return;
+
+                ScoreInfo = scoreInfo;
+
+                ScoreInfo.ID = id;
+                ScoreInfo.BeatmapID = beatmap_id;
+                ScoreInfo.UserID = user_id;
+                ScoreInfo.RulesetID = ruleset_id;
+            }
+        }
+
+        [JsonIgnore]
+        public bool preserve { get; set; }
+
+        [JsonIgnore]
+        public bool has_replay { get; set; }
+
+        [JsonIgnore]
+        public SoloScoreInfo ScoreInfo = new SoloScoreInfo();
+
+        [JsonIgnore]
+        public DateTimeOffset created_at { get; set; }
+
+        [JsonIgnore]
+        public DateTimeOffset updated_at { get; set; }
+
+        public override string ToString() => $"score_id: {id} user_id: {user_id}";
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-server-spectator/issues/187
Closes https://github.com/ppy/osu-infrastructure/issues/19

`SoloScore` model taken from [osu-queue-score-statistics](https://github.com/ppy/osu-queue-score-statistics/blob/3cc58af62a4805ca51c1ef13ed85385b4179cf84/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs)