### PR TITLE
Update game packages

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1013.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1114.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1013.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1114.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1026.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1013.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1013.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1026.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1026.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1114.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.822.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
     </ItemGroup>


### PR DESCRIPTION
Two reasons:

- Pulls in score encoder changes from https://github.com/ppy/osu/pull/24794 which means replays recorded after deploy of this should download correctly
- Spectator server didn't really need any changes from touch device but incompatibility stuff changed there so the added validation will be nice.