### PR TITLE
Update `BouncyCastle.Cryptography` to 2.3.1

### DIFF
--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.S3" Version="3.7.305.28" />
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
         <PackageReference Include="Dapper" Version="2.1.28" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.2" />


### PR DESCRIPTION
To address several published vulnerabilities/CVEs:

- https://github.com/advisories/GHSA-8xfc-gm6g-vgpv
- https://github.com/advisories/GHSA-m44j-cfrm-g8qc
- https://github.com/advisories/GHSA-v435-xc8x-wvr9

Noticed this through build warnings.

I don't believe any of these *realistically* impact our usage of the library but I'm not that well-versed in cryptography and I'd rather not risk using known-bad versions longer than they need to be.