### PR TITLE
Unify logging to use ASP.NET default console logger

### DIFF
--- a/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/BuildUserCountUpdaterTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
@@ -17,6 +18,7 @@ namespace osu.Server.Spectator.Tests
         private readonly EntityStore<MetadataClientState> clientStates;
         private readonly Mock<IDatabaseFactory> databaseFactoryMock;
         private readonly Mock<IDatabaseAccess> databaseAccessMock;
+        private readonly Mock<ILoggerFactory> loggerFactoryMock;
 
         public BuildUserCountUpdaterTest()
         {
@@ -24,6 +26,9 @@ namespace osu.Server.Spectator.Tests
 
             databaseFactoryMock = new Mock<IDatabaseFactory>();
             databaseAccessMock = new Mock<IDatabaseAccess>();
+            loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
             databaseFactoryMock.Setup(df => df.GetInstance()).Returns(databaseAccessMock.Object);
         }
 
@@ -53,7 +58,7 @@ namespace osu.Server.Spectator.Tests
             await trackUser(6, "unknown");
 
             AppSettings.TrackBuildUserCounts = true;
-            var updater = new BuildUserCountUpdater(clientStates, databaseFactoryMock.Object)
+            var updater = new BuildUserCountUpdater(clientStates, databaseFactoryMock.Object, loggerFactoryMock.Object)
             {
                 UpdateInterval = 50
             };

--- a/osu.Server.Spectator.Tests/ConcurrentConnectionLimiterTests.cs
+++ b/osu.Server.Spectator.Tests/ConcurrentConnectionLimiterTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
@@ -18,6 +19,7 @@ namespace osu.Server.Spectator.Tests
     {
         private readonly EntityStore<ConnectionState> connectionStates;
         private readonly Mock<IServiceProvider> serviceProviderMock;
+        private readonly Mock<ILoggerFactory> loggerFactoryMock;
         private readonly Mock<Hub> hubMock;
 
         public ConcurrentConnectionLimiterTests()
@@ -28,6 +30,10 @@ namespace osu.Server.Spectator.Tests
             var hubContextMock = new Mock<IHubContext>();
             serviceProviderMock.Setup(sp => sp.GetService(It.IsAny<Type>()))
                                .Returns(hubContextMock.Object);
+
+            loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
 
             hubMock = new Mock<Hub>();
         }
@@ -45,7 +51,7 @@ namespace osu.Server.Spectator.Tests
                 })
             }));
 
-            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object, loggerFactoryMock.Object);
             var lifetimeContext = new HubLifetimeContext(hubCallerContextMock.Object, serviceProviderMock.Object, hubMock.Object);
 
             bool connected = false;
@@ -104,7 +110,7 @@ namespace osu.Server.Spectator.Tests
                 })
             }));
 
-            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object, loggerFactoryMock.Object);
 
             var firstLifetimeContext = new HubLifetimeContext(firstContextMock.Object, serviceProviderMock.Object, hubMock.Object);
             await filter.OnConnectedAsync(firstLifetimeContext, _ => Task.CompletedTask);
@@ -150,7 +156,7 @@ namespace osu.Server.Spectator.Tests
                 })
             }));
 
-            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object, loggerFactoryMock.Object);
 
             var firstLifetimeContext = new HubLifetimeContext(firstContextMock.Object, serviceProviderMock.Object, hubMock.Object);
             await filter.OnConnectedAsync(firstLifetimeContext, _ => Task.CompletedTask);
@@ -190,7 +196,7 @@ namespace osu.Server.Spectator.Tests
                 })
             }));
 
-            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object);
+            var filter = new ConcurrentConnectionLimiter(connectionStates, serviceProviderMock.Object, loggerFactoryMock.Object);
 
             var firstLifetimeContext = new HubLifetimeContext(firstContextMock.Object, serviceProviderMock.Object, new FirstHub());
             await filter.OnConnectedAsync(firstLifetimeContext, _ => Task.CompletedTask);

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Online.Metadata;
 using osu.Game.Users;
