### PR TITLE
Reduce exceptions

### DIFF
--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -103,7 +103,7 @@ namespace osu.Server.Spectator
                 bool connectionIsValid = tokenIdMatches && hubRegistered && connectionIdMatches;
 
                 if (!connectionIsValid)
-                    throw new InvalidStateException("State is not valid for this connection");
+                    throw new InvalidStateException($"State is not valid for this connection, context: {LoggingHubFilter.GetMethodCallDisplayString(invocationContext)})");
             }
 
             return await next(invocationContext);

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -60,8 +60,11 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 clientState.State = state;
                 clientState.ScoreToken = scoreToken;
 
-                if (state.RulesetID == null) throw new ArgumentNullException(nameof(state.RulesetID));
-                if (state.BeatmapID == null) throw new ArgumentNullException(nameof(state.BeatmapID));
+                if (state.RulesetID == null)
+                    return;
+
+                if (state.BeatmapID == null)
+                    return;
 
                 using (var db = databaseFactory.GetInstance())
                 {
@@ -72,7 +75,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
                         throw new ArgumentException(nameof(username));
 
                     if (string.IsNullOrEmpty(beatmap?.checksum))
-                        throw new ArgumentException(nameof(state.BeatmapID));
+                        return;
 
                     clientState.Score = new Score
                     {

--- a/osu.Server.Spectator/LoggingHubFilter.cs
+++ b/osu.Server.Spectator/LoggingHubFilter.cs
@@ -25,13 +25,13 @@ namespace osu.Server.Spectator
             try
             {
                 if (DebugUtils.IsDebugBuild)
-                    logTarget.Log($"Invoking hub method: {getMethodCallDisplayString(invocationContext)}", LogLevel.Debug);
+                    logTarget.Log($"Invoking hub method: {GetMethodCallDisplayString(invocationContext)}", LogLevel.Debug);
 
                 return await next(invocationContext);
             }
             catch (Exception e)
             {
-                logTarget.Error($"Failed to invoke hub method: {getMethodCallDisplayString(invocationContext)}", e);
+                logTarget.Error($"Failed to invoke hub method: {GetMethodCallDisplayString(invocationContext)}", e);
                 throw;
             }
         }
@@ -68,7 +68,7 @@ namespace osu.Server.Spectator
             }
         }
 
-        private static string getMethodCallDisplayString(HubInvocationContext invocationContext)
+        public static string GetMethodCallDisplayString(HubInvocationContext invocationContext)
         {
             var methodCall = $"{invocationContext.HubMethodName}({string.Join(", ", invocationContext.HubMethodArguments.Select(getReadableString))})";
             return methodCall;

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -41,7 +42,7 @@ namespace osu.Server.Spectator
                        {
                            webBuilder.UseSentry(o =>
                            {
-                               o.AddExceptionFilterForType<ServerShuttingDownException>();
+                               o.AddExceptionFilterForType<HubException>();
                                o.TracesSampleRate = 0.01;
 #if !DEBUG
                                o.Dsn = "https://775dc89c1c3142e8a8fa5fd10590f443@sentry.ppy.sh/8";


### PR DESCRIPTION
Should reduce some of the load on Sentry. `HubException`s are generally (at least in the way we use them) intended for messaging to the client, usually via `InvalidStateException`.

I've also added some basic logging to the concurrency limiter so we can scope down the issue.