### PR TITLE
Update users' last visit time on connecting to spectator server

### DIFF
--- a/osu.Server.Spectator.Tests/BatchMetadataUpdaterTests.cs
+++ b/osu.Server.Spectator.Tests/BatchMetadataUpdaterTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Hubs.Metadata;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class BatchMetadataUpdaterTests
+    {
+        private readonly EntityStore<MetadataClientState> metadataStateStore;
+        private readonly Mock<IDatabaseAccess> mockDatabase;
+        private readonly BatchMetadataUpdater batchMetadataUpdater;
+
+        public BatchMetadataUpdaterTests()
+        {
+            metadataStateStore = new EntityStore<MetadataClientState>();
+            mockDatabase = new Mock<IDatabaseAccess>();
+
+            var databaseFactory = new Mock<IDatabaseFactory>();
+            databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
+
+            batchMetadataUpdater = new BatchMetadataUpdater(databaseFactory.Object, metadataStateStore);
+            batchMetadataUpdater.BatchInterval = 100;
+            batchMetadataUpdater.BatchSize = 2;
+        }
+
+        [Fact]
+        public async Task LastVisitTimeUpdatedCorrectly()
+        {
+            const int user_id = 1234;
+
+            using (var usage = await metadataStateStore.GetForUse(user_id, true))
+                usage.Item = new MetadataClientState(Guid.NewGuid().ToString(), user_id);
+
+            await Task.Delay(200);
+            mockDatabase.Verify(db => db.UpdateLastVisitTimeToNowAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Single() == user_id)), Times.AtLeastOnce);
+
+            using (var usage = await metadataStateStore.GetForUse(user_id))
+                usage.Destroy();
+
+            mockDatabase.Invocations.Clear();
+
+            await Task.Delay(200);
+            mockDatabase.Verify(db => db.UpdateLastVisitTimeToNowAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Single() == user_id)), Times.Never);
+        }
+
+        [Fact]
+        public async Task TestBatching()
+        {
+            int[] userIds = { 1234, 5678, 9012 };
+
+            foreach (int userId in userIds)
+            {
+                using (var usage = await metadataStateStore.GetForUse(userId, true))
+                    usage.Item = new MetadataClientState(Guid.NewGuid().ToString(), userId);
+            }
+
+            await Task.Delay(150);
+            mockDatabase.Verify(db => db.UpdateLastVisitTimeToNowAsync(
+                It.IsAny<IEnumerable<int>>()), Times.Exactly(2));
+        }
+    }
+}

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -332,6 +333,16 @@ namespace osu.Server.Spectator.Database
             return await connection.QuerySingleOrDefaultAsync<bool>("SELECT `user_allow_pm` FROM `phpbb_users` WHERE `user_id` = @UserId", new
             {
                 UserId = userId
+            });
+        }
+
+        public async Task UpdateLastVisitTimeToNowAsync(IEnumerable<int> userIds)
+        {
+            var connection = await getConnectionAsync();
+
+            await connection.ExecuteAsync("UPDATE `phpbb_users` SET `user_lastvisit` = UNIX_TIMESTAMP() WHERE `user_id` in @UserIds", new
+            {
+                UserIds = userIds
             });
         }
 

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using osu.Game.Online.Metadata;
@@ -141,5 +142,10 @@ namespace osu.Server.Spectator.Database
         /// Returns <see langword="true"/> if the user with the supplied <paramref name="userId"/> allows private messages from people not on their friends list.
         /// </summary>
         Task<bool> GetUserAllowsPMs(int userId);
+
+        /// <summary>
+        /// Updates the last visit time of users with the supplied <paramref name="userIds"/> to the current time.
+        /// </summary>
+        Task UpdateLastVisitTimeToNowAsync(IEnumerable<int> userIds);
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -20,11 +20,13 @@ namespace osu.Server.Spectator.Extensions
             return serviceCollection.AddSingleton<EntityStore<SpectatorClientState>>()
                                     .AddSingleton<EntityStore<MultiplayerClientState>>()
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
+                                    .AddSingleton<EntityStore<MetadataClientState>>()
                                     .AddSingleton<GracefulShutdownManager>()
                                     .AddSingleton<MetadataBroadcaster>()
                                     .AddSingleton<IScoreStorage, S3ScoreStorage>()
                                     .AddSingleton<ScoreUploader>()
-                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>();
+                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
+                                    .AddSingleton<BatchMetadataUpdater>();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -11,6 +11,7 @@ using osu.Framework.Logging;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs;
+using osu.Server.Spectator.Hubs.Metadata;
 using osu.Server.Spectator.Hubs.Multiplayer;
 using osu.Server.Spectator.Hubs.Spectator;
 
@@ -29,14 +30,19 @@ namespace osu.Server.Spectator
         private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
         private readonly EntityStore<ServerMultiplayerRoom> roomStore;
 
-        public GracefulShutdownManager(EntityStore<ServerMultiplayerRoom> roomStore, EntityStore<SpectatorClientState> clientStateStore, IHostApplicationLifetime hostApplicationLifetime,
-                                       ScoreUploader scoreUploader)
+        public GracefulShutdownManager(
+            EntityStore<ServerMultiplayerRoom> roomStore,
+            EntityStore<SpectatorClientState> clientStateStore,
+            IHostApplicationLifetime hostApplicationLifetime,
+            ScoreUploader scoreUploader,
+            EntityStore<MetadataClientState> metadataClientStore)
         {
             this.roomStore = roomStore;
 
             dependentStores.Add(roomStore);
             dependentStores.Add(clientStateStore);
             dependentStores.Add(scoreUploader);
+            dependentStores.Add(metadataClientStore);
 
             hostApplicationLifetime.ApplicationStopping.Register(shutdownSafely);
         }