@@ -36,8 +37,11 @@ namespace osu.Server.Spectator.Tests
             var mockDatabase = new Mock<IDatabaseAccess>();
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
 
-            hub = new MetadataHub(cache, userStates, databaseFactory.Object);
+            hub = new MetadataHub(loggerFactoryMock.Object, cache, userStates, databaseFactory.Object);
 
             var mockContext = new Mock<HubCallerContext>();
             mockContext.Setup(ctx => ctx.UserIdentifier).Returns(user_id.ToString());

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
@@ -128,7 +129,11 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID_2))).Returns(Receiver2.Object);
             Clients.Setup(client => client.Caller).Returns(Caller.Object);
 
-            Hub = new TestMultiplayerHub(new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())), Rooms, UserStates, DatabaseFactory.Object, hubContext.Object);
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
+
+            Hub = new TestMultiplayerHub(loggerFactoryMock.Object, new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())), Rooms, UserStates, DatabaseFactory.Object, hubContext.Object);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;
 

--- a/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs.Multiplayer;
@@ -13,9 +14,14 @@ namespace osu.Server.Spectator.Tests.Multiplayer
     {
         public new MultiplayerHubContext HubContext => base.HubContext;
 
-        public TestMultiplayerHub(IDistributedCache cache, EntityStore<ServerMultiplayerRoom> rooms, EntityStore<MultiplayerClientState> users, IDatabaseFactory databaseFactory,
-                                  IHubContext<MultiplayerHub> hubContext)
-            : base(cache, rooms, users, databaseFactory, hubContext)
+        public TestMultiplayerHub(
+            ILoggerFactory loggerFactory,
+            IDistributedCache cache,
+            EntityStore<ServerMultiplayerRoom> rooms,
+            EntityStore<MultiplayerClientState> users,
+            IDatabaseFactory databaseFactory,
+            IHubContext<MultiplayerHub> hubContext)
+            : base(loggerFactory, cache, rooms, users, databaseFactory, hubContext)
         {
         }
 

--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Scoring;
@@ -33,8 +34,12 @@ namespace osu.Server.Spectator.Tests
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
 
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
+
             mockStorage = new Mock<IScoreStorage>();
-            uploader = new ScoreUploader(databaseFactory.Object, mockStorage.Object);
+            uploader = new ScoreUploader(loggerFactoryMock.Object, databaseFactory.Object, mockStorage.Object);
             uploader.UploadInterval = 1000; // Set a high timer interval for testing purposes.
         }
 

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -67,7 +67,7 @@ namespace osu.Server.Spectator.Tests
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
 
             mockScoreStorage = new Mock<IScoreStorage>();
-            scoreUploader = new ScoreUploader(databaseFactory.Object, mockScoreStorage.Object);
+            scoreUploader = new ScoreUploader(loggerFactoryMock.Object, databaseFactory.Object, mockScoreStorage.Object);
 
             var mockScoreProcessedSubscriber = new Mock<IScoreProcessedSubscriber>();
 

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
@@ -43,6 +44,10 @@ namespace osu.Server.Spectator.Tests
 
         public SpectatorHubTest()
         {
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
+
             // not used for now, but left here for potential future usage.
             MemoryDistributedCache cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
 
@@ -66,7 +71,7 @@ namespace osu.Server.Spectator.Tests
 
             var mockScoreProcessedSubscriber = new Mock<IScoreProcessedSubscriber>();
 
-            hub = new SpectatorHub(cache, clientStates, databaseFactory.Object, scoreUploader, mockScoreProcessedSubscriber.Object);
+            hub = new SpectatorHub(loggerFactoryMock.Object, cache, clientStates, databaseFactory.Object, scoreUploader, mockScoreProcessedSubscriber.Object);
         }
 
         [Fact]

