### PR TITLE
Stop tracking build user counts when shutting down

### DIFF
--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -29,6 +29,7 @@ namespace osu.Server.Spectator
 
         private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
         private readonly EntityStore<ServerMultiplayerRoom> roomStore;
+        private readonly BuildUserCountUpdater buildUserCountUpdater;
 
         public GracefulShutdownManager(
             EntityStore<ServerMultiplayerRoom> roomStore,
@@ -36,9 +37,11 @@ namespace osu.Server.Spectator
             IHostApplicationLifetime hostApplicationLifetime,
             ScoreUploader scoreUploader,
             EntityStore<ConnectionState> connectionStateStore,
-            EntityStore<MetadataClientState> metadataClientStore)
+            EntityStore<MetadataClientState> metadataClientStore,
+            BuildUserCountUpdater buildUserCountUpdater)
         {
             this.roomStore = roomStore;
+            this.buildUserCountUpdater = buildUserCountUpdater;
 
             dependentStores.Add(roomStore);
             dependentStores.Add(clientStateStore);
@@ -56,6 +59,10 @@ namespace osu.Server.Spectator
         private void shutdownSafely()
         {
             Logger.Log("Server shutdown triggered");
+
+            // stop tracking user counts.
+            // it is presumed that another instance will take over doing so.
+            buildUserCountUpdater.Dispose();
 
             foreach (var store in dependentStores)
                 store.StopAcceptingEntities();

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -23,8 +24,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         private readonly EntityStore<MetadataClientState> clientStates;
         private readonly IDatabaseFactory databaseFactory;
-        private readonly CancellationTokenSource cancellationSource;
         private readonly Logger logger;
+
+        private CancellationTokenSource? cancellationSource;
 
         public BuildUserCountUpdater(
             EntityStore<MetadataClientState> clientStates,
@@ -41,7 +43,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         private void runUpdateLoop()
         {
-            while (!cancellationSource.IsCancellationRequested)
+            while (cancellationSource?.IsCancellationRequested == false)
             {
                 try
                 {
@@ -140,8 +142,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         public void Dispose()
         {
-            cancellationSource.Cancel();
-            cancellationSource.Dispose();
+            cancellationSource?.Cancel();
+            cancellationSource?.Dispose();
+            cancellationSource = null;
         }
     }
 }


### PR DESCRIPTION
As per https://discord.com/channels/188630481301012481/188630652340404224/1186195069062094918

Simplest feasible solution.

I also considered making `BuildCountUserUpdater` implement `IEntityStore` but it's a stretch. It doesn't really track entities, so two out of three members of the interface don't make sense for the class. You could split the one method that does to an interface, but at that point the split-out interface would become a cheap copy of `IDisposable` anyways.

Can be tested via something like the following (probably won't apply directly due to the `REPLAYS_PATH` I have set locally):

```diff
diff --git a/osu.Server.Spectator/GracefulShutdownManager.cs b/osu.Server.Spectator/GracefulShutdownManager.cs
index f75323c..8a06c98 100644
--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Spectator
         // This should probably be configurable in the future.
         // 6 hours is way too long, but set initially to test the whole process out.
         // We can manually override this for immediate shutdown if/when required from a kubernetes or docker level.
-        public static readonly TimeSpan TIME_BEFORE_FORCEFUL_SHUTDOWN = TimeSpan.FromHours(6);
+        public static readonly TimeSpan TIME_BEFORE_FORCEFUL_SHUTDOWN = TimeSpan.FromSeconds(30);
 
         private readonly List<IEntityStore> dependentStores = new List<IEntityStore>();
         private readonly EntityStore<ServerMultiplayerRoom> roomStore;
@@ -82,8 +82,8 @@ namespace osu.Server.Spectator
             {
                 var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
 
-                if (remaining.Sum(s => s.RemainingUsages) == 0)
-                    break;
+                //if (remaining.Sum(s => s.RemainingUsages) == 0)
+                //    break;
 
                 Logger.Log("Waiting for usages of existing entities to finish...");
                 foreach (var r in remaining)
diff --git a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
index 55d072d..ebe2ee7 100644
--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -20,7 +20,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
         /// <summary>
         /// Amount of time (in milliseconds) between subsequent updates of user counts.
         /// </summary>
-        public int UpdateInterval = 300_000;
+        public int UpdateInterval = 1000;
 
         private readonly EntityStore<MetadataClientState> clientStates;
         private readonly IDatabaseFactory databaseFactory;
diff --git a/osu.Server.Spectator/Properties/launchSettings.json b/osu.Server.Spectator/Properties/launchSettings.json
index c3ea1ca..1a3c792 100644
--- a/osu.Server.Spectator/Properties/launchSettings.json
+++ b/osu.Server.Spectator/Properties/launchSettings.json
@@ -17,7 +17,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SAVE_REPLAYS": "1",
-        "REPLAYS_PATH": "/home/dachb/Documents/opensource/osu-web/public/uploads-solo-replay"
+        "REPLAYS_PATH": "/home/dachb/Documents/opensource/osu-web/public/uploads-solo-replay",
+        "TRACK_BUILD_USER_COUNTS": "1"
       }
     }
   }

```