### PR TITLE
Ensure ranks are properly populated in spectated scores

### DIFF
--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
@@ -435,6 +436,60 @@ namespace osu.Server.Spectator.Tests
 
             mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Never);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Failed)), Times.Once());
+        }
+
+        [Fact]
+        public async Task ScoreRankPopulatedCorrectly()
+        {
+            AppSettings.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.All).Returns(mockReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockReceiver.Object);
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            await hub.SendFrameData(new FrameDataBundle(
+                new FrameHeader(new ScoreInfo
+                {
+                    Accuracy = 0.95,
+                    Statistics = new Dictionary<HitResult, int>
+                    {
+                        [HitResult.Great] = 19,
+                        [HitResult.Miss] = 1,
+                    }
+                }, new ScoreProcessorStatistics()),
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Passed,
+            });
+
+            await scoreUploader.Flush();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.Rank == ScoreRank.A)), Times.Once);
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
     }
 }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.219.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.219.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="4.1.1" />
+        <PackageReference Include="Sentry.AspNetCore" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
> [!WARNING]
> This - or an alternative PR fixing this same issue - **must** be merged before the next bump of game packages in spectator server. Without fixing this issue one way or another, **all** online replays after next game bump & deploy thereof will have rank D **stored to the replay and read client-side**.

RFC.

This begins to matter after https://github.com/ppy/osu/pull/28058, as with that pull the rank is encoded to the replay, so it must be correctly set on the server side. Otherwise spectator server will default to storing D rank, which the client will happily read and use raw without checking.

This is purposefully computed server-side rather than sent in replay headers for the reasons of simplicity and backwards compatibility. You could add score rank to the replay headers, but to ensure that replays recorded with old clients don't have D rank set, recomputing server-side would have to be done at least for the old clients. And you could argue recomputing ranks always server-side removes a tamper vector too (although that's not a very strong argument).

---

Also includes a sentry package bump in https://github.com/ppy/osu-server-spectator/commit/e1603205f57e0cd98058cb71b7f8b904d579488a - without this the server dies at runtime with newest game packages.