### PR TITLE
Fix user tracking database logic to match production reality

### DIFF
--- a/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
@@ -30,7 +30,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task TestPeriodicUpdates()
         {
-            databaseAccessMock.Setup(db => db.GetAllLazerBuildsAsync())
+            databaseAccessMock.Setup(db => db.GetAllMainLazerBuildsAsync())
                               .ReturnsAsync(new[]
                               {
                                   new osu_build { build_id = 1, hash = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, users = 0, version = "2023.1208.0" },

--- a/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
@@ -33,15 +33,23 @@ namespace osu.Server.Spectator.Tests
             databaseAccessMock.Setup(db => db.GetAllMainLazerBuildsAsync())
                               .ReturnsAsync(new[]
                               {
-                                  new osu_build { build_id = 1, hash = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, users = 0, version = "2023.1208.0" },
-                                  new osu_build { build_id = 2, hash = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, users = 0, version = "2023.1209.0" }
+                                  new osu_build { build_id = 1, hash = null, version = "2023.1208.0" },
+                                  new osu_build { build_id = 2, hash = null, version = "2023.1209.0" }
+                              });
+            databaseAccessMock.Setup(db => db.GetAllPlatformSpecificLazerBuildsAsync())
+                              .ReturnsAsync(new[]
+                              {
+                                  new osu_build { build_id = 101, hash = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, version = "2023.1208.0-lazer-windows" },
+                                  new osu_build { build_id = 102, hash = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, version = "2023.1208.0-lazer-ios" },
+                                  new osu_build { build_id = 103, hash = new byte[] { 0xC0, 0xC0, 0xC0, 0xC0 }, version = "2023.1209.0-lazer-windows" },
+                                  new osu_build { build_id = 104, hash = new byte[] { 0xFE, 0xDC, 0xBA, 0x98 }, version = "2023.1209.0-lazer-ios" }
                               });
 
-            await trackUser(1, "cafebabe");
-            await trackUser(2, "cafebabe");
-            await trackUser(3, "deadbeef");
-            await trackUser(4, "cafebabe");
-            await trackUser(5, "deadbeef");
+            await trackUser(1, "cafebabe"); // 2023.1208.0-lazer-windows
+            await trackUser(2, "cafebabe"); // 2023.1208.0-lazer-windows
+            await trackUser(3, "c0c0c0c0"); // 2023.1209.0-lazer-windows
+            await trackUser(4, "fedcba98"); // 2023.1209.0-lazer-ios
+            await trackUser(5, "deadbeef"); // 2023.1208.0-lazer-ios
             await trackUser(6, "unknown");
 
             AppSettings.TrackBuildUserCounts = true;
@@ -51,14 +59,14 @@ namespace osu.Server.Spectator.Tests
             };
             await Task.Delay(100);
 
-            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 1 && build.users == 3)), Times.AtLeastOnce);
-            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 2 && build.users == 2)), Times.AtLeastOnce);
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.version == "2023.1208.0" && build.users == 3)), Times.AtLeastOnce);
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.version == "2023.1209.0" && build.users == 2)), Times.AtLeastOnce);
 
             await disconnectUser(3);
-            await disconnectUser(5);
+            await disconnectUser(4);
             await Task.Delay(100);
 
-            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.build_id == 2 && build.users == 0)), Times.AtLeastOnce);
+            databaseAccessMock.Verify(db => db.UpdateBuildUserCountAsync(It.Is<osu_build>(build => build.version == "2023.1209.0" && build.users == 0)), Times.AtLeastOnce);
 
             updater.Dispose();
         }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -336,7 +336,7 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task<IEnumerable<osu_build>> GetAllLazerBuildsAsync()
+        public async Task<IEnumerable<osu_build>> GetAllMainLazerBuildsAsync()
         {
             var connection = await getConnectionAsync();
 
@@ -344,6 +344,16 @@ namespace osu.Server.Spectator.Database
                 "SELECT `build_id`, `version`, `hash`, `users` "
                 + "FROM `osu_builds` "
                 + "WHERE stream_id = 7 AND allow_bancho = 1");
+        }
+
+        public async Task<IEnumerable<osu_build>> GetAllPlatformSpecificLazerBuildsAsync()
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryAsync<osu_build>(
+                "SELECT `build_id`, `version`, `hash`, `users` "
+                + "FROM `osu_builds` "
+                + "WHERE `stream_id` IS NULL AND `version` LIKE '%-lazer-%' AND `allow_bancho` = 1");
         }
 
         public async Task UpdateBuildUserCountAsync(osu_build build)

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -144,9 +144,14 @@ namespace osu.Server.Spectator.Database
         Task<bool> GetUserAllowsPMs(int userId);
 
         /// <summary>
-        /// Returns all available builds from the lazer release stream.
+        /// Returns all available main builds from the lazer release stream.
         /// </summary>
-        Task<IEnumerable<osu_build>> GetAllLazerBuildsAsync();
+        Task<IEnumerable<osu_build>> GetAllMainLazerBuildsAsync();
+
+        /// <summary>
+        /// Returns all known platform-specifc lazer builds.
+        /// </summary>
+        Task<IEnumerable<osu_build>> GetAllPlatformSpecificLazerBuildsAsync();
 
         /// <summary>
         /// Updates the <see cref="osu_build.users"/> count of a given <paramref name="build"/>.

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using var db = databaseFactory.GetInstance();
 
