### PR TITLE
Fix replay upload flow not encoding player username

### DIFF
--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -111,17 +111,11 @@ namespace osu.Server.Spectator.Hubs
                             if (!dbScore.ScoreInfo.Passed)
                                 return;
 
-                            var updatedScore = new Score
-                            {
-                                Replay = item.Score.Replay,
-                                ScoreInfo = dbScore.ScoreInfo.ToScoreInfo(item.Score.ScoreInfo.Mods, item.Score.ScoreInfo.BeatmapInfo)
-                            };
+                            item.Score.ScoreInfo.OnlineID = dbScore.ScoreInfo.OnlineID;
+                            item.Score.ScoreInfo.Passed = dbScore.ScoreInfo.Passed;
 
-                            // This needs to be updated to a valid reference for the score encoder.
-                            updatedScore.ScoreInfo.Ruleset = item.Score.ScoreInfo.Ruleset;
-
-                            await scoreStorage.WriteAsync(updatedScore);
-                            await db.MarkScoreHasReplay(updatedScore);
+                            await scoreStorage.WriteAsync(item.Score);
+                            await db.MarkScoreHasReplay(item.Score);
                         }
                         finally
                         {


### PR DESCRIPTION
[As described on discord.](https://discord.com/channels/188630481301012481/188630652340404224/1167006468134944829)

The username is pretty important to the replay upload flow working as so far it is the only reference to the player that set the score in a replay. Not having it there will lead client to attempt to look up the player via `null` username and therefore fail to import the score and also spew errors.