--- a/osu.Server.Spectator/Authentication/ConfigureJwtBearerOptions.cs
+++ b/osu.Server.Spectator/Authentication/ConfigureJwtBearerOptions.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -17,10 +18,12 @@ namespace osu.Server.Spectator.Authentication
     public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions>
     {
         private readonly IDatabaseFactory databaseFactory;
+        private readonly ILoggerFactory loggerFactory;
 
-        public ConfigureJwtBearerOptions(IDatabaseFactory databaseFactory)
+        public ConfigureJwtBearerOptions(IDatabaseFactory databaseFactory, ILoggerFactory loggerFactory)
         {
             this.databaseFactory = databaseFactory;
+            this.loggerFactory = loggerFactory;
         }
 
         public void Configure(JwtBearerOptions options)
@@ -50,7 +53,7 @@ namespace osu.Server.Spectator.Authentication
 
                         if (userId != tokenUserId)
                         {
-                            Console.WriteLine("Token revoked or expired");
+                            loggerFactory.CreateLogger("JsonWebToken").LogInformation("Token revoked or expired");
                             context.Fail("Token has expired or been revoked");
                         }
                     }

--- a/osu.Server.Spectator/CodeAnalysis/BannedSymbols.txt
+++ b/osu.Server.Spectator/CodeAnalysis/BannedSymbols.txt
@@ -1,1 +1,2 @@
 T:osu.Framework.Logging.Logger;Don't use osu!framework logger. Use Microsoft.Extensions.Logging.ILogger instead through DI.
+T:System.Console;Don't use Console for logging. Use Microsoft.Extensions.Logging.ILogger instead through DI.

--- a/osu.Server.Spectator/CodeAnalysis/BannedSymbols.txt
+++ b/osu.Server.Spectator/CodeAnalysis/BannedSymbols.txt
@@ -1,0 +1,1 @@
+T:osu.Framework.Logging.Logger;Don't use osu!framework logger. Use Microsoft.Extensions.Logging.ILogger instead through DI.

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Framework.Logging;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
@@ -22,16 +22,19 @@ namespace osu.Server.Spectator
         private readonly EntityStore<ConnectionState> connectionStates;
 
         private readonly IServiceProvider serviceProvider;
+        private readonly ILogger logger;
 
         private static readonly IEnumerable<Type> stateful_user_hubs
             = typeof(IStatefulUserHub).Assembly.GetTypes().Where(type => typeof(IStatefulUserHub).IsAssignableFrom(type) && typeof(Hub).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract).ToArray();
 
         public ConcurrentConnectionLimiter(
             EntityStore<ConnectionState> connectionStates,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            ILoggerFactory loggerFactory)
         {
             this.connectionStates = connectionStates;
             this.serviceProvider = serviceProvider;
+            logger = loggerFactory.CreateLogger(nameof(ConcurrentConnectionLimiter));
         }
 
         public async Task OnConnectedAsync(HubLifetimeContext context, Func<HubLifetimeContext, Task> next)
@@ -84,8 +87,8 @@ namespace osu.Server.Spectator
             }
         }
 
-        private static void log(HubLifetimeContext context, string message)
-            => Logger.Log($"[user:{context.Context.GetUserId()}] [connection:{context.Context.ConnectionId}] [hub:{context.Hub.GetType().ReadableName()}] {message}");
+        private void log(HubLifetimeContext context, string message)
+            => logger.LogInformation($"[user:{context.Context.GetUserId()}] [connection:{context.Context.ConnectionId}] [hub:{context.Hub.GetType().ReadableName()}] {message}");
 
         public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
         {

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -88,7 +88,11 @@ namespace osu.Server.Spectator
         }
 
         private void log(HubLifetimeContext context, string message)