--- a/osu.Server.Spectator/Hubs/Metadata/BatchMetadataUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BatchMetadataUpdater.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Logging;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Entities;
+
+namespace osu.Server.Spectator.Hubs.Metadata
+{
+    /// <summary>
+    /// Performes updates of user metadata in a batched manner.
+    /// </summary>
+    public class BatchMetadataUpdater : IDisposable
+    {
+        /// <summary>
+        /// Amount of time (in milliseconds) between update batches.
+        /// Also used to stagger updates in a single batch.
+        /// </summary>
+        public int BatchInterval { get; set; } = 300_000;
+
+        /// <summary>
+        /// Maximum number of rows to update at once.
+        /// </summary>
+        public int BatchSize { get; set; } = 100;
+
+        private readonly IDatabaseFactory databaseFactory;
+        private readonly EntityStore<MetadataClientState> clientStates;
+
+        private readonly CancellationTokenSource cancellationTokenSource;
+        private readonly Logger logger;
+
+        public BatchMetadataUpdater(
+            IDatabaseFactory databaseFactory,
+            EntityStore<MetadataClientState> clientStates)
+        {
+            this.databaseFactory = databaseFactory;
+            this.clientStates = clientStates;
+
+            logger = Logger.GetLogger(nameof(BatchMetadataUpdater));
+            cancellationTokenSource = new CancellationTokenSource();
+            Task.Factory.StartNew(updateLastVisitTimes, TaskCreationOptions.LongRunning);
+        }
+
+        private void updateLastVisitTimes()
+        {
+            while (!cancellationTokenSource.IsCancellationRequested)
+            {
+                try
+                {
+                    var clientStatesSnapshot = clientStates.GetAllEntities();
+
+                    var batches = clientStatesSnapshot.Select((kvp, index) => (kvp.Value.UserId, index))
+                                                      .GroupBy(pair => pair.index / BatchSize, pair => pair.UserId)
+                                                      .ToList();
+
+                    if (!batches.Any())
+                        continue;
+
+                    int updateInterval = (int)Math.Round((double)BatchInterval / batches.Count);
+
+                    using (var connection = databaseFactory.GetInstance())
+                    {
+                        foreach (var batch in batches)
+                            connection.UpdateLastVisitTimeToNowAsync(batch);
+
+                        Thread.Sleep(updateInterval);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.Add($"Failed to update users' last visit times", LogLevel.Error, ex);
+                }
+                finally
+                {
+                    Thread.Sleep(BatchInterval);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataClientState.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataClientState.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.Spectator.Hubs.Metadata
+{
+    public class MetadataClientState : ClientState
+    {
+        // TODO: user activity information
+        // TODO: build hash
+
+        public MetadataClientState(in string connectionId, in int userId)
+            : base(in connectionId, in userId)
+        {
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -2,18 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
 using osu.Game.Online.Metadata;
 using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Entities;
 
 namespace osu.Server.Spectator.Hubs.Metadata
 {
-    public class MetadataHub : LoggingHub<IMetadataClient>, IMetadataServer
+    public class MetadataHub : StatefulUserHub<IMetadataClient, MetadataClientState>, IMetadataServer
     {
         private readonly IDatabaseFactory databaseFactory;
 
-        public MetadataHub(IDatabaseFactory databaseFactory)
+        public MetadataHub(
+            IDistributedCache cache,
+            EntityStore<MetadataClientState> userStates,
+            IDatabaseFactory databaseFactory)
+            : base(cache, userStates)
         {
             this.databaseFactory = databaseFactory;
+        }
+
+        public override async Task OnConnectedAsync()
+        {
+            await base.OnConnectedAsync();
+
+            using (var usage = await GetOrCreateLocalUserState())
+                usage.Item = new MetadataClientState(Context.ConnectionId, CurrentContextUserId);
         }
 
         public async Task<BeatmapUpdates> GetChangesSince(int queueId)

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -121,6 +121,7 @@ namespace osu.Server.Spectator
 
             app.ApplicationServices.GetRequiredService<MetadataBroadcaster>();
             app.ApplicationServices.GetRequiredService<ScoreUploader>();
+            app.ApplicationServices.GetRequiredService<BatchMetadataUpdater>();
         }
     }
 }


### PR DESCRIPTION
Addresses the core part of ppy/osu#12635.

The functionality is purposefully placed in `MetadataHub` due to an IRL discussion with @peppy (and also briefly @nanaya), whose conclusion is that we probably don't want a new hub for this to avoid introducing even more websocket connections into the mix.

The updates are performed in batches of 100. The updates in a batch are staggered, and there is a delay between batches as well. The delay is partially arbitrary, but matches web [in a sense](https://github.com/ppy/osu-web/blob/f858ec2d1c2c61f4229c40bc01a943e9df2376e0/app/Http/Middleware/UpdateUserLastvisit.php#L37).

I intend to extend the metadata hub further with reporting the users' activities and broadcasting them to other clients, as well as tracking per-build information.

This change does not depend on https://github.com/ppy/osu-server-spectator/pull/196, but the two will inevitably conflict. I will deal with that when it will be required to do so.