### PR TITLE
Track user counts per build

### DIFF
--- a/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
@@ -44,6 +44,7 @@ namespace osu.Server.Spectator.Tests
             await trackUser(5, "deadbeef");
             await trackUser(6, "unknown");
 
+            AppSettings.TrackBuildUserCounts = true;
             var updater = new BuildUserCountUpdater(clientStates, databaseFactoryMock.Object)
             {
                 UpdateInterval = 50

--- a/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Hubs.Metadata;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class BuildUserCountUpdaterTest
+    {
+        private readonly EntityStore<MetadataClientState> clientStates;
+        private readonly Mock<IDatabaseFactory> databaseFactoryMock;
+        private readonly Mock<IDatabaseAccess> databaseAccessMock;
+
+        public BuildUserCountUpdaterTest()
+        {
+            clientStates = new EntityStore<MetadataClientState>();
+
+            databaseFactoryMock = new Mock<IDatabaseFactory>();
+            databaseAccessMock = new Mock<IDatabaseAccess>();
+            databaseFactoryMock.Setup(df => df.GetInstance()).Returns(databaseAccessMock.Object);
+        }
+
+        [Fact]
+        public async Task TestPeriodicUpdates()
+        {
+            databaseAccessMock.Setup(db => db.GetAllLazerBuildsAsync())
+                              .ReturnsAsync(new[]
+                              {
+                                  new osu_build { build_id = 1, hash = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, users = 0, version = "2023.1208.0" },
+                                  new osu_build { build_id = 2, hash = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, users = 0, version = "2023.1209.0" }
+                              });
+
+            await trackUser(1, "cafebabe");
+            await trackUser(2, "cafebabe");
+            await trackUser(3, "deadbeef");
+            await trackUser(4, "cafebabe");
+            await trackUser(5, "deadbeef");
+            await trackUser(6, "unknown");
+
+            var updater = new BuildUserCountUpdater(clientStates, databaseFactoryMock.Object)
+            {
+                UpdateInterval = 50
+            };
+            await Task.Delay(100);
+
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 1 && build.users == 3)), Times.AtLeastOnce);
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 2 && build.users == 2)), Times.AtLeastOnce);
+
+            await disconnectUser(3);
+            await disconnectUser(5);
+            await Task.Delay(100);
+
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 2 && build.users == 0)), Times.AtLeastOnce);
+
+            updater.Dispose();
+        }
+
+        private async Task trackUser(int userId, string versionHash)
+        {
+            using (var usage = await clientStates.GetForUse(userId, true))
+                usage.Item = new MetadataClientState(Guid.NewGuid().ToString(), userId, versionHash);
+        }
+
+        private async Task disconnectUser(int userId)
+        {
+            using (var usage = await clientStates.GetForUse(userId))
+                usage.Destroy();
+        }
+    }
+}

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -25,6 +25,8 @@ namespace osu.Server.Spectator
 
         public static string RedisHost { get; }
 
+        public static bool TrackBuildUserCounts { get; set; }
+
         static AppSettings()
         {
             SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
@@ -34,6 +36,8 @@ namespace osu.Server.Spectator
             ReplaysBucket = Environment.GetEnvironmentVariable("REPLAYS_BUCKET") ?? string.Empty;
 
             RedisHost = Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost";
+
+            TrackBuildUserCounts = Environment.GetEnvironmentVariable("TRACK_BUILD_USER_COUNTS") == "1";
         }
     }
 }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -333,6 +334,24 @@ namespace osu.Server.Spectator.Database
             {
                 UserId = userId
             });
