### PR TITLE
Apply chat filters to room name when editing multiplayer room settings

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -128,7 +128,13 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             Clients.Setup(clients => clients.Group(MultiplayerHub.GetGroupId(ROOM_ID_2))).Returns(Receiver2.Object);
             Clients.Setup(client => client.Caller).Returns(Caller.Object);
 
-            Hub = new TestMultiplayerHub(new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())), Rooms, UserStates, DatabaseFactory.Object, hubContext.Object);
+            Hub = new TestMultiplayerHub(
+                new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+                Rooms,
+                UserStates,
+                DatabaseFactory.Object,
+                new ChatFilters(DatabaseFactory.Object),
+                hubContext.Object);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;
 

--- a/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
@@ -13,9 +13,13 @@ namespace osu.Server.Spectator.Tests.Multiplayer
     {
         public new MultiplayerHubContext HubContext => base.HubContext;
 
-        public TestMultiplayerHub(IDistributedCache cache, EntityStore<ServerMultiplayerRoom> rooms, EntityStore<MultiplayerClientState> users, IDatabaseFactory databaseFactory,
+        public TestMultiplayerHub(IDistributedCache cache,
+                                  EntityStore<ServerMultiplayerRoom> rooms,
+                                  EntityStore<MultiplayerClientState> users,
+                                  IDatabaseFactory databaseFactory,
+                                  ChatFilters chatFilters,
                                   IHubContext<MultiplayerHub> hubContext)
-            : base(cache, rooms, users, databaseFactory, hubContext)
+            : base(cache, rooms, users, databaseFactory, chatFilters, hubContext)
         {
         }
 

--- a/osu.Server.Spectator/ChatFilters.cs
+++ b/osu.Server.Spectator/ChatFilters.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading.Tasks;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Database.Models;
+
+namespace osu.Server.Spectator
+{
+    public class ChatFilters
+    {
+        private readonly IDatabaseFactory factory;
+        private ImmutableArray<chat_filter>? filters;
+
+        public ChatFilters(IDatabaseFactory factory)
+        {
+            this.factory = factory;
+        }
+
+        public async Task<string> FilterAsync(string input)
+        {
+            if (filters == null)
+            {
+                using var db = factory.GetInstance();
+                filters = (await db.GetAllChatFiltersAsync()).ToImmutableArray();
+            }
+
+            var stringBuilder = new StringBuilder(input);
+
+            foreach (var filter in filters)
+                stringBuilder.Replace(filter.match, filter.replacement);
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -363,6 +363,13 @@ namespace osu.Server.Spectator.Database
             await connection.ExecuteAsync("UPDATE `osu_builds` SET `users` = @users WHERE `build_id` = @build_id", build);
         }
 
+        public async Task<IEnumerable<chat_filter>> GetAllChatFiltersAsync()
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryAsync<chat_filter>("SELECT * FROM `chat_filters`");
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -157,5 +157,10 @@ namespace osu.Server.Spectator.Database
         /// Updates the <see cref="osu_build.users"/> count of a given <paramref name="build"/>.
         /// </summary>
         Task UpdateBuildUserCountAsync(osu_build build);
+
+        /// <summary>
+        /// Retrieves all <see cref="chat_filter"/>s from the database.
+        /// </summary>
+        Task<IEnumerable<chat_filter>> GetAllChatFiltersAsync();
     }
 }

--- a/osu.Server.Spectator/Database/Models/chat_filter.cs
+++ b/osu.Server.Spectator/Database/Models/chat_filter.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+// ReSharper disable InconsistentNaming (matches database table)
+
+namespace osu.Server.Spectator.Database.Models
+{
+    [Serializable]
+    public class chat_filter
+    {
+        public long id { get; set; }
+        public string match { get; set; } = string.Empty;
+        public string replacement { get; set; } = string.Empty;
+    }
+}

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -27,7 +27,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<IScoreStorage, S3ScoreStorage>()
                                     .AddSingleton<ScoreUploader>()
                                     .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
-                                    .AddSingleton<BuildUserCountUpdater>();
+                                    .AddSingleton<BuildUserCountUpdater>()
+                                    .AddSingleton<ChatFilters>();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -25,13 +25,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         protected readonly EntityStore<ServerMultiplayerRoom> Rooms;
         protected readonly MultiplayerHubContext HubContext;
         private readonly IDatabaseFactory databaseFactory;
+        private readonly ChatFilters chatFilters;
 
-        public MultiplayerHub(IDistributedCache cache, EntityStore<ServerMultiplayerRoom> rooms, EntityStore<MultiplayerClientState> users, IDatabaseFactory databaseFactory,
+        public MultiplayerHub(IDistributedCache cache,
+                              EntityStore<ServerMultiplayerRoom> rooms,
+                              EntityStore<MultiplayerClientState> users,
+                              IDatabaseFactory databaseFactory,
+                              ChatFilters chatFilters,
                               IHubContext<MultiplayerHub> hubContext)
             : base(cache, users)
         {
             Rooms = rooms;
             this.databaseFactory = databaseFactory;
+            this.chatFilters = chatFilters;
             HubContext = new MultiplayerHubContext(hubContext, rooms, users);
         }
 
@@ -626,6 +632,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 ensureIsHost(room);
 
                 Log(room, "Settings updating");
+
+                settings.Name = await chatFilters.FilterAsync(settings.Name);
 
                 // Server is authoritative over the playlist item ID.
                 // Todo: This needs to change for tournament mode.


### PR DESCRIPTION
Covers off another avenue of people potentially misusing text boxes after https://github.com/ppy/osu-web/pull/11175.

The chat filters are retrieved once-ever and never refetched until the instance gets restarted. I think web also does this? And also I didn't wanna complicate things unless necessary, but if deemed required I can add some crude local expiration/refetch logic.