### PR TITLE
Update github actions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -37,16 +37,16 @@ jobs:
             latest=false
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ./osu.Server.Spectator
           file: ./osu.Server.Spectator/Dockerfile
@@ -99,7 +99,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # the "Create Sentry release" step relies on accessing git history
           # to find the SHA of the previous release and set the range of new commits in the release being deployed.
@@ -107,7 +107,7 @@ jobs:
           fetch-depth: 0
       -
         name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
           repository: ppy/osu-kubernetes-config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     name: Unit testing
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install .NET 8.0.x
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 


### PR DESCRIPTION
Relevant bumps:

- https://github.com/actions/checkout/releases/tag/v4.0.0
- https://github.com/docker/metadata-action/releases/tag/v5.0.0
- https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
- https://github.com/docker/login-action/releases/tag/v3.0.0
- https://github.com/docker/build-push-action/releases/tag/v5.0.0
    - This one may cause issues because it includes v4.0.0, which is [plastered with a very large warning about "OCI compliance" and "provenance attestation" being enabled.](https://github.com/docker/build-push-action/releases/tag/v4.0.0) I don't really know what these words mean, and am hoping docker hub will be fine with whatever that is. @ThePooN maybe you know what this is talking about?
- https://github.com/peter-evans/repository-dispatch/releases/tag/v3.0.0
- https://github.com/actions/setup-dotnet/releases/tag/v4.0.0