+        }
+
+        public async Task<IEnumerable<osu_build>> GetAllLazerBuildsAsync()
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryAsync<osu_build>(
+                "SELECT `build_id`, `version`, `hash`, `users` "
+                + "FROM `osu_builds` `b` "
+                + "JOIN `osu_updates`.`streams` `s` ON `b`.`stream_id` = `s`.`stream_id` "
+                + "WHERE `s`.`name` = 'lazer'");
+        }
+
+        public async Task UpdateBuildUserCountAsync(osu_build build)
+        {
+            var connection = await getConnectionAsync();
+
+            await connection.ExecuteAsync("UPDATE `osu_builds` SET `users` = @users WHERE `build_id` = @build_id", build);
         }
 
         public void Dispose()

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -342,9 +342,8 @@ namespace osu.Server.Spectator.Database
 
             return await connection.QueryAsync<osu_build>(
                 "SELECT `build_id`, `version`, `hash`, `users` "
-                + "FROM `osu_builds` `b` "
-                + "JOIN `osu_updates`.`streams` `s` ON `b`.`stream_id` = `s`.`stream_id` "
-                + "WHERE `s`.`name` = 'lazer'");
+                + "FROM `osu_builds` "
+                + "WHERE stream_id = 7 AND allow_bancho = 1");
         }
 
         public async Task UpdateBuildUserCountAsync(osu_build build)

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using osu.Game.Online.Metadata;
@@ -141,5 +142,15 @@ namespace osu.Server.Spectator.Database
         /// Returns <see langword="true"/> if the user with the supplied <paramref name="userId"/> allows private messages from people not on their friends list.
         /// </summary>
         Task<bool> GetUserAllowsPMs(int userId);
+
+        /// <summary>
+        /// Returns all available builds from the lazer release stream.
+        /// </summary>
+        Task<IEnumerable<osu_build>> GetAllLazerBuildsAsync();
+
+        /// <summary>
+        /// Updates the <see cref="osu_build.users"/> count of a given <paramref name="build"/>.
+        /// </summary>
+        Task UpdateBuildUserCountAsync(osu_build build);
     }
 }

--- a/osu.Server.Spectator/Database/Models/osu_build.cs
+++ b/osu.Server.Spectator/Database/Models/osu_build.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Server.Spectator.Database.Models
+{
+    [Serializable]
+    public class osu_build
+    {
+        public uint build_id { get; set; }
+        public string? version { get; set; }
+        public byte[]? hash { get; set; }
+        public uint users { get; set; }
+    }
+}

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -26,7 +26,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<MetadataBroadcaster>()
                                     .AddSingleton<IScoreStorage, S3ScoreStorage>()
                                     .AddSingleton<ScoreUploader>()