-            => logger.LogInformation($"[user:{context.Context.GetUserId()}] [connection:{context.Context.ConnectionId}] [hub:{context.Hub.GetType().ReadableName()}] {message}");
+            => logger.LogInformation("[user:{user}] [connection:{connection}] [hub:{hub}] {message}",
+                context.Context.GetUserId(),
+                context.Context.ConnectionId,
+                context.Hub.GetType().ReadableName(),
+                message);
 
         public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
         {

--- a/osu.Server.Spectator/GracefulShutdownManager.cs
+++ b/osu.Server.Spectator/GracefulShutdownManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -81,6 +82,8 @@ namespace osu.Server.Spectator
             TimeSpan timeWaited = new TimeSpan();
             TimeSpan timeBetweenChecks = TimeSpan.FromSeconds(10);
 
+            var stringBuilder = new StringBuilder();
+
             while (timeWaited < TIME_BEFORE_FORCEFUL_SHUTDOWN)
             {
                 var remaining = dependentStores.Select(store => (store.EntityName, store.RemainingUsages));
@@ -88,9 +91,11 @@ namespace osu.Server.Spectator
                 if (remaining.Sum(s => s.RemainingUsages) == 0)
                     break;
 
-                logger.LogInformation("Waiting for usages of existing entities to finish...");
+                stringBuilder.Clear();
+                stringBuilder.AppendLine("Waiting for usages of existing entities to finish...");
                 foreach (var r in remaining)
-                    logger.LogInformation($"{r.EntityName,10}: {r.RemainingUsages}");
+                    stringBuilder.AppendLine($"{r.EntityName,10}: {r.RemainingUsages}");
+                logger.LogInformation(stringBuilder.ToString());
 
                 Thread.Sleep(timeBetweenChecks);
                 timeWaited = timeWaited.Add(timeBetweenChecks);

--- a/osu.Server.Spectator/Hubs/ILogTarget.cs
+++ b/osu.Server.Spectator/Hubs/ILogTarget.cs
@@ -2,13 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace osu.Server.Spectator.Hubs
 {
     internal interface ILogTarget
     {
-        void Log(string message, LogLevel logLevel = LogLevel.Verbose);
+        void Log(string message, LogLevel logLevel = LogLevel.Information);
 
         void Error(string message, Exception exception);
     }

--- a/osu.Server.Spectator/Hubs/LoggingHub.cs
+++ b/osu.Server.Spectator/Hubs/LoggingHub.cs
@@ -43,9 +43,13 @@ namespace osu.Server.Spectator.Hubs
             await base.OnDisconnectedAsync(exception);
         }
 
-        protected void Log(string message, LogLevel logLevel = LogLevel.Information) => logger.Log(logLevel, $"[user:{getLoggableUserIdentifier()}] {message.Trim()}");
+        protected void Log(string message, LogLevel logLevel = LogLevel.Information) => logger.Log(logLevel, "[user:{userId}] {message}",
+            getLoggableUserIdentifier(),
+            message.Trim());
 
-        protected void Error(string message, Exception exception) => logger.LogError(exception, $"[user:{getLoggableUserIdentifier()}] {message.Trim()}");
+        protected void Error(string message, Exception exception) => logger.LogError(exception, "[user:{userId}] {message)}",
+            getLoggableUserIdentifier(),
+            message.Trim());
 
         private string getLoggableUserIdentifier() => Context.UserIdentifier ?? "???";
 

--- a/osu.Server.Spectator/Hubs/LoggingHub.cs
+++ b/osu.Server.Spectator/Hubs/LoggingHub.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using osu.Framework.Logging;
+using Microsoft.Extensions.Logging;
 using Sentry;
 using StatsdClient;
 
@@ -16,16 +16,16 @@ namespace osu.Server.Spectator.Hubs
     {
         protected string Name;
 
-        private readonly Logger logger;
+        private readonly ILogger logger;
 
         // ReSharper disable once StaticMemberInGenericType
         private static int totalConnected;
 
-        public LoggingHub()
+        public LoggingHub(ILoggerFactory loggerFactory)
         {
             Name = GetType().Name.Replace("Hub", string.Empty);
 
-            logger = Logger.GetLogger(Name);
+            logger = loggerFactory.CreateLogger(Name);
         }
 
         public override async Task OnConnectedAsync()
@@ -43,9 +43,9 @@ namespace osu.Server.Spectator.Hubs
             await base.OnDisconnectedAsync(exception);
         }
 
-        protected void Log(string message, LogLevel logLevel = LogLevel.Verbose) => logger.Add($"[user:{getLoggableUserIdentifier()}] {message.Trim()}", logLevel);
+        protected void Log(string message, LogLevel logLevel = LogLevel.Information) => logger.Log(logLevel, $"[user:{getLoggableUserIdentifier()}] {message.Trim()}");
 
-        protected void Error(string message, Exception exception) => logger.Add($"[user:{getLoggableUserIdentifier()}] {message.Trim()}", LogLevel.Error, exception);
+        protected void Error(string message, Exception exception) => logger.LogError(exception, $"[user:{getLoggableUserIdentifier()}] {message.Trim()}");
 
         private string getLoggableUserIdentifier() => Context.UserIdentifier ?? "???";
 

--- a/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/BuildUserCountUpdater.cs
@@ -83,7 +83,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
                 if (buildsByHash.TryGetValue(versionHash, out var build))
                     newUserCounts[build] += userCount;
                 else
-                    logger.LogInformation($"Unrecognised version hash {versionHash} reported by {userCount} clients. Skipping update.");
+                    logger.LogInformation("Unrecognised version hash {versionHash} reported by {userCount} clients. Skipping update.", versionHash, userCount);
             }
 
             foreach (var (build, newUserCount) in newUserCounts)
@@ -108,13 +108,13 @@ namespace osu.Server.Spectator.Hubs.Metadata
             {
                 if (platformBuild.hash == null)
                 {
-                    logger.LogInformation($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has no hash");
+                    logger.LogInformation("Data anomaly during creation of hash-to-build mapping: Platform build {buildId} has no hash", platformBuild.build_id);
                     continue;
                 }
 
                 if (string.IsNullOrEmpty(platformBuild.version))
                 {
-                    logger.LogInformation($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has empty version");
+                    logger.LogInformation("Data anomaly during creation of hash-to-build mapping: Platform build {buildId} has empty version", platformBuild.build_id);
                     continue;
                 }
 
@@ -122,7 +122,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
                 if (!match.Success)
                 {
-                    logger.LogInformation($"Data anomaly during creation of hash-to-build mapping: Platform build {platformBuild.build_id} has non-conformant version {platformBuild.version}");
+                    logger.LogInformation("Data anomaly during creation of hash-to-build mapping: Platform build {buildId} has non-conformant version {version}",
+                        platformBuild.build_id,
+                        platformBuild.version);
                     continue;
                 }
 
@@ -130,7 +132,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
                 if (!mainBuildsByVersion.TryGetValue(mainVersion, out var mainBuild))
                 {
-                    logger.LogInformation($"Data anomaly during creation of hash-to-build mapping: No parent build found for platform build {platformBuild.build_id} with version {platformBuild.version}");
+                    logger.LogInformation("Data anomaly during creation of hash-to-build mapping: No parent build found for platform build {buildId} with version {version}",
+                        platformBuild.build_id,
+                        platformBuild.version);
                     continue;
                 }
 

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataBroadcaster.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataBroadcaster.cs
@@ -56,11 +56,11 @@ namespace osu.Server.Spectator.Hubs.Metadata
                     var updates = await db.GetUpdatedBeatmapSets(lastQueueId);
 
                     lastQueueId = updates.LastProcessedQueueID;
-                    logger.LogInformation($"Polled beatmap changes up to last queue id {updates.LastProcessedQueueID}");
+                    logger.LogInformation("Polled beatmap changes up to last queue id {lastProcessedQueueID}", updates.LastProcessedQueueID);
 
                     if (updates.BeatmapSetIDs.Any())
                     {
-                        logger.LogInformation($"Broadcasting new beatmaps to client: {string.Join(',', updates.BeatmapSetIDs.Select(i => i.ToString()))}");
+                        logger.LogInformation("Broadcasting new beatmaps to client: {beatmapIds}", string.Join(',', updates.BeatmapSetIDs.Select(i => i.ToString())));
                         await metadataHubContext.Clients.All.SendAsync(nameof(IMetadataClient.BeatmapSetsUpdated), updates, cancellationToken: timerCancellationToken);
                     }
                 }

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Logging;
 using osu.Game.Online.Metadata;
 using osu.Game.Users;
 using osu.Server.Spectator.Database;
@@ -21,10 +22,11 @@ namespace osu.Server.Spectator.Hubs.Metadata
         internal const string ONLINE_PRESENCE_WATCHERS_GROUP = "metadata:online-presence-watchers";
 
         public MetadataHub(
+            ILoggerFactory loggerFactory,
             IDistributedCache cache,
             EntityStore<MetadataClientState> userStates,
             IDatabaseFactory databaseFactory)
-            : base(cache, userStates)
+            : base(loggerFactory, cache, userStates)
         {
             this.databaseFactory = databaseFactory;
         }

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using osu.Framework.Logging;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
@@ -26,13 +26,18 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         protected readonly MultiplayerHubContext HubContext;
         private readonly IDatabaseFactory databaseFactory;
 
-        public MultiplayerHub(IDistributedCache cache, EntityStore<ServerMultiplayerRoom> rooms, EntityStore<MultiplayerClientState> users, IDatabaseFactory databaseFactory,
-                              IHubContext<MultiplayerHub> hubContext)
-            : base(cache, users)
+        public MultiplayerHub(
+            ILoggerFactory loggerFactory,
+            IDistributedCache cache,
+            EntityStore<ServerMultiplayerRoom> rooms,
+            EntityStore<MultiplayerClientState> users,
+            IDatabaseFactory databaseFactory,
+            IHubContext<MultiplayerHub> hubContext)
+            : base(loggerFactory, cache, users)
         {
             Rooms = rooms;
             this.databaseFactory = databaseFactory;
-            HubContext = new MultiplayerHubContext(hubContext, rooms, users);
+            HubContext = new MultiplayerHubContext( hubContext, rooms, users, loggerFactory);
         }
 
         public Task<MultiplayerRoom> JoinRoom(long roomId) => JoinRoomWithPassword(roomId, string.Empty);
@@ -932,6 +937,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         internal Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId) => Rooms.GetForUse(roomId);
 
-        protected void Log(ServerMultiplayerRoom room, string message, LogLevel logLevel = LogLevel.Verbose) => base.Log($"[room:{room.RoomID}] {message}", logLevel);
+        protected void Log(ServerMultiplayerRoom room, string message, LogLevel logLevel = LogLevel.Information) => base.Log($"[room:{room.RoomID}] {message}", logLevel);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
@@ -234,12 +234,17 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         private void log(ServerMultiplayerRoom room, MultiplayerRoomUser? user, string message, LogLevel logLevel = LogLevel.Information)
         {
-            logger.Log(logLevel, $"[user:{getLoggableUserIdentifier(user)}] [room:{room.RoomID}] {message.Trim()}");
+            logger.Log(logLevel, "[user:{userId}] [room:{roomID}] {message}",
+                getLoggableUserIdentifier(user),
+                room.RoomID,
+                message.Trim());
         }
 
         private void error(MultiplayerRoomUser? user, string message, Exception exception)
         {
-            logger.LogError(exception, $"[user:{getLoggableUserIdentifier(user)}] {message.Trim()}");
+            logger.LogError(exception, "[user:{userId}] {message}",
+                getLoggableUserIdentifier(user),
+                message.Trim());
         }
 
         private string getLoggableUserIdentifier(MultiplayerRoomUser? user)

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -107,7 +107,7 @@ namespace osu.Server.Spectator.Hubs
                         {
                             if (dbScore == null)
                             {
-                                logger.LogInformation($"Score upload timed out for token: {item.Token}");
+                                logger.LogInformation("Score upload timed out for token: {tokenId}", item.Token);
                                 return;
                             }
 

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using osu.Game.Scoring;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
@@ -26,14 +27,16 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         public double TimeoutInterval = 30000;
 
+        private readonly ILogger logger;
         private readonly ConcurrentQueue<UploadItem> queue = new ConcurrentQueue<UploadItem>();
         private readonly IDatabaseFactory databaseFactory;
         private readonly IScoreStorage scoreStorage;
         private readonly CancellationTokenSource cancellationSource;
         private readonly CancellationToken cancellationToken;
 
-        public ScoreUploader(IDatabaseFactory databaseFactory, IScoreStorage scoreStorage)
+        public ScoreUploader(ILoggerFactory loggerFactory, IDatabaseFactory databaseFactory, IScoreStorage scoreStorage)
         {
+            logger = loggerFactory.CreateLogger(nameof(ScoreUploader));
             this.databaseFactory = databaseFactory;
             this.scoreStorage = scoreStorage;
 
@@ -104,7 +107,7 @@ namespace osu.Server.Spectator.Hubs
                         {
                             if (dbScore == null)
                             {
-                                Console.WriteLine($"Score upload timed out for token: {item.Token}");
+                                logger.LogInformation($"Score upload timed out for token: {item.Token}");
                                 return;
                             }
 
@@ -127,7 +130,7 @@ namespace osu.Server.Spectator.Hubs
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Error during score upload: {e}");
+                logger.LogError(e, $"Error during score upload");
             }
         }
 

--- a/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
@@ -111,7 +111,10 @@ namespace osu.Server.Spectator.Hubs.Spectator
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, $"Failed to register connection {receiverConnectionId} for info about score {userId}:{scoreToken}");
+                logger.LogError(ex, "Failed to register connection {receiverConnectionId} for info about score {userId}:{scoreToken}",
+                    receiverConnectionId,
+                    userId,
+                    scoreToken);
                 DogStatsd.Increment($"{statsd_prefix}.subscriptions.failed");
             }
         }

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
@@ -33,12 +34,13 @@ namespace osu.Server.Spectator.Hubs.Spectator
         private readonly IScoreProcessedSubscriber scoreProcessedSubscriber;
 
         public SpectatorHub(
+            ILoggerFactory loggerFactory,
             IDistributedCache cache,
             EntityStore<SpectatorClientState> users,
             IDatabaseFactory databaseFactory,
             ScoreUploader scoreUploader,
             IScoreProcessedSubscriber scoreProcessedSubscriber)
