### PR TITLE
Disconnect existing client connections when another client instance for same user is detected

### DIFF
--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
+using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -45,6 +46,7 @@ namespace SampleMultiplayerClient
             connection.On<MultiplayerPlaylistItem>(nameof(IMultiplayerClient.PlaylistItemChanged), ((IMultiplayerClient)this).PlaylistItemChanged);
             connection.On<long>(nameof(IMultiplayerClient.PlaylistItemRemoved), ((IMultiplayerClient)this).PlaylistItemRemoved);
             connection.On<int, long, string>(nameof(IMultiplayerClient.Invited), ((IMultiplayerClient)this).Invited);
+            connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
         }
 
         public MultiplayerUserState State { get; private set; }
@@ -249,6 +251,12 @@ namespace SampleMultiplayerClient
         {
             Console.WriteLine($"Playlist item changed (id: {item.ID} beatmap: {item.BeatmapID}, ruleset: {item.RulesetID})");
             return Task.CompletedTask;
+        }
+
+        public async Task DisconnectRequested()
+        {
+            Console.WriteLine("Disconnect requested");
+            await LeaveRoom();
         }
     }
 }

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -157,7 +157,11 @@ namespace SampleMultiplayerClient
         {
             var connection = new HubConnectionBuilder()
                              .AddMessagePackProtocol(options => { options.SerializerOptions = SignalRUnionWorkaroundResolver.OPTIONS; })
-                             .WithUrl("http://localhost:80/multiplayer", http => http.Headers.Add("user_id", userId.ToString()))
+                             .WithUrl("http://localhost:80/multiplayer", http =>
+                             {
+                                 http.Headers.Add("user_id", userId.ToString());
+                                 http.Headers.Add("client_id", Guid.NewGuid().ToString());
+                             })
                              .ConfigureLogging(logging =>
                              {
                                  // logging.AddFilter("Microsoft.AspNetCore.SignalR", LogLevel.Debug);

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1013.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1128.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1013.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1128.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SpectatorClient.cs
+++ b/SampleSpectatorClient/SpectatorClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
+using osu.Game.Online;
 using osu.Game.Online.Spectator;
 
 namespace SampleSpectatorClient
@@ -26,6 +27,7 @@ namespace SampleSpectatorClient
             connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
             connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
             connection.On<int, long>(nameof(ISpectatorClient.UserScoreProcessed), ((ISpectatorClient)this).UserScoreProcessed);
+            connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
         }
 
         Task ISpectatorClient.UserBeganPlaying(int userId, SpectatorState state)
@@ -69,5 +71,11 @@ namespace SampleSpectatorClient
         public Task EndPlaying(SpectatorState state) => connection.SendAsync(nameof(ISpectatorServer.EndPlaySession), state);
 
         public Task WatchUser(int userId) => connection.SendAsync(nameof(ISpectatorServer.StartWatchingUser), userId);
+
+        public Task DisconnectRequested()
+        {
+            Console.WriteLine($"{connection.ConnectionId} Disconnect requested");
+            return Task.CompletedTask;
+        }
     }
 }

--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -141,5 +141,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             return (Task)GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public)!.Invoke(this, args)!;
         }
+
+        public async Task DisconnectRequested()
+        {
+            foreach (var c in Clients)
+                await c.DisconnectRequested();
+        }
     }
 }

--- a/osu.Server.Spectator.Tests/StatefulUserHubTest.cs
+++ b/osu.Server.Spectator.Tests/StatefulUserHubTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq;
 using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Extensions;
 using osu.Server.Spectator.Hubs;
 using Xunit;
 
@@ -114,7 +115,7 @@ namespace osu.Server.Spectator.Tests
             public async Task CreateUserState()
             {
                 using (var state = await GetOrCreateLocalUserState())
-                    state.Item = new ClientState(Context.ConnectionId, CurrentContextUserId);
+                    state.Item = new ClientState(Context.ConnectionId, Context.GetUserId());
             }
         }
     }

