### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install .NET 6.0.x
+      - name: Install .NET 8.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Test
         run: dotnet test

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.114.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.124.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.114.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.124.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/DelegatingMultiplayerClient.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
     /// Used in testing. Delegates calls to one or more <see cref="IMultiplayerClient"/>s.
     /// Note: All members must be virtual!!
     /// </summary>
-    public class DelegatingMultiplayerClient : IMultiplayerClient, IClientProxy
+    public class DelegatingMultiplayerClient : IMultiplayerClient, ISingleClientProxy
     {
         public virtual IEnumerable<IMultiplayerClient> Clients => Enumerable.Empty<IMultiplayerClient>();
 
@@ -144,6 +144,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = new CancellationToken())
         {
             return (Task)GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public)!.Invoke(this, args)!;
+        }
+
+        public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken)
+        {
+            return (Task<T>)GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public)!.Invoke(this, args)!;
         }
 
         public async Task DisconnectRequested()

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -150,7 +150,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Equal(1, room.Playlist.Count);
+                Assert.Single(room.Playlist);
                 Database.Verify(db => db.RemovePlaylistItemAsync(ROOM_ID, 2), Times.Once);
                 Receiver.Verify(client => client.PlaylistItemRemoved(2), Times.Once);
             }
@@ -201,7 +201,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Equal(1, room.Playlist.Count);
+                Assert.Single(room.Playlist);
                 Database.Verify(db => db.RemovePlaylistItemAsync(ROOM_ID, 2), Times.Once);
                 Receiver.Verify(client => client.PlaylistItemRemoved(2), Times.Once);
             }
@@ -256,7 +256,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 var room = usage.Item;
                 Debug.Assert(room != null);
 
-                Assert.Equal(1, room.Playlist.Count);
+                Assert.Single(room.Playlist);
                 Assert.Equal(2, room.Settings.PlaylistItemId);
                 Database.Verify(db => db.RemovePlaylistItemAsync(ROOM_ID, 1), Times.Once);
                 Receiver.Verify(client => client.PlaylistItemRemoved(1), Times.Once);

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -105,9 +105,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             var hubContext = new Mock<IHubContext<MultiplayerHub>>();
             hubContext.Setup(ctx => ctx.Groups).Returns(Groups.Object);
-            hubContext.Setup(ctx => ctx.Clients.Client(It.IsAny<string>())).Returns<string>(connectionId => (IClientProxy)Clients.Object.Client(connectionId));
-            hubContext.Setup(ctx => ctx.Clients.Group(It.IsAny<string>())).Returns<string>(groupName => (IClientProxy)Clients.Object.Group(groupName));
-            hubContext.Setup(ctx => ctx.Clients.All).Returns((IClientProxy)Clients.Object.All);
+            hubContext.Setup(ctx => ctx.Clients.Client(It.IsAny<string>())).Returns<string>(connectionId => (ISingleClientProxy)Clients.Object.Client(connectionId));
+            hubContext.Setup(ctx => ctx.Clients.Group(It.IsAny<string>())).Returns<string>(groupName => (ISingleClientProxy)Clients.Object.Group(groupName));
+            hubContext.Setup(ctx => ctx.Clients.All).Returns((ISingleClientProxy)Clients.Object.All);
 
             Groups.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                   .Callback<string, string, CancellationToken>((connectionId, groupId, _) =>

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.6.6" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Database
             }) != 0;
         }
 
-        public async Task<multiplayer_room> GetRoomAsync(long roomId)
+        public async Task<multiplayer_room?> GetRoomAsync(long roomId)
         {
             var connection = await getConnectionAsync();
 

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -33,7 +33,7 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Returns the <see cref="multiplayer_room"/> with the given <paramref name="roomId"/>.
         /// </summary>
-        Task<multiplayer_room> GetRoomAsync(long roomId);
+        Task<multiplayer_room?> GetRoomAsync(long roomId);
 
         /// <summary>
         /// Retrieves a beatmap corresponding to the given <paramref name="beatmapId"/>.

--- a/osu.Server.Spectator/Dockerfile
+++ b/osu.Server.Spectator/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,7 +13,7 @@ RUN dotnet publish -c Release -o out
 RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "osu.Server.Spectator.dll"]

--- a/osu.Server.Spectator/StartupDevelopment.cs
+++ b/osu.Server.Spectator/StartupDevelopment.cs
@@ -35,8 +35,8 @@ namespace osu.Server.Spectator
 
         public LocalAuthenticationHandler(
             IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger,
-            UrlEncoder encoder, ISystemClock clock)
-            : base(options, logger, encoder, clock)
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
         {
         }
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,22 +6,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.104.27" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.305.17" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
-        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Dapper" Version="2.1.28" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.12" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.114.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.114.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.114.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.114.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.114.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.124.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
+        <PackageReference Include="Sentry.AspNetCore" Version="3.41.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The majority of the overhead we're seeing is system%, in sockets and native code. Hardly any of what we are doing is causing overhead. Given the amount of optimisation done between net6 and net8, this should give us some headroom.

Willing to take a gamble on this one under the premise that we can rollback if required. Will test on staging for efficiency.

https://github.com/dotnet/AspNetCore.Docs/issues/17880