### PR TITLE
Fix compilation failure in release mode

### DIFF
--- a/osu.Server.Spectator/Program.cs
+++ b/osu.Server.Spectator/Program.cs
@@ -5,6 +5,9 @@ using System;
 using System.IO;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
+#if !DEBUG
+using Microsoft.AspNetCore.SignalR;
+#endif
 using Microsoft.Extensions.Hosting;
 using osu.Framework.Logging;
 using osu.Framework.Platform;


### PR DESCRIPTION
See https://github.com/ppy/osu-server-spectator/actions/runs/8982642085/job/24686174288#step:6:262.

Regressed in 0f78897ca6debde589842e4071da552d44372a5b.

Using's back with an extra preprocessor directive to hopefully avoid this happening again.