--- a/osu.Server.Spectator.Tests/StatefulUserHubTest.cs
+++ b/osu.Server.Spectator.Tests/StatefulUserHubTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq;
+using osu.Game.Online;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Extensions;
 using osu.Server.Spectator.Hubs;
@@ -105,7 +106,7 @@ namespace osu.Server.Spectator.Tests
         private void setNewConnectionId(string? connectionId = null) =>
             mockContext.Setup(context => context.ConnectionId).Returns(connectionId ?? Guid.NewGuid().ToString());
 
-        private class TestStatefulHub : StatefulUserHub<object, ClientState>
+        private class TestStatefulHub : StatefulUserHub<IStatefulUserHubClient, ClientState>
         {
             public TestStatefulHub(IDistributedCache cache, EntityStore<ClientState> userStates)
                 : base(cache, userStates)

--- a/osu.Server.Spectator.sln.DotSettings
+++ b/osu.Server.Spectator.sln.DotSettings
@@ -777,6 +777,7 @@ See the LICENCE file in the repository root for full licence text.&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -80,14 +80,15 @@ namespace osu.Server.Spectator
 
         public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
         {
-            // TODO: allow things to execute for hubs that aren't exclusive (like metadata or whatever)
-
             var userId = invocationContext.Context.GetUserId();
 
             using (var userState = await connectionStates.GetForUse(userId))
             {
-                if (invocationContext.Context.GetTokenId() != userState.Item?.TokenId)
+                if (invocationContext.Context.GetTokenId() != userState.Item?.TokenId
+                    || invocationContext.Context.ConnectionId != userState.Item?.ConnectionIds[invocationContext.Hub.GetType()])
+                {
                     throw new InvalidStateException("State is not valid for this connection");
+                }
             }
 
             return await next(invocationContext);

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -53,12 +53,16 @@ namespace osu.Server.Spectator
                     {
                         log(context, "connection from new client instance, dropping existing state");
 
-                        foreach (var hub in stateful_user_hubs)
+                        foreach (var hubType in stateful_user_hubs)
                         {
-                            var hubContextType = typeof(IHubContext<>).MakeGenericType(hub);
+                            var hubContextType = typeof(IHubContext<>).MakeGenericType(hubType);
                             var hubContext = serviceProvider.GetRequiredService(hubContextType) as IHubContext;
-                            hubContext?.Clients.Client(userState.Item.ConnectionIds[hub])
-                                      .SendCoreAsync(nameof(IStatefulUserHubClient.DisconnectRequested), Array.Empty<object>());
+
+                            if (userState.Item.ConnectionIds.TryGetValue(hubType, out var connectionId))
+                            {
+                                hubContext?.Clients.Client(connectionId)
+                                          .SendCoreAsync(nameof(IStatefulUserHubClient.DisconnectRequested), Array.Empty<object>());
+                            }
                         }
 
                         log(context, "existing state dropped");

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -2,12 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;
+using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Extensions;
+using osu.Server.Spectator.Hubs;
 
 namespace osu.Server.Spectator
 {
@@ -15,10 +21,17 @@ namespace osu.Server.Spectator
     {
         private readonly EntityStore<ConnectionState> connectionStates;
 
+        private readonly IServiceProvider serviceProvider;
+
+        private static readonly IEnumerable<Type> stateful_user_hubs
+            = typeof(IStatefulUserHub).Assembly.GetTypes().Where(type => typeof(IStatefulUserHub).IsAssignableFrom(type) && typeof(Hub).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract).ToArray();
+
         public ConcurrentConnectionLimiter(
-            EntityStore<ConnectionState> connectionStates)
+            EntityStore<ConnectionState> connectionStates,
+            IServiceProvider serviceProvider)
         {
             this.connectionStates = connectionStates;
+            this.serviceProvider = serviceProvider;
         }
 
         public async Task OnConnectedAsync(HubLifetimeContext context, Func<HubLifetimeContext, Task> next)
@@ -31,16 +44,29 @@ namespace osu.Server.Spectator
                 {
                     if (context.Context.GetTokenId() == userState.Item?.TokenId)
                     {
-                        Logger.Log($"connection continued for user {userId}");
+                        log(context, "subsequent connection from same client instance, registering");
+                        userState.Item.RegisterConnectionId(context);
                         return;
                     }
 
-                    if (userState.Item == null)
-                        Logger.Log($"{userId} connected");
-                    else
-                        Logger.Log($"new connection spotted for user {userId}, should drop existing");
+                    if (userState.Item != null)
+                    {
+                        log(context, "connection from new client instance, dropping existing state");
 
-                    userState.Item = new ConnectionState(context.Context);
+                        foreach (var hub in stateful_user_hubs)
+                        {
+                            var hubContextType = typeof(IHubContext<>).MakeGenericType(hub);
+                            var hubContext = serviceProvider.GetRequiredService(hubContextType) as IHubContext;
+                            hubContext?.Clients.Client(userState.Item.ConnectionIds[hub])
+                                      .SendCoreAsync(nameof(IStatefulUserHubClient.DisconnectRequested), Array.Empty<object>());
+                        }
+
+                        log(context, "existing state dropped");
+                    }
+                    else
+                        log(context, "connection from first client instance");
+
+                    userState.Item = new ConnectionState(context);
                 }
             }
             finally
@@ -48,6 +74,9 @@ namespace osu.Server.Spectator
                 await next(context);
             }
         }
+
+        private static void log(HubLifetimeContext context, string message)
+            => Logger.Log($"[user:{context.Context.GetUserId()}] [connection:{context.Context.ConnectionId}] [hub:{context.Hub.GetType().ReadableName()}] {message}");
 
         public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
         {
@@ -78,7 +107,7 @@ namespace osu.Server.Spectator
                 {
                     if (userState.Item?.TokenId == context.Context.GetTokenId())
                     {
-                        Logger.Log($"{userId} disconnected");
+                        log(context, "disconnected");
                         userState.Destroy();
                     }
                 }

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -38,7 +38,7 @@ namespace osu.Server.Spectator
         {
             try
             {
-                var userId = context.Context.GetUserId();
+                int userId = context.Context.GetUserId();
 
                 using (var userState = await connectionStates.GetForUse(userId, true))
                 {

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -90,7 +90,7 @@ namespace osu.Server.Spectator
 
         public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
         {
-            var userId = invocationContext.Context.GetUserId();
+            int userId = invocationContext.Context.GetUserId();
 
             using (var userState = await connectionStates.GetForUse(userId))
             {
@@ -112,7 +112,7 @@ namespace osu.Server.Spectator
                     // network disconnection. wait for user to return.
                     return;
 
-                var userId = context.Context.GetUserId();
+                int userId = context.Context.GetUserId();
 
                 using (var userState = await connectionStates.GetForUse(userId, true))
                 {

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using osu.Framework.Logging;
+using osu.Game.Online.Multiplayer;
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Extensions;
+
+namespace osu.Server.Spectator
+{
+    public class ConcurrentConnectionLimiter : IHubFilter
+    {
+        private readonly EntityStore<ConnectionState> connectionStates;
+
+        public ConcurrentConnectionLimiter(
+            EntityStore<ConnectionState> connectionStates)
+        {
+            this.connectionStates = connectionStates;
+        }
+
+        public async Task OnConnectedAsync(HubLifetimeContext context, Func<HubLifetimeContext, Task> next)
+        {
+            try
+            {
+                var userId = context.Context.GetUserId();
+
+                using (var userState = await connectionStates.GetForUse(userId, true))
+                {
+                    if (context.Context.GetTokenId() == userState.Item?.TokenId)
+                    {
+                        Logger.Log($"connection continued for user {userId}");
+                        return;
+                    }
+
+                    if (userState.Item == null)
+                        Logger.Log($"{userId} connected");
+                    else
+                        Logger.Log($"new connection spotted for user {userId}, should drop existing");
+
+                    userState.Item = new ConnectionState(context.Context);
+                }
+            }
+            finally
+            {
+                await next(context);
+            }
+        }
+
+        public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
+        {
+            // TODO: allow things to execute for hubs that aren't exclusive (like metadata or whatever)
+
+            var userId = invocationContext.Context.GetUserId();
+
+            using (var userState = await connectionStates.GetForUse(userId))
+            {
+                if (invocationContext.Context.GetTokenId() != userState.Item?.TokenId)
+                    throw new InvalidStateException("State is not valid for this connection");
+            }
+
+            return await next(invocationContext);
+        }
+
+        public async Task OnDisconnectedAsync(HubLifetimeContext context, Exception? exception, Func<HubLifetimeContext, Exception?, Task> next)
+        {
+            try
+            {
+                if (exception != null)
+                    // network disconnection. wait for user to return.
+                    return;
+
+                var userId = context.Context.GetUserId();
+
+                using (var userState = await connectionStates.GetForUse(userId, true))
+                {
+                    if (userState.Item?.TokenId == context.Context.GetTokenId())
+                    {
+                        Logger.Log($"{userId} disconnected");
+                        userState.Destroy();
+                    }
+                }
+            }
+            finally
+            {
+                await next(context, exception);
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -1,25 +1,38 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.SignalR;
 using osu.Server.Spectator.Extensions;
-using osu.Server.Spectator.Hubs;
 
 namespace osu.Server.Spectator.Entities
 {
-    public class ConnectionState : ClientState
+    public class ConnectionState
     {
+        /// <summary>
+        /// The unique ID of the JWT the user is using to authenticate.
+        /// This is used to control user uniqueness.
+        /// </summary>
         public readonly string TokenId;
 
-        public ConnectionState(in string connectionId, in int userId, in string tokenId)
-            : base(in connectionId, in userId)
+        /// <summary>
+        /// The connection IDs of the user.
+        /// </summary>
+        /// <remarks>
+        /// In SignalR, connection IDs are unique per user, <em>and</em> per hub instance.
+        /// Therefore, to keep track of all of them, a dictionary is necessary.
+        /// </remarks>
+        public readonly Dictionary<Type, string> ConnectionIds = new Dictionary<Type, string>();
+
+        public ConnectionState(HubLifetimeContext context)
         {
-            this.TokenId = tokenId;
+            TokenId = context.Context.GetTokenId();
+
+            RegisterConnectionId(context);
         }
 
-        public ConnectionState(HubCallerContext context)
-            : this(context.ConnectionId, context.GetUserId(), context.GetTokenId())
-        {
-        }
+        public void RegisterConnectionId(HubLifetimeContext context)
+            => ConnectionIds.Add(context.Hub.GetType(), context.Context.ConnectionId);
     }
 }

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -8,6 +8,9 @@ using osu.Server.Spectator.Extensions;
 
 namespace osu.Server.Spectator.Entities
 {
+    /// <summary>
+    /// Maintains the connection state of a single client (notably, client, not user) across multiple hubs.
+    /// </summary>
     public class ConnectionState
     {
         /// <summary>
@@ -17,11 +20,12 @@ namespace osu.Server.Spectator.Entities
         public readonly string TokenId;
 
         /// <summary>
-        /// The connection IDs of the user.
+        /// The connection IDs of the user for each hub type.
         /// </summary>
         /// <remarks>
-        /// In SignalR, connection IDs are unique per user, <em>and</em> per hub instance.
-        /// Therefore, to keep track of all of them, a dictionary is necessary.
+        /// In SignalR, connection IDs are unique per connection.
+        /// Because we use multiple hubs and a user is expected to be connected to each hub individually,
+        /// we use a dictionary to track connections across all hubs for a specific user.
         /// </remarks>
         public readonly Dictionary<Type, string> ConnectionIds = new Dictionary<Type, string>();
 
@@ -32,6 +36,10 @@ namespace osu.Server.Spectator.Entities
             RegisterConnectionId(context);
         }
 
+        /// <summary>
+        /// Registers the provided hub/connection context, replacing any existing connection for the hub type.
+        /// </summary>
+        /// <param name="context">The hub context to retrieve information from.</param>
         public void RegisterConnectionId(HubLifetimeContext context)
             => ConnectionIds[context.Hub.GetType()] = context.Context.ConnectionId;
     }

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -33,6 +33,6 @@ namespace osu.Server.Spectator.Entities
         }
 
         public void RegisterConnectionId(HubLifetimeContext context)
-            => ConnectionIds.Add(context.Hub.GetType(), context.Context.ConnectionId);
+            => ConnectionIds[context.Hub.GetType()] = context.Context.ConnectionId;
     }
 }

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.AspNetCore.SignalR;
+using osu.Server.Spectator.Extensions;
+using osu.Server.Spectator.Hubs;
+
+namespace osu.Server.Spectator.Entities
+{
+    public class ConnectionState : ClientState
+    {
+        public readonly string TokenId;
+
+        public ConnectionState(in string connectionId, in int userId, in string tokenId)
+            : base(in connectionId, in userId)
+        {
+            this.TokenId = tokenId;
+        }
+
+        public ConnectionState(HubCallerContext context)
+            : this(context.ConnectionId, context.GetUserId(), context.GetTokenId())
+        {
+        }
+    }
+}

--- a/osu.Server.Spectator/Extensions/HubCallerContextExtensions.cs
+++ b/osu.Server.Spectator/Extensions/HubCallerContextExtensions.cs
@@ -18,5 +18,17 @@ namespace osu.Server.Spectator.Extensions
 
             return int.Parse(context.UserIdentifier);
         }
+
+        /// <summary>
+        /// Returns the ID of the authorisation token (more accurately, the <c>jti</c> claim)
+        /// for the supplied <paramref name="context"/>.
+        /// This is used for the purpose of identifying individual client instances
+        /// and preventing multiple concurrent sessions from being active.
+        /// </summary>
+        public static string GetTokenId(this HubCallerContext context)
+        {
+            return context.User?.FindFirst(claim => claim.Type == "jti")?.Value
+                   ?? throw new InvalidOperationException("Could not retrieve JWT ID claim from token");
+        }
     }
 }

--- a/osu.Server.Spectator/Extensions/HubCallerContextExtensions.cs
+++ b/osu.Server.Spectator/Extensions/HubCallerContextExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Microsoft.AspNetCore.SignalR;
+
+namespace osu.Server.Spectator.Extensions
+{
+    public static class HubCallerContextExtensions
+    {
+        /// <summary>
+        /// Returns the osu! user id for the supplied <paramref name="context"/>.
+        /// </summary>
+        public static int GetUserId(this HubCallerContext context)
+        {
+            if (context.UserIdentifier == null)
+                throw new InvalidOperationException($"Attempted to get user id with null {nameof(context.UserIdentifier)}");
+
+            return int.Parse(context.UserIdentifier);
+        }
+    }
+}

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace osu.Server.Spectator.Extensions
             return serviceCollection.AddSingleton<EntityStore<SpectatorClientState>>()
                                     .AddSingleton<EntityStore<MultiplayerClientState>>()
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
+                                    .AddSingleton<EntityStore<ConnectionState>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
                                     .AddSingleton<IScoreStorage, S3ScoreStorage>()

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -29,14 +29,22 @@ namespace osu.Server.Spectator
         private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
         private readonly EntityStore<ServerMultiplayerRoom> roomStore;
 
-        public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime,
-                                       ScoreUploader scoreUploader)
+        public GracefulShutdownManager(
+            EntityStore<ServerMultiplayerRoom> roomStore,
+            EntityStore<SpectatorClientState> clientStateStore,
+            IHostApplicationLifetime hostApplicationLifetime,
+            ScoreUploader scoreUploader,
+            EntityStore<ConnectionState> connectionStateStore)
         {
             this.roomStore = roomStore;
 
             dependentStores.Add(roomStore);
             dependentStores.Add(clientStateStore);
             dependentStores.Add(scoreUploader);
+            dependentStores.Add(connectionStateStore);
+            // Importantly, we don't care to block `MultiplayerClientState` stores because they can only be created
+            // if a `ServerMultiplayerRoom` is first in existence.
+            // More so, we want to allow these states to be created so existing rooms can continue to function until they are disbanded.
 
             hostApplicationLifetime.ApplicationStopping.Register(shutdownSafely);
         }

--- a/osu.Server.Spectator/Hubs/IStatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/IStatefulUserHub.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.Spectator.Hubs
+{
+    /// <summary>
+    /// Marker interface for <see cref="StatefulUserHub{TClient,TUserState}"/>.
+    /// Allows bypassing generic constraints.
+    /// </summary>
+    public interface IStatefulUserHub
+    {
+    }
+}

--- a/osu.Server.Spectator/Hubs/LoggingHub.cs
+++ b/osu.Server.Spectator/Hubs/LoggingHub.cs
@@ -28,20 +28,6 @@ namespace osu.Server.Spectator.Hubs
             logger = Logger.GetLogger(Name);
         }
 
-        /// <summary>
-        /// The osu! user id for the currently processing context.
-        /// </summary>
-        protected int CurrentContextUserId
-        {
-            get
-            {
-                if (Context.UserIdentifier == null)
-                    throw new InvalidOperationException($"Attempted to get user id with null {nameof(Context.UserIdentifier)}");
-
-                return int.Parse(Context.UserIdentifier);
-            }
-        }
-
         public override async Task OnConnectedAsync()
         {
             Log("Connected");

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -16,6 +16,7 @@ using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Extensions;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer
 {
@@ -42,7 +43,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
             bool isRestricted;
             using (var db = databaseFactory.GetInstance())
-                isRestricted = await db.IsUserRestrictedAsync(CurrentContextUserId);
+                isRestricted = await db.IsUserRestrictedAsync(Context.GetUserId());
 
             if (isRestricted)
                 throw new InvalidStateException("Can't join a room when restricted.");
@@ -56,7 +57,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 }
 
                 // add the user to the room.
-                var roomUser = new MultiplayerRoomUser(CurrentContextUserId);
+                var roomUser = new MultiplayerRoomUser(Context.GetUserId());
 
                 // track whether this join necessitated starting the process of fetching the room and adding it to the room store.
                 bool newRoomFetchStarted = false;
@@ -98,7 +99,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                                 throw new InvalidOperationException($"User {roomUser.UserID} attempted to join room {room.RoomID} they are already present in.");
                         }
 
-                        userUsage.Item = new MultiplayerClientState(Context.ConnectionId, CurrentContextUserId, roomId);
+                        userUsage.Item = new MultiplayerClientState(Context.ConnectionId, Context.GetUserId(), roomId);
 
                         // because match type implementations may send subsequent information via Users collection hooks,
                         // inform clients before adding user to the room.
@@ -180,7 +181,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (databaseRoom.ends_at != null && databaseRoom.ends_at < DateTimeOffset.Now)
                     throw new InvalidStateException("Match has already ended.");
 
-                if (databaseRoom.user_id != CurrentContextUserId)
+                if (databaseRoom.user_id != Context.GetUserId())
                     throw new InvalidStateException("Non-host is attempting to join match before host");
 
                 var room = new ServerMultiplayerRoom(roomId, HubContext)
@@ -241,13 +242,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (isRestricted)
                     throw new InvalidStateException("Can't invite a restricted user to a room.");
 
-                var relation = await db.GetUserRelation(CurrentContextUserId, userId);
+                var relation = await db.GetUserRelation(Context.GetUserId(), userId);
 
                 // The local user has the player they are trying to invite blocked.
                 if (relation?.foe == true)
                     throw new UserBlockedException();
 
-                var inverseRelation = await db.GetUserRelation(userId, CurrentContextUserId);
+                var inverseRelation = await db.GetUserRelation(userId, Context.GetUserId());
 
                 // The player being invited has the local user blocked.
                 if (inverseRelation?.foe == true)
@@ -346,7 +347,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
 
                 if (user == null)
                     throw new InvalidStateException("Local user was not found in the expected room");
@@ -400,7 +401,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
 
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
@@ -419,7 +420,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
 
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
@@ -438,7 +439,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
 
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
@@ -515,7 +516,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
 
@@ -536,7 +537,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
 
@@ -557,7 +558,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
 
@@ -575,7 +576,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 if (room == null)
                     throw new InvalidOperationException("Attempted to operate on a null room");
 
-                var user = room.Users.FirstOrDefault(u => u.UserID == CurrentContextUserId);
+                var user = room.Users.FirstOrDefault(u => u.UserID == Context.GetUserId());
                 if (user == null)
                     throw new InvalidOperationException("Local user was not found in the expected room");
 
@@ -832,7 +833,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         /// </summary>
         private void ensureIsHost(MultiplayerRoom room)
         {
-            if (room.Host?.UserID != CurrentContextUserId)
+            if (room.Host?.UserID != Context.GetUserId())
                 throw new NotHostException();
         }
 

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Caching.Distributed;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Extensions;
 
 namespace osu.Server.Spectator.Hubs
 {
@@ -59,7 +60,7 @@ namespace osu.Server.Spectator.Hubs
 
             try
             {
-                usage = await UserStates.GetForUse(CurrentContextUserId);
+                usage = await UserStates.GetForUse(Context.GetUserId());
             }
             catch (KeyNotFoundException)
             {
@@ -106,7 +107,7 @@ namespace osu.Server.Spectator.Hubs
 
         protected async Task<ItemUsage<TUserState>> GetOrCreateLocalUserState()
         {
-            var usage = await UserStates.GetForUse(CurrentContextUserId, true);
+            var usage = await UserStates.GetForUse(Context.GetUserId(), true);
 
             if (usage.Item != null && usage.Item.ConnectionId != Context.ConnectionId)
             {

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Caching.Distributed;
+using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Extensions;
@@ -15,9 +16,9 @@ namespace osu.Server.Spectator.Hubs
 {
     [UsedImplicitly]
     [Authorize]
-    public abstract class StatefulUserHub<TClient, TUserState> : LoggingHub<TClient>
+    public abstract class StatefulUserHub<TClient, TUserState> : LoggingHub<TClient>, IStatefulUserHub
         where TUserState : ClientState
-        where TClient : class
+        where TClient : class, IStatefulUserHubClient
     {
         protected readonly EntityStore<TUserState> UserStates;
 

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -27,7 +27,11 @@ namespace osu.Server.Spectator
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSignalR(options => options.AddFilter<LoggingHubFilter>())
+            services.AddSignalR(options =>
+                    {
+                        options.AddFilter<LoggingHubFilter>();
+                        options.AddFilter<ConcurrentConnectionLimiter>();
+                    })
                     .AddMessagePackProtocol(options =>
                     {
                         // This is required for match type states/events, which are regularly sent as derived implementations where that type is not conveyed in the invocation signature itself.

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,12 +15,12 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1026.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1013.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1013.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1026.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1026.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.822.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1128.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1128.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1128.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1128.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1128.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1114.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- [x] Depends on (and is the server side of) https://github.com/ppy/osu/pull/25522
- [x] Depends on game package w/ above
- Closes https://github.com/ppy/osu-server-spectator/issues/80

The detection of client instances relies on the JSON web tokens issued by web, namely by the uniqueness of the `jti` claim, which is [optional but standardised to seemingly be suitable for this purpose](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7).

Tokens are valid for 24 hours, which seems like a sane session length. If the use of `jti` causes problems, we can (will have to?) come up with our own unique ID generating scheme on the client side.