-            IEnumerable<osu_build> builds = await db.GetAllLazerBuildsAsync();
+            IEnumerable<osu_build> builds = await db.GetAllMainLazerBuildsAsync();
             var buildsByHash = builds.Where(build => build.hash != null)
                                      .ToDictionary(build => string.Concat(build.hash!.Select(b => b.ToString("X2"))), StringComparer.OrdinalIgnoreCase);
 

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
@@ -62,35 +63,79 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using var db = databaseFactory.GetInstance();
 
-            IEnumerable<osu_build> builds = await db.GetAllMainLazerBuildsAsync();
-            var buildsByHash = builds.Where(build => build.hash != null)
-                                     .ToDictionary(build => string.Concat(build.hash!.Select(b => b.ToString("X2"))), StringComparer.OrdinalIgnoreCase);
+            var mainBuilds = await db.GetAllMainLazerBuildsAsync();
+            var platformBuilds = await db.GetAllPlatformSpecificLazerBuildsAsync();
+
+            // note that this is not a one-to-one mapping.
+            // a build may be accessible via multiple platform-specific hashes.
+            var buildsByHash = constructHashToBuildMapping(mainBuilds, platformBuilds);
+            var newUserCounts = mainBuilds.ToDictionary(build => build, _ => (uint)0);
 
             var usersByHash = clientStates.GetAllEntities()
                                           .Where(kvp => kvp.Value.VersionHash != null)
                                           .GroupBy(kvp => kvp.Value.VersionHash!)
                                           .ToDictionary(grp => grp.Key, grp => (uint)grp.Count(), StringComparer.OrdinalIgnoreCase);
 
-            // we must loop over all builds as returned by the database,
-            // because if we were to loop by the `usersByHash` dictionary,
-            // it would not be possible for a build's users count to be set to 0 after the last user has disconnected
-            // (because there would be no key-value entry in `usersByHash` in such a scenario).
-            foreach (var (hash, build) in buildsByHash)
+            foreach (var (versionHash, userCount) in usersByHash)
             {
-                uint newUsers = usersByHash.GetValueOrDefault(hash);
+                if (buildsByHash.TryGetValue(versionHash, out var build))
+                    newUserCounts[build] += userCount;
+                else
+                    logger.Add($"Unrecognised version hash {versionHash} reported by {userCount} clients. Skipping update.");
+            }
 
-                // perform the absolute minimal number of updates.
-                if (newUsers != build.users)
+            foreach (var (build, newUserCount) in newUserCounts)
+            {
+                if (build.users != newUserCount)
                 {
-                    build.users = newUsers;
+                    build.users = newUserCount;
                     await db.UpdateBuildUserCountAsync(build);
                 }
             }
+        }
 
-            var unknownHashes = usersByHash.Keys.Except(buildsByHash.Keys, StringComparer.OrdinalIgnoreCase);
+        private static readonly Regex build_version_regex = new Regex(@"(?<version>\d+\.\d+\.\d+)-lazer-.+", RegexOptions.Compiled);
 
-            foreach (string unknownHash in unknownHashes)
-                logger.Add($"Unrecognised version hash {unknownHash} reported by {usersByHash[unknownHash]} clients. Skipping update.");
+        private Dictionary<string, osu_build> constructHashToBuildMapping(IEnumerable<osu_build> mainBuilds, IEnumerable<osu_build> platformBuilds)
+        {
+            var mainBuildsByVersion = mainBuilds.Where(build => build.version != null).ToDictionary(build => build.version!);
+
+            var result = new Dictionary<string, osu_build>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var platformBuild in platformBuilds)
+            {
+                if (platformBuild.hash == null)
+                {
+                    logger.Add($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has no hash");
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(platformBuild.version))
+                {
+                    logger.Add($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has empty version");
+                    continue;
+                }
+
+                var match = build_version_regex.Match(platformBuild.version);
+
+                if (!match.Success)
+                {
+                    logger.Add($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has non-conformant version {platformBuild.version}");
+                    continue;
+                }
+
+                string mainVersion = match.Groups["version"].Value;
+
+                if (!mainBuildsByVersion.TryGetValue(mainVersion, out var mainBuild))
+                {
+                    logger.Add($"Data anomaly during creation of hash-to-build mapping: No parent build found for platform build {platformBuild.build_id} with version {platformBuild.version}");
+                    continue;
+                }
+
+                result.Add(string.Concat(platformBuild.hash!.Select(b => b.ToString("X2"))), mainBuild);
+            }
+
+            return result;
         }
 
         public void Dispose()


### PR DESCRIPTION
Hopefully closes #138 again.

As it turns out, the actual production setup is thus:

- There is a main row for the build, which is shown on the website, has `stream_id` 7 set, and has no hash.
- There are multiple platform-specific rows, one for each platform, not shown on the website (by the virtue of having a null `stream_id`), which have the actual platform-specific hashes.

Thus, in order to report user counts on the main build, the mapping of platform-hash-to-main-build has to be manually reconstructed. This pull attempts to do so.

Note that the reconstruction process is rather cagey and logs everything that may or may not be an issue. This is intentional because the setup is quite rickety; essentially the `version` field of the platform-specific builds is moonlighting as a foreign key, but has to be trimmed to function as one first. Therefore the code tries to precisely exercise the fine print details of this entire rickety setup so that it does not suddenly start doing something idiotic and unintended when data starts to deviate from normal.