-            : base(cache, users)
+            : base(loggerFactory, cache, users)
         {
             this.databaseFactory = databaseFactory;
             this.scoreUploader = scoreUploader;

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Entities;
@@ -22,7 +23,11 @@ namespace osu.Server.Spectator.Hubs
     {
         protected readonly EntityStore<TUserState> UserStates;
 
-        protected StatefulUserHub(IDistributedCache cache, EntityStore<TUserState> userStates)
+        protected StatefulUserHub(
+            ILoggerFactory loggerFactory,
+            IDistributedCache cache,
+            EntityStore<TUserState> userStates)
+            : base(loggerFactory)
         {
             UserStates = userStates;
         }

--- a/osu.Server.Spectator/LoggingHubFilter.cs
+++ b/osu.Server.Spectator/LoggingHubFilter.cs
@@ -6,8 +6,8 @@ using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using osu.Framework.Development;
-using osu.Framework.Logging;
 using osu.Server.Spectator.Hubs;
 
 namespace osu.Server.Spectator

--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -2,13 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.IO;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
-using osu.Framework.Logging;
-using osu.Framework.Platform;
 using Sentry;
 using StatsdClient;
 
@@ -18,9 +15,6 @@ namespace osu.Server.Spectator
     {
         public static void Main(string[] args)
         {
-            Logger.GameIdentifier = "osu-server-spectator";
-            Logger.Storage = new NativeStorage(Path.Combine(Environment.CurrentDirectory, "Logs"));
-
             DogStatsd.Configure(new StatsdConfig
             {
                 StatsdServerName = AppSettings.DataDogAgentHost,

--- a/osu.Server.Spectator/Storage/FileScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/FileScoreStorage.cs
@@ -24,7 +24,9 @@ namespace osu.Server.Spectator.Storage
 
             string filename = score.ScoreInfo.OnlineID.ToString();
 
-            logger.LogInformation($"Writing replay for score {score.ScoreInfo.OnlineID} to {filename}");
+            logger.LogInformation("Writing replay for score {scoreId} to {filename}",
+                score.ScoreInfo.OnlineID,
+                filename);
 
             using (var outStream = File.Create(Path.Combine(AppSettings.ReplaysPath, filename)))
                 legacyEncoder.Encode(outStream);

--- a/osu.Server.Spectator/Storage/FileScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/FileScoreStorage.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 
@@ -11,13 +11,20 @@ namespace osu.Server.Spectator.Storage
 {
     public class FileScoreStorage : IScoreStorage
     {
+        private readonly ILogger logger;
+
+        public FileScoreStorage(ILoggerFactory loggerFactory)
+        {
+            logger = loggerFactory.CreateLogger(nameof(FileScoreStorage));
+        }
+
         public Task WriteAsync(Score score)
         {
             var legacyEncoder = new LegacyScoreEncoder(score, null);
 
             string filename = score.ScoreInfo.OnlineID.ToString();
 
-            Console.WriteLine($"Writing replay for score {score.ScoreInfo.OnlineID} to {filename}");
+            logger.LogInformation($"Writing replay for score {score.ScoreInfo.OnlineID} to {filename}");
 
             using (var outStream = File.Create(Path.Combine(AppSettings.ReplaysPath, filename)))
                 legacyEncoder.Encode(outStream);

--- a/osu.Server.Spectator/Storage/S3ScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/S3ScoreStorage.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 
@@ -12,6 +12,13 @@ namespace osu.Server.Spectator.Storage
 {
     public class S3ScoreStorage : IScoreStorage
     {
+        private readonly ILogger logger;
+
+        public S3ScoreStorage(ILoggerFactory loggerFactory)
+        {
+            logger = loggerFactory.CreateLogger(nameof(S3ScoreStorage));
+        }
+
         public async Task WriteAsync(Score score)
         {
             using (var outStream = new MemoryStream())
@@ -20,7 +27,7 @@ namespace osu.Server.Spectator.Storage
 
                 outStream.Seek(0, SeekOrigin.Begin);
 
-                Console.WriteLine($"Uploading replay for score {score.ScoreInfo.OnlineID}");
+                logger.LogInformation($"Uploading replay for score {score.ScoreInfo.OnlineID}");
 
                 await S3.Upload(AppSettings.ReplaysBucket, score.ScoreInfo.OnlineID.ToString(CultureInfo.InvariantCulture), outStream, outStream.Length);
             }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -31,5 +31,9 @@
         </Content>
     </ItemGroup>
 
+    <ItemGroup Label="Code Analysis">
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
+        <AdditionalFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis\BannedSymbols.txt" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/214 for mergeability
- [x] Ask @ThePooN if he's okay with deploying this

This has been bothering me for a little while. Spectator server logging is a mix of built-in ASP.NET logging to console, direct `Console.WriteLine()` usage, and (over)use of framework logger. The last of these is especially problematic when deploying to k8s as file-based logs are not how you're supposed to be doing logging on k8s.

So here's a diff that moves everything to the ASP.NET logger and just straight up bans the other methods to keep things in shape.