### PR TITLE
Announce currently active "daily challenge" playlist to clients

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.219.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.523.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.219.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.523.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/DailyChallengeUpdaterTest.cs
+++ b/osu.Server.Spectator.Tests/DailyChallengeUpdaterTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using osu.Game.Online.Metadata;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Metadata;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests
+{
+    public class DailyChallengeUpdaterTest
+    {
+        private readonly Mock<ILoggerFactory> loggerFactoryMock;
+        private readonly Mock<IDatabaseFactory> databaseFactoryMock;
+        private readonly Mock<IDatabaseAccess> databaseAccessMock;
+        private readonly Mock<IHubContext<MetadataHub>> metadataHubContextMock;
+        private readonly Mock<IClientProxy> allClientsProxy;
+
+        public DailyChallengeUpdaterTest()
+        {
+            loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
+                             .Returns(new Mock<ILogger>().Object);
+
+            databaseFactoryMock = new Mock<IDatabaseFactory>();
+            databaseAccessMock = new Mock<IDatabaseAccess>();
+            databaseFactoryMock.Setup(factory => factory.GetInstance()).Returns(databaseAccessMock.Object);
+
+            metadataHubContextMock = new Mock<IHubContext<MetadataHub>>();
+            allClientsProxy = new Mock<IClientProxy>();
+            metadataHubContextMock.Setup(ctx => ctx.Clients.All).Returns(allClientsProxy.Object);
+        }
+
+        [Fact]
+        public async Task TestChangeTracking()
+        {
+            databaseAccessMock.Setup(db => db.GetActiveDailyChallengeRoomsAsync())
+                              .ReturnsAsync([new multiplayer_room { id = 4, category = room_category.daily_challenge }]);
+
+            var updater = new DailyChallengeUpdater(
+                loggerFactoryMock.Object,
+                databaseFactoryMock.Object,
+                metadataHubContextMock.Object)
+            {
+                UpdateInterval = 50
+            };
+
+            var task = updater.StartAsync(default);
+            await Task.Delay(100);
+
+            allClientsProxy.Verify(proxy => proxy.SendCoreAsync(
+                    nameof(IMetadataClient.DailyChallengeUpdated),
+                    It.Is<object[]>(args => ((DailyChallengeInfo?)args![0]).Value.RoomID == 4),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            databaseAccessMock.Setup(db => db.GetActiveDailyChallengeRoomsAsync())
+                              .ReturnsAsync([]);
+            await Task.Delay(100);
+
+            allClientsProxy.Verify(proxy => proxy.SendCoreAsync(
+                    nameof(IMetadataClient.DailyChallengeUpdated),
+                    It.Is<object?[]>(args => args[0] == null),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            databaseAccessMock.Setup(db => db.GetActiveDailyChallengeRoomsAsync())
+                              .ReturnsAsync([new multiplayer_room { id = 5, category = room_category.daily_challenge }]);
+            await Task.Delay(100);
+
+            allClientsProxy.Verify(proxy => proxy.SendCoreAsync(
+                    nameof(IMetadataClient.DailyChallengeUpdated),
+                    It.Is<object[]>(args => ((DailyChallengeInfo?)args![0]).HasValue && ((DailyChallengeInfo?)args[0]).Value.RoomID == 5),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            await updater.StopAsync(default);
+            await task;
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Spectator.Tests
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
 
-            hub = new MetadataHub(cache, userStates, databaseFactory.Object);
+            hub = new MetadataHub(cache, userStates, databaseFactory.Object, new Mock<IDailyChallengeUpdater>().Object);
 
             var mockContext = new Mock<HubCallerContext>();
             mockContext.Setup(ctx => ctx.UserIdentifier).Returns(user_id.ToString());

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -370,6 +370,18 @@ namespace osu.Server.Spectator.Database
             return await connection.QueryAsync<chat_filter>("SELECT * FROM `chat_filters`");
         }
 
+        public async Task<IEnumerable<multiplayer_room>> GetActiveDailyChallengeRoomsAsync()
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryAsync<multiplayer_room>(
+                "SELECT * FROM `multiplayer_rooms` "
+                + "WHERE `category` = 'daily_challenge' "
+                + "AND `type` = 'playlists' "
+                + "AND `starts_at` <= NOW() "
+                + "AND `ends_at` > NOW()");
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -162,5 +162,10 @@ namespace osu.Server.Spectator.Database
         /// Retrieves all <see cref="chat_filter"/>s from the database.
         /// </summary>
         Task<IEnumerable<chat_filter>> GetAllChatFiltersAsync();
+
+        /// <summary>
+        /// Retrieves all active rooms from the <see cref="room_category.daily_challenge"/> category.
+        /// </summary>
+        Task<IEnumerable<multiplayer_room>> GetActiveDailyChallengeRoomsAsync();
     }
 }

--- a/osu.Server.Spectator/Database/Models/multiplayer_room.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_room.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Online.Rooms;
 
 // ReSharper disable InconsistentNaming (matches database table)
 
@@ -23,7 +22,7 @@ namespace osu.Server.Spectator.Database.Models
         public DateTimeOffset? created_at { get; set; }
         public DateTimeOffset? updated_at { get; set; }
         public DateTimeOffset? deleted_at { get; set; }
-        public RoomCategory category { get; set; }
+        public room_category category { get; set; }
         public database_match_type type { get; set; }
         public database_queue_mode queue_mode { get; set; }
         public ushort auto_start_duration { get; set; }

--- a/osu.Server.Spectator/Database/Models/room_category.cs
+++ b/osu.Server.Spectator/Database/Models/room_category.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Server.Spectator.Database.Models
+{
+    // ReSharper disable once InconsistentNaming
+    [Serializable]
+    public enum room_category
+    {
+        normal,
+        spotlights,
+        featured_artist,
+        daily_challenge,
+    }
+}

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -28,7 +28,9 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<ScoreUploader>()
                                     .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
                                     .AddSingleton<BuildUserCountUpdater>()
-                                    .AddSingleton<ChatFilters>();
+                                    .AddSingleton<ChatFilters>()
+                                    .AddSingleton<IDailyChallengeUpdater, DailyChallengeUpdater>()
+                                    .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>());
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Metadata/DailyChallengeUpdater.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/DailyChallengeUpdater.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using osu.Game.Online.Metadata;
+using osu.Server.Spectator.Database;
+
+namespace osu.Server.Spectator.Hubs.Metadata
+{
+    public interface IDailyChallengeUpdater : IHostedService
+    {
+        DailyChallengeInfo? Current { get; }
+    }
+
+    public class DailyChallengeUpdater : BackgroundService, IDailyChallengeUpdater
+    {
+        /// <summary>
+        /// Amount of time (in milliseconds) between subsequent polls for the current beatmap of the day.
+        /// </summary>
+        public int UpdateInterval = 60_000;
+
+        public DailyChallengeInfo? Current { get; private set; }
+
+        private readonly ILogger logger;
+        private readonly IDatabaseFactory databaseFactory;
+        private readonly IHubContext<MetadataHub> hubContext;
+
+        public DailyChallengeUpdater(
+            ILoggerFactory loggerFactory,
+            IDatabaseFactory databaseFactory,
+            IHubContext<MetadataHub> hubContext)
+        {
+            logger = loggerFactory.CreateLogger(nameof(DailyChallengeUpdater));
+            this.databaseFactory = databaseFactory;
+            this.hubContext = hubContext;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await updateDailyChallengeInfo(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to update beatmap of the day");
+                }
+
+                await Task.Delay(UpdateInterval, stoppingToken);
+            }
+        }
+
+        private async Task updateDailyChallengeInfo(CancellationToken cancellationToken)
+        {
+            using var db = databaseFactory.GetInstance();
+
+            var activeRooms = (await db.GetActiveDailyChallengeRoomsAsync()).ToList();
+
+            if (activeRooms.Count > 1)
+            {
+                logger.LogWarning("More than one active 'beatmap of the day' room detected (ids: {roomIds}). Will only use the first one.",
+                    string.Join(',', activeRooms.Select(room => room.id)));
+            }
+
+            DailyChallengeInfo? newInfo = null;
+
+            var activeRoom = activeRooms.FirstOrDefault();
+
+            if (activeRoom?.id != null)
+                newInfo = new DailyChallengeInfo { RoomID = activeRoom.id };
+
+            if (!Current.Equals(newInfo))
+            {
+                logger.LogInformation("Broadcasting 'beatmap of the day' room change from id {oldRoomID} to {newRoomId}", Current?.RoomID, newInfo?.RoomID);
+                Current = newInfo;
+                await hubContext.Clients.All.SendAsync(nameof(IMetadataClient.DailyChallengeUpdated), Current, cancellationToken);
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -17,16 +17,19 @@ namespace osu.Server.Spectator.Hubs.Metadata
     public class MetadataHub : StatefulUserHub<IMetadataClient, MetadataClientState>, IMetadataServer
     {
         private readonly IDatabaseFactory databaseFactory;
+        private readonly IDailyChallengeUpdater dailyChallengeUpdater;
 
         internal const string ONLINE_PRESENCE_WATCHERS_GROUP = "metadata:online-presence-watchers";
 
         public MetadataHub(
             IDistributedCache cache,
             EntityStore<MetadataClientState> userStates,
-            IDatabaseFactory databaseFactory)
+            IDatabaseFactory databaseFactory,
+            IDailyChallengeUpdater dailyChallengeUpdater)
             : base(cache, userStates)
         {
             this.databaseFactory = databaseFactory;
+            this.dailyChallengeUpdater = dailyChallengeUpdater;
         }
 
         public override async Task OnConnectedAsync()
@@ -49,6 +52,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
                 usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash);
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
+                await Clients.Caller.DailyChallengeUpdated(dailyChallengeUpdater.Current);
             }
         }
 

--- a/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
@@ -49,16 +49,19 @@ namespace osu.Server.Spectator.Hubs.Spectator
             timer.Start();
 
             subscriber = redis.GetSubscriber();
-            subscriber.Subscribe("osu-channel:score:processed", (_, message) => onMessageReceived(message));
+            subscriber.Subscribe(new RedisChannel("osu-channel:score:processed", RedisChannel.PatternMode.Literal), (_, message) => onMessageReceived(message));
 
             logger = Logger.GetLogger(nameof(ScoreProcessedSubscriber));
         }
 
-        private void onMessageReceived(string message)
+        private void onMessageReceived(string? message)
         {
             try
             {
-                var scoreProcessed = JsonConvert.DeserializeObject<ScoreProcessed>(message);
+                if (string.IsNullOrEmpty(message))
+                    return;
+
+                ScoreProcessed? scoreProcessed = JsonConvert.DeserializeObject<ScoreProcessed>(message);
 
                 if (scoreProcessed == null)
                     return;

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,12 +15,12 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.219.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.219.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.219.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.219.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.219.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.523.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.523.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.523.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.523.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.523.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="4.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-web/pull/11204 for the DB tables
- [x] Depends on https://github.com/ppy/osu/pull/28194 for the models

This adds a `DailyChallengeUpdater` that polls the database every minute (interval obviously negotiable) to check whether the current active "daily challenge" room changed, and announces that to all clients if it did.

Additionally, on connection to `MetadataHub`, the metadata hub sends the current "daily challenge" info to the newly-connected client using state stored in the `DailyChallengeUpdater`.