### PR TITLE
Refactor multiplayer invite tests

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -45,7 +45,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 await c.UserKicked(user);
         }
 
-        public virtual Task Invited(int invitedBy, long roomID, string password) => Task.CompletedTask;
+        public virtual async Task Invited(int invitedBy, long roomID, string password)
+        {
+            foreach (var c in Clients)
+                await c.Invited(invitedBy, roomID, password);
+        }
 
         public virtual async Task HostChanged(int userId)
         {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
@@ -11,14 +11,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer;
 
 public class MultiplayerInviteTest : MultiplayerTest
 {
-    private const int invited_user_id = 3;
-    private readonly Mock<DelegatingMultiplayerClient> invitedUser;
-
-    public MultiplayerInviteTest()
-    {
-        CreateUser(invited_user_id, out _, out invitedUser);
-    }
-
     [Fact]
     public async Task UserCanInviteFriends()
     {
@@ -28,9 +20,9 @@ public class MultiplayerInviteTest : MultiplayerTest
         Database.Setup(d => d.GetUserRelation(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(new phpbb_zebra { friend = true });
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(invited_user_id);
+        await Hub.InvitePlayer(USER_ID_2);
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             string.Empty
@@ -43,13 +35,13 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        Database.Setup(d => d.GetUserRelation(USER_ID, invited_user_id)).ReturnsAsync(new phpbb_zebra { foe = true });
-        Database.Setup(d => d.GetUserRelation(invited_user_id, USER_ID)).ReturnsAsync(new phpbb_zebra { friend = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID, USER_ID_2)).ReturnsAsync(new phpbb_zebra { foe = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID_2, USER_ID)).ReturnsAsync(new phpbb_zebra { friend = true });
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(invited_user_id));
+        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(USER_ID_2));
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -62,13 +54,13 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        Database.Setup(d => d.GetUserRelation(USER_ID, invited_user_id)).ReturnsAsync(new phpbb_zebra { friend = true });
-        Database.Setup(d => d.GetUserRelation(invited_user_id, USER_ID)).ReturnsAsync(new phpbb_zebra { foe = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID, USER_ID_2)).ReturnsAsync(new phpbb_zebra { friend = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID_2, USER_ID)).ReturnsAsync(new phpbb_zebra { foe = true });
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(invited_user_id));
+        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(USER_ID_2));
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -81,12 +73,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(false);
+        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(false);
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlocksPMsException>(() => Hub.InvitePlayer(invited_user_id));
+        await Assert.ThrowsAsync<UserBlocksPMsException>(() => Hub.InvitePlayer(USER_ID_2));
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -103,9 +95,9 @@ public class MultiplayerInviteTest : MultiplayerTest
         Database.Setup(d => d.IsUserRestrictedAsync(It.IsAny<int>())).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<InvalidStateException>(() => Hub.InvitePlayer(invited_user_id));
+        await Assert.ThrowsAsync<InvalidStateException>(() => Hub.InvitePlayer(USER_ID_2));
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -118,12 +110,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(true);
+        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(invited_user_id);
+        await Hub.InvitePlayer(USER_ID_2);
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             string.Empty
@@ -146,12 +138,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoomWithPassword(ROOM_ID, password);
 
-        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(true);
+        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(invited_user_id);
+        await Hub.InvitePlayer(USER_ID_2);
 
-        invitedUser.Verify(r => r.Invited(
+        User2Receiver.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             password

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
@@ -11,21 +11,26 @@ namespace osu.Server.Spectator.Tests.Multiplayer;
 
 public class MultiplayerInviteTest : MultiplayerTest
 {
+    private const int invited_user_id = 3;
+    private readonly Mock<DelegatingMultiplayerClient> invitedUser;
+
+    public MultiplayerInviteTest()
+    {
+        CreateUser(invited_user_id, out _, out invitedUser);
+    }
+
     [Fact]
     public async Task UserCanInviteFriends()
     {
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
         Database.Setup(d => d.GetUserRelation(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(new phpbb_zebra { friend = true });
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(USER_ID_2);
+        await Hub.InvitePlayer(invited_user_id);
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             string.Empty
@@ -38,16 +43,13 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
-        Database.Setup(d => d.GetUserRelation(USER_ID, USER_ID_2)).ReturnsAsync(new phpbb_zebra { foe = true });
-        Database.Setup(d => d.GetUserRelation(USER_ID_2, USER_ID)).ReturnsAsync(new phpbb_zebra { friend = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID, invited_user_id)).ReturnsAsync(new phpbb_zebra { foe = true });
+        Database.Setup(d => d.GetUserRelation(invited_user_id, USER_ID)).ReturnsAsync(new phpbb_zebra { friend = true });
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(USER_ID_2));
+        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(invited_user_id));
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -60,16 +62,13 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
-        Database.Setup(d => d.GetUserRelation(USER_ID, USER_ID_2)).ReturnsAsync(new phpbb_zebra { friend = true });
-        Database.Setup(d => d.GetUserRelation(USER_ID_2, USER_ID)).ReturnsAsync(new phpbb_zebra { foe = true });
+        Database.Setup(d => d.GetUserRelation(USER_ID, invited_user_id)).ReturnsAsync(new phpbb_zebra { friend = true });
+        Database.Setup(d => d.GetUserRelation(invited_user_id, USER_ID)).ReturnsAsync(new phpbb_zebra { foe = true });
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(USER_ID_2));
+        await Assert.ThrowsAsync<UserBlockedException>(() => Hub.InvitePlayer(invited_user_id));
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -82,15 +81,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
-        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(false);
+        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(false);
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<UserBlocksPMsException>(() => Hub.InvitePlayer(USER_ID_2));
+        await Assert.ThrowsAsync<UserBlocksPMsException>(() => Hub.InvitePlayer(invited_user_id));
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -103,16 +99,13 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
         Database.Setup(d => d.GetUserRelation(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(new phpbb_zebra { friend = true });
         Database.Setup(d => d.IsUserRestrictedAsync(It.IsAny<int>())).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Assert.ThrowsAsync<InvalidStateException>(() => Hub.InvitePlayer(USER_ID_2));
+        await Assert.ThrowsAsync<InvalidStateException>(() => Hub.InvitePlayer(invited_user_id));
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             It.IsAny<int>(),
             It.IsAny<long>(),
             It.IsAny<string>()
@@ -125,15 +118,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoom(ROOM_ID);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
-        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(true);
+        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(USER_ID_2);
+        await Hub.InvitePlayer(invited_user_id);
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             string.Empty
@@ -156,15 +146,12 @@ public class MultiplayerInviteTest : MultiplayerTest
         SetUserContext(ContextUser);
         await Hub.JoinRoomWithPassword(ROOM_ID, password);
 
-        var invitedUserReceiver = new Mock<IMultiplayerClient>();
-        Clients.Setup(clients => clients.User(USER_ID_2.ToString())).Returns(invitedUserReceiver.Object);
-
-        Database.Setup(d => d.GetUserAllowsPMs(USER_ID_2)).ReturnsAsync(true);
+        Database.Setup(d => d.GetUserAllowsPMs(invited_user_id)).ReturnsAsync(true);
 
         SetUserContext(ContextUser);
-        await Hub.InvitePlayer(USER_ID_2);
+        await Hub.InvitePlayer(invited_user_id);
 
-        invitedUserReceiver.Verify(r => r.Invited(
+        invitedUser.Verify(r => r.Invited(
             USER_ID,
             ROOM_ID,
             password

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -157,6 +157,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             clientMapping[userId] = client.Object;
 
             Clients.Setup(clients => clients.Client(userId.ToString())).Returns(client.Object);
+            Clients.Setup(clients => clients.User(userId.ToString())).Returns(client.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
While going through tests and eventually implementing the change to `CreateUser`, I noticed that these tests didn't use the `CreateUser` method and instead opted to create users locally.