-                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>();
+                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
+                                    .AddSingleton<BuildUserCountUpdater>();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Logging;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Entities;
+
+namespace osu.Server.Spectator.Hubs.Metadata
+{
+    public class BuildUserCountUpdater : IDisposable
+    {
+        /// <summary>
+        /// Amount of time (in milliseconds) between subsequent updates of user counts.
+        /// </summary>
+        public int UpdateInterval = 300_000;
+
+        private readonly EntityStore<MetadataClientState> clientStates;
+        private readonly IDatabaseFactory databaseFactory;
+        private readonly CancellationTokenSource cancellationSource;
+        private readonly Logger logger;
+
+        public BuildUserCountUpdater(
+            EntityStore<MetadataClientState> clientStates,
+            IDatabaseFactory databaseFactory)
+        {
+            this.clientStates = clientStates;
+            this.databaseFactory = databaseFactory;
+
+            cancellationSource = new CancellationTokenSource();
+            logger = Logger.GetLogger(nameof(BuildUserCountUpdater));
+
+            Task.Factory.StartNew(runUpdateLoop, TaskCreationOptions.LongRunning);
+        }
+
+        private void runUpdateLoop()
+        {
+            while (!cancellationSource.IsCancellationRequested)
+            {
+                try
+                {
+                    updateBuildUserCounts().Wait();
+                }
+                catch (Exception ex)
+                {
+                    logger.Add("Failed to update build user counts", LogLevel.Error, ex);
+                }
+
+                Thread.Sleep(UpdateInterval);
+            }
+        }
+
+        private async Task updateBuildUserCounts()
+        {
+            using var db = databaseFactory.GetInstance();
+
+            IEnumerable<osu_build> builds = await db.GetAllLazerBuildsAsync();
+            Dictionary<string, osu_build> buildsByHash = builds.Where(build => build.hash != null)
+                                                               .ToDictionary(build => string.Concat(build.hash!.Select(b => b.ToString("X2"))), StringComparer.OrdinalIgnoreCase);
+
+            Dictionary<string, int> usersByHash = clientStates.GetAllEntities()
+                                                              .Where(kvp => kvp.Value.VersionHash != null)
+                                                              .GroupBy(kvp => kvp.Value.VersionHash!)
+                                                              .ToDictionary(grp => grp.Key, grp => grp.Count());
+
+            foreach (var (hash, count) in usersByHash)
+            {
+                if (buildsByHash.TryGetValue(hash, out var build))
+                {
+                    build.users = (uint)count;
+                    await db.UpdateBuildUserCountAsync(build);
+                }
+                else
+                {
+                    logger.Add($"Unrecognised version hash {hash} reported by {count} clients. Skipping update.");
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationSource.Cancel();
+            cancellationSource.Dispose();
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -57,6 +57,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         private async Task updateBuildUserCounts()
         {
+            if (!AppSettings.TrackBuildUserCounts)
+                return;
+
             using var db = databaseFactory.GetInstance();
 
             IEnumerable<osu_build> builds = await db.GetAllLazerBuildsAsync();

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataClientState.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataClientState.cs
@@ -11,11 +11,12 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         public UserStatus? UserStatus { get; set; }
 
-        // TODO: build hash
+        public string? VersionHash { get; set; }
 
-        public MetadataClientState(in string connectionId, in int userId)
+        public MetadataClientState(in string connectionId, in int userId, in string? versionHash)
             : base(in connectionId, in userId)
         {
+            VersionHash = versionHash;
         }
 
         public UserPresence ToUserPresence() => new UserPresence

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Primitives;
 using osu.Game.Online.Metadata;
 using osu.Game.Users;
 using osu.Server.Spectator.Database;
@@ -34,7 +35,11 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using (var usage = await GetOrCreateLocalUserState())
             {
-                Context.GetHttpContext()?.Request.Headers.TryGetValue("OsuVersionHash", out var versionHash);
+                string? versionHash = null;
+
+                if (Context.GetHttpContext()?.Request.Headers.TryGetValue("OsuVersionHash", out StringValues headerValue) == true)
+                    versionHash = headerValue;
+
                 usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash);
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
             }

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using osu.Game.Online.Metadata;
 using osu.Game.Users;
@@ -33,7 +34,8 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using (var usage = await GetOrCreateLocalUserState())
             {
-                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId());
+                Context.GetHttpContext()?.Request.Headers.TryGetValue("OsuVersionHash", out var versionHash);
+                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash);
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
             }
         }

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -125,6 +125,7 @@ namespace osu.Server.Spectator
 
             app.ApplicationServices.GetRequiredService<MetadataBroadcaster>();
             app.ApplicationServices.GetRequiredService<ScoreUploader>();
+            app.ApplicationServices.GetRequiredService<BuildUserCountUpdater>();
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/202
- Closes https://github.com/ppy/osu-server-spectator/issues/138

No osu!-side changes necessary for this. [The client already sends its version hash to the spectator server on connecting, in headers](https://github.com/ppy/osu/blob/07da9d95a90c330b4bf90e26fb68ee24a2e3e803/osu.Game/Online/HubClientConnector.cs#L72) - the server just hasn't been doing anything with this data thus far.

The tracking is disabled by default, and must be enabled by setting the envvar `TRACK_BUILD_USER_COUNTS` to `1`. I imagine we may want to keep this disabled on dev server just to have less noise there as it's pretty much useless over there.

The user counts are updated every 5 minutes by default.