### PR TITLE
Fix issues with concurrent connection filtering

### DIFF
--- a/osu.Server.Spectator.Tests/ConcurrentConnectionLimiterTests.cs
+++ b/osu.Server.Spectator.Tests/ConcurrentConnectionLimiterTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using osu.Game.Online.Multiplayer;
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Hubs.Spectator;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class ConcurrentConnectionLimiterTests
+    {
+        private readonly EntityStore<ConnectionState> connectionStates;
+        private readonly Mock<IServiceProvider> serviceProviderMock;
+        private readonly Mock<Hub> hubMock;
+
+        public ConcurrentConnectionLimiterTests()
+        {
+            connectionStates = new EntityStore<ConnectionState>();
+            serviceProviderMock = new Mock<IServiceProvider>();
+
+            var hubContextMock = new Mock<IHubContext>();
+            serviceProviderMock.Setup(sp => sp.GetService(It.IsAny<Type>()))
+                               .Returns(hubContextMock.Object);
+
+            hubMock = new Mock<Hub>();
+        }
+
+        [Fact]
+        public async Task TestNormalOperation()
+        {
+            var hubCallerContextMock = new Mock<HubCallerContext>();
+            hubCallerContextMock.Setup(ctx => ctx.UserIdentifier).Returns("1234");
+            hubCallerContextMock.Setup(ctx => ctx.User).Returns(new ClaimsPrincipal(new[]
+            {
+                new ClaimsIdentity(new[]
+                {
+                    new Claim("jti", Guid.NewGuid().ToString())
+                })
+            }));
+
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+            var lifetimeContext = new HubLifetimeContext(hubCallerContextMock.Object, serviceProviderMock.Object, hubMock.Object);
+
+            bool connected = false;
+            await filter.OnConnectedAsync(lifetimeContext, _ =>
+            {
+                connected = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(connected);
+            Assert.Single(connectionStates.GetEntityUnsafe(1234)!.ConnectionIds);
+
+            bool methodInvoked = false;
+            var invocationContext = new HubInvocationContext(hubCallerContextMock.Object, serviceProviderMock.Object, hubMock.Object,
+                typeof(SpectatorHub).GetMethod(nameof(SpectatorHub.StartWatchingUser))!, new object[] { 1234 });
+            await filter.InvokeMethodAsync(invocationContext, _ =>
+            {
+                methodInvoked = true;
+                return new ValueTask<object?>(new object());
+            });
+            Assert.True(methodInvoked);
+            Assert.Single(connectionStates.GetEntityUnsafe(1234)!.ConnectionIds);
+
+            bool disconnected = false;
+            await filter.OnDisconnectedAsync(lifetimeContext, null, (_, _) =>
+            {
+                disconnected = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(disconnected);
+            Assert.Null(connectionStates.GetEntityUnsafe(1234));
+        }
+
+        [Fact]
+        public async Task TestConcurrencyBlocked()
+        {
+            var firstContextMock = new Mock<HubCallerContext>();
+            var secondContextMock = new Mock<HubCallerContext>();
+
+            firstContextMock.Setup(ctx => ctx.UserIdentifier).Returns("1234");
+            firstContextMock.Setup(ctx => ctx.ConnectionId).Returns("abcd");
+            firstContextMock.Setup(ctx => ctx.User).Returns(new ClaimsPrincipal(new[]
+            {
+                new ClaimsIdentity(new[]
+                {
+                    new Claim("jti", Guid.NewGuid().ToString())
+                })
+            }));
+
+            secondContextMock.Setup(ctx => ctx.UserIdentifier).Returns("1234");
+            secondContextMock.Setup(ctx => ctx.ConnectionId).Returns("efgh");
+            secondContextMock.Setup(ctx => ctx.User).Returns(new ClaimsPrincipal(new[]
+            {
+                new ClaimsIdentity(new[]
+                {
+                    new Claim("jti", Guid.NewGuid().ToString())
+                })
+            }));
+
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+
+            var firstLifetimeContext = new HubLifetimeContext(firstContextMock.Object, serviceProviderMock.Object, hubMock.Object);
+            await filter.OnConnectedAsync(firstLifetimeContext, _ => Task.CompletedTask);
+
+            var secondLifetimeContext = new HubLifetimeContext(secondContextMock.Object, serviceProviderMock.Object, hubMock.Object);
+            await filter.OnConnectedAsync(secondLifetimeContext, _ => Task.CompletedTask);
+
+            var secondInvocationContext = new HubInvocationContext(secondContextMock.Object, serviceProviderMock.Object, hubMock.Object,
+                typeof(SpectatorHub).GetMethod(nameof(SpectatorHub.StartWatchingUser))!, new object[] { 1234 });
+            // should succeed.
+            await filter.InvokeMethodAsync(secondInvocationContext, _ => new ValueTask<object?>(new object()));
+
+            var firstInvocationContext = new HubInvocationContext(firstContextMock.Object, serviceProviderMock.Object, hubMock.Object,
+                typeof(SpectatorHub).GetMethod(nameof(SpectatorHub.StartWatchingUser))!, new object[] { 1234 });
+            // should throw.
+            await Assert.ThrowsAsync<InvalidStateException>(() => filter.InvokeMethodAsync(firstInvocationContext, _ => new ValueTask<object?>(new object())).AsTask());
+        }
+    }
+}

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -94,11 +94,16 @@ namespace osu.Server.Spectator
 
             using (var userState = await connectionStates.GetForUse(userId))
             {
-                if (invocationContext.Context.GetTokenId() != userState.Item?.TokenId
-                    || invocationContext.Context.ConnectionId != userState.Item?.ConnectionIds[invocationContext.Hub.GetType()])
-                {
+                string? registeredConnectionId = null;
+
+                bool tokenIdMatches = invocationContext.Context.GetTokenId() == userState.Item?.TokenId;
+                bool hubRegistered = userState.Item?.ConnectionIds.TryGetValue(invocationContext.Hub.GetType(), out registeredConnectionId) == true;
+                bool connectionIdMatches = registeredConnectionId == invocationContext.Context.ConnectionId;
+
+                bool connectionIsValid = tokenIdMatches && hubRegistered && connectionIdMatches;
+
+                if (!connectionIsValid)
                     throw new InvalidStateException("State is not valid for this connection");
-                }
             }
 
             return await next(invocationContext);

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -68,7 +68,7 @@ namespace osu.Server.Spectator
                         var hubContextType = typeof(IHubContext<>).MakeGenericType(hubType);
                         var hubContext = serviceProvider.GetRequiredService(hubContextType) as IHubContext;
 
-                        if (userState.Item.ConnectionIds.TryGetValue(hubType, out var connectionId))
+                        if (userState.Item.ConnectionIds.TryGetValue(hubType, out string? connectionId))
                         {
                             hubContext?.Clients.Client(connectionId)
                                       .SendCoreAsync(nameof(IStatefulUserHubClient.DisconnectRequested), Array.Empty<object>());


### PR DESCRIPTION
The hope here is that this closes https://github.com/ppy/osu/issues/25635 and fixes similar issues that have been visible on sentry for the past day or so, but I can't provide any strong guarantee that it does, as testing this in practice is difficult.

The goal here is to fix two shortcomings:

- Because each hub is a separate endpoint / websocket connection, they do not have to be synchronised wrt connection state at all. Therefore, it is possible for the user to disconnect from only _some_ of the hubs (and I have observed this in practice). The previous cleanup logic implicitly assumed this to be impossible, and as such nuked the user's entire state. To counteract this, each disconnect event only performs cleanup in the context of the hub where the disconnect happened, and the entity is removed from the store if and only if it has no connections registered any more.

  This is covered by `TestHubDisconnectsTrackedSeparately()` in the tests. It also can be tested in practice by e.g. launching a game instance in debug and pausing its execution until signalr-side keepalive detects some hubs as dead, and then resuming the game instance. Doing so should result in a sequence similar to

  ```
  2023-12-01 10:33:41 [verbose]: [user:13] [connection:70q_Und49nat8Ky1vQYHZw] [hub:MultiplayerHub] connection from first client instance
  2023-12-01 10:33:41 [verbose]: [user:13] [connection:fZ5XUJpztt3HkTGeRpAPaQ] [hub:MetadataHub] subsequent connection from same client instance, registering
  2023-12-01 10:33:41 [verbose]: [user:13] [connection:pXga_043AKYWsifLMLXz0Q] [hub:SpectatorHub] subsequent connection from same client instance, registering
  2023-12-01 10:34:59 [verbose]: [user:13] [connection:70q_Und49nat8Ky1vQYHZw] [hub:MultiplayerHub] disconnected from hub
  2023-12-01 10:34:59 [verbose]: [user:13] [connection:pXga_043AKYWsifLMLXz0Q] [hub:SpectatorHub] disconnected from hub
  2023-12-01 10:35:01 [verbose]: [user:13] [connection:UXsCivQPhyGUoUWCsOYjyQ] [hub:MultiplayerHub] subsequent connection from same client instance, registering
  2023-12-01 10:35:06 [verbose]: [user:13] [connection:x4_gO7ftW8cSIQEMl_IbVQ] [hub:SpectatorHub] subsequent connection from same client instance, registering
  ```
  with this pull.
- Another scenario pointed out by @peppy - theoretical at this point, although plausible - is that if the following sequence of events happens (using server-side message ordering) for a single client instance:

  - Connection A with hub X established
  - Connection B with hub X established due to client-side reconnection
  - Connection A with hub X closed cleanly

  then the last disconnection would not only nuke the entire connection state as mentioned in the previous point, it shouldn't really be doing anything _at all_, since it's a stale event concerning a stale connection and therefore it should not result in anything changing. Thus, a connection disconnection event can only unregister a connection now if the connection IDs match.

  This is covered in the added unit tests, in `TestStaleDisconnectIsANoOp()`.