### PR TITLE
Fix `EndPlaySession()` not broadcasting play end to other users on unranked beatmap plays

### DIFF
--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -32,12 +32,6 @@ namespace osu.Server.Spectator.Tests
         private const int beatmap_id = 88;
         private const int watcher_id = 8000;
 
-        private static readonly SpectatorState state = new SpectatorState
-        {
-            BeatmapID = beatmap_id,
-            RulesetID = 0,
-        };
-
         private readonly ScoreUploader scoreUploader;
         private readonly Mock<IScoreStorage> mockScoreStorage;
         private readonly Mock<IDatabaseAccess> mockDatabase;
@@ -96,7 +90,11 @@ namespace osu.Server.Spectator.Tests
 
             // check all other users were informed that streaming began
             mockClients.Verify(clients => clients.All, Times.Once);
-            mockReceiver.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state))), Times.Once());
+            mockReceiver.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            }))), Times.Once());
 
             var data = new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
@@ -131,7 +129,12 @@ namespace osu.Server.Spectator.Tests
                 passed = true
             }));
 
-            await hub.BeginPlaySession(1234, state);
+            var state1 = new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            };
+            await hub.BeginPlaySession(1234, state1);
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo
                 {
@@ -141,7 +144,7 @@ namespace osu.Server.Spectator.Tests
                     }
                 }, new ScoreProcessorStatistics()),
                 new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
-            await hub.EndPlaySession(state);
+            await hub.EndPlaySession(state1);
 
             await scoreUploader.Flush();
 
@@ -173,11 +176,16 @@ namespace osu.Server.Spectator.Tests
                 passed = true
             }));
 
-            await hub.BeginPlaySession(1234, state);
+            var state1 = new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            };
+            await hub.BeginPlaySession(1234, state1);
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
                 new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
-            await hub.EndPlaySession(state);
+            await hub.EndPlaySession(state1);
 
             await scoreUploader.Flush();
 
@@ -209,12 +217,18 @@ namespace osu.Server.Spectator.Tests
             hub.Clients = mockClients.Object;
             hub.Groups = mockGroups.Object;
 
+            var state1 = new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            };
+
             if (ongoing)
             {
                 hub.Context = streamerContext.Object;
-                await hub.BeginPlaySession(0, state);
+                await hub.BeginPlaySession(0, state1);
 
-                mockCaller.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state))), Times.Once);
+                mockCaller.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state1))), Times.Once);
             }
 
             hub.Context = watcherContext.Object;
@@ -223,7 +237,7 @@ namespace osu.Server.Spectator.Tests
 
             mockGroups.Verify(groups => groups.AddToGroupAsync(connectionId, SpectatorHub.GetGroupId(streamer_id), default));
 
-            mockCaller.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state))), Times.Exactly(ongoing ? 2 : 0));
+            mockCaller.Verify(clients => clients.UserBeganPlaying(streamer_id, It.Is<SpectatorState>(m => m.Equals(state1))), Times.Exactly(ongoing ? 2 : 0));
         }
 
         [Fact]
@@ -324,7 +338,12 @@ namespace osu.Server.Spectator.Tests
                 checksum = "checksum"
             })!);
 
-            await hub.BeginPlaySession(1234, state);
+            var state1 = new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            };
+            await hub.BeginPlaySession(1234, state1);
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo
                 {
@@ -334,7 +353,7 @@ namespace osu.Server.Spectator.Tests
                     }
                 }, new ScoreProcessorStatistics()),
                 new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
-            await hub.EndPlaySession(state);
+            await hub.EndPlaySession(state1);
 
             await scoreUploader.Flush();
 
@@ -366,11 +385,16 @@ namespace osu.Server.Spectator.Tests
                 passed = false
             }));
 
-            await hub.BeginPlaySession(1234, state);
+            var state1 = new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+            };
+            await hub.BeginPlaySession(1234, state1);
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
                 new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
-            await hub.EndPlaySession(state);
+            await hub.EndPlaySession(state1);
 
             await scoreUploader.Flush();
 

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -161,6 +161,8 @@ namespace osu.Server.Spectator.Tests
                 mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Once);
             else
                 mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
 
         [Fact]
@@ -206,6 +208,7 @@ namespace osu.Server.Spectator.Tests
             await scoreUploader.Flush();
 
             mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 
         [Theory]
@@ -384,6 +387,8 @@ namespace osu.Server.Spectator.Tests
                 mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Once);
             else
                 mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Never);
+
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
 
         [Fact]
@@ -429,6 +434,7 @@ namespace osu.Server.Spectator.Tests
             await scoreUploader.Flush();
 
             mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Never);
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Failed)), Times.Once());
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -141,21 +141,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
                     if (score == null || scoreToken == null)
                         return;
 
-                    // Do nothing with scores on unranked beatmaps.
-                    var status = score.ScoreInfo.BeatmapInfo!.Status;
-                    if (status < min_beatmap_status_for_replays || status > max_beatmap_status_for_replays)
-                        return;
-
-                    // if the user never hit anything, further processing that depends on the score existing can be waived because the client won't have submitted the score anyway.
-                    // note that this isn't an early return as we still want to end the play session.
-                    // see: https://github.com/ppy/osu/blob/a47ccb8edd2392258b6b7e176b222a9ecd511fc0/osu.Game/Screens/Play/SubmittingPlayer.cs#L281
-                    if (score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
-                    {
-                        score.ScoreInfo.Date = DateTimeOffset.UtcNow;
-
-                        scoreUploader.Enqueue(scoreToken.Value, score);
-                        await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, Context.GetUserId(), scoreToken.Value);
-                    }
+                    await processScore(score, scoreToken.Value);
                 }
                 finally
                 {
@@ -164,6 +150,24 @@ namespace osu.Server.Spectator.Hubs.Spectator
             }
 
             await endPlaySession(Context.GetUserId(), state);
+        }
+
+        private async Task processScore(Score score, long scoreToken)
+        {
+            // Do nothing with scores on unranked beatmaps.
+            var status = score.ScoreInfo.BeatmapInfo!.Status;
+            if (status < min_beatmap_status_for_replays || status > max_beatmap_status_for_replays)
+                return;
+
+            // if the user never hit anything, further processing that depends on the score existing can be waived because the client won't have submitted the score anyway.
+            // see: https://github.com/ppy/osu/blob/a47ccb8edd2392258b6b7e176b222a9ecd511fc0/osu.Game/Screens/Play/SubmittingPlayer.cs#L281
+            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
+                return;
+
+            score.ScoreInfo.Date = DateTimeOffset.UtcNow;
+
+            scoreUploader.Enqueue(scoreToken, score);
+            await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
         }
 
         public async Task StartWatchingUser(int userId)

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -138,6 +138,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
 
                     // Score may be null if the BeginPlaySession call failed but the client is still sending frame data.
                     // For now it's safe to drop these frames.
+                    // Note that this *intentionally* skips the `endPlaySession()` call at the end of method.
                     if (score == null || scoreToken == null)
                         return;
 


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu-server-spectator/pull/224#discussion_r1524570095.

In full-stack testing, this manifests as an actual bug wherein when spectating a player who's playing an unranked beatmap, spectator player will not exit even when the spectated player is done playing and will hang there forevermore.