### PR TITLE
Remove reference to `multiplayer_scores` table

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -240,9 +240,7 @@ namespace osu.Server.Spectator.Database
                 "DELETE FROM multiplayer_playlist_items p"
                 + " WHERE p.room_id = @RoomID"
                 + " AND p.expired = 0"
-                + " AND (SELECT COUNT(*) FROM multiplayer_score_links l WHERE l.playlist_item_id = p.id) = 0"
-                // condition below can be removed once scores are fully moved to multiplayer_score_links
-                + " AND (SELECT COUNT(*) FROM multiplayer_scores s WHERE s.playlist_item_id = p.id) = 0",
+                + " AND (SELECT COUNT(*) FROM multiplayer_score_links l WHERE l.playlist_item_id = p.id) = 0",
                 new
                 {
                     RoomID = room.RoomID


### PR DESCRIPTION
This needs to be deployed before trying to drop the table again.

See: https://sentry.ppy.sh/organizations/ppy/issues/27445