### PR TITLE
Allow `ScoreUploader` to process replays concurrently

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -40,7 +40,6 @@ namespace osu.Server.Spectator.Tests
 
             mockStorage = new Mock<IScoreStorage>();
             uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
-            uploader.UploadInterval = 1000; // Set a high timer interval for testing purposes.
         }
 
         /// <summary>
@@ -57,7 +56,7 @@ namespace osu.Server.Spectator.Tests
         {
             enableUpload();
 
-            uploader.Enqueue(1, new Score
+            await uploader.EnqueueAsync(1, new Score
             {
                 ScoreInfo =
                 {
@@ -69,7 +68,9 @@ namespace osu.Server.Spectator.Tests
                     // note OnlineID and Passed not set.
                 }
             });
-            await Task.Delay(2000);
+
+            await uploadsCompleteAsync();
+
             mockStorage.Verify(s => s.WriteAsync(
                 It.Is<Score>(score => score.ScoreInfo.OnlineID == 2
                                       && score.ScoreInfo.Passed
@@ -77,18 +78,16 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public async Task ScoreUploadsEveryInterval()
+        public async Task ScoreUploads()
         {
             enableUpload();
 
-            // First score.
-            uploader.Enqueue(1, new Score());
-            await Task.Delay(2000);
+            await uploader.EnqueueAsync(1, new Score());
+            await uploadsCompleteAsync();
             mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
 
-            // Second score (ensure the loop keeps running).
-            uploader.Enqueue(1, new Score());
-            await Task.Delay(2000);
+            await uploader.EnqueueAsync(1, new Score());
+            await uploadsCompleteAsync();
             mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Exactly(2));
         }
 
@@ -97,20 +96,9 @@ namespace osu.Server.Spectator.Tests
         {
             disableUpload();
 
-            uploader.Enqueue(1, new Score());
-            await uploader.Flush();
+            await uploader.EnqueueAsync(1, new Score());
+            await Task.Delay(1000);
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task ScoreOnlyUploadsOnce()
-        {
-            enableUpload();
-
-            uploader.Enqueue(1, new Score());
-            await uploader.Flush();
-            await uploader.Flush();
-            mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Once);
         }
 
         [Fact]
@@ -119,8 +107,8 @@ namespace osu.Server.Spectator.Tests
             enableUpload();
 
             // Score with no token.
-            uploader.Enqueue(2, new Score());
-            await uploader.Flush();
+            await uploader.EnqueueAsync(2, new Score());
+            await Task.Delay(1000);
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // Give the score a token.
@@ -130,8 +118,7 @@ namespace osu.Server.Spectator.Tests
                 passed = true
             }));
 
-            await uploader.Flush();
-
+            await uploadsCompleteAsync();
             mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 3)), Times.Once);
         }
 
@@ -143,9 +130,8 @@ namespace osu.Server.Spectator.Tests
             uploader.TimeoutInterval = 0;
 
             // Score with no token.
-            uploader.Enqueue(2, new Score());
+            await uploader.EnqueueAsync(2, new Score());
             Thread.Sleep(1000); // Wait for cancellation.
-            await uploader.Flush();
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // Give the score a token now. It should still not upload because it has timed out.
@@ -154,15 +140,18 @@ namespace osu.Server.Spectator.Tests
                 id = 3,
                 passed = true
             }));
-
-            await uploader.Flush();
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // New score that has a token (ensure the loop keeps running).
-            uploader.Enqueue(1, new Score());
-            await uploader.Flush();
+            mockDatabase.Setup(db => db.GetScoreFromToken(3)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 4,
+                passed = true
+            }));
+            await uploader.EnqueueAsync(3, new Score());
+            await uploadsCompleteAsync();
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Once);
-            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
+            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 4)), Times.Once);
         }
 
         [Fact]
@@ -184,36 +173,34 @@ namespace osu.Server.Spectator.Tests
                        });
 
             // Throwing score.
-            uploader.Enqueue(1, new Score());
-            await uploader.Flush();
+            await uploader.EnqueueAsync(1, new Score());
+            await uploadsCompleteAsync();
             Assert.Equal(0, uploadCount);
 
             shouldThrow = false;
 
             // Same score shouldn't reupload.
-            await uploader.Flush();
+            await Task.Delay(1000);
             Assert.Equal(0, uploadCount);
 
-            uploader.Enqueue(1, new Score());
-            await uploader.Flush();
+            await uploader.EnqueueAsync(1, new Score());
+            await uploadsCompleteAsync();
             Assert.Equal(1, uploadCount);
-        }
-
-        [Fact]
-        public async Task TimedOutItemGetsOneAttempt()
-        {
-            enableUpload();
-
-            uploader.TimeoutInterval = 0;
-
-            // Score with no token.
-            uploader.Enqueue(1, new Score());
-            Thread.Sleep(1000); // Wait for cancellation.
-            await uploader.Flush();
-            mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Once);
         }
 
         private void enableUpload() => AppSettings.SaveReplays = true;
         private void disableUpload() => AppSettings.SaveReplays = false;
+
+        private async Task uploadsCompleteAsync(int attempts = 5)
+        {
+            while (uploader.RemainingUsages > 0)
+            {
+                if (attempts <= 0)
+                    Assert.Fail("Waiting for score upload to proceed timed out");
+
+                attempts -= 1;
+                await Task.Delay(1000);
+            }
+        }
     }
 }

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -8,6 +8,7 @@ namespace osu.Server.Spectator
     public static class AppSettings
     {
         public static bool SaveReplays { get; set; }
+        public static int ReplayUploaderConcurrency { get; set; }
 
         #region For use with FileScoreStorage
 
@@ -36,6 +37,9 @@ namespace osu.Server.Spectator
         static AppSettings()
         {
             SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
+            ReplayUploaderConcurrency = int.Parse(Environment.GetEnvironmentVariable("REPLAY_UPLOAD_THREADS") ?? "1");
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ReplayUploaderConcurrency);
+
             ReplaysPath = Environment.GetEnvironmentVariable("REPLAYS_PATH") ?? "replays";
             S3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? string.Empty;
             S3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? string.Empty;

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -45,7 +45,9 @@ namespace osu.Server.Spectator.Hubs
             cancellationSource = new CancellationTokenSource();
             cancellationToken = cancellationSource.Token;
 
-            Task.Factory.StartNew(readLoop, TaskCreationOptions.LongRunning);
+            for (int i = 0; i < AppSettings.ReplayUploaderConcurrency; ++i)
+                Task.Factory.StartNew(readLoop, TaskCreationOptions.LongRunning);
+
             Task.Factory.StartNew(monitorLoop, TaskCreationOptions.LongRunning);
         }
 

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -173,7 +173,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
             // even though in theory the rank could be recomputed after every replay frame.
             score.ScoreInfo.Rank = StandardisedScoreMigrationTools.ComputeRank(score.ScoreInfo);
 
-            scoreUploader.Enqueue(scoreToken, score);
+            await scoreUploader.EnqueueAsync(scoreToken, score);
             await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
         }
 


### PR DESCRIPTION
As things stand, `ScoreUploader` is inherently single threaded. Today, @peppy noticed that replay uploads have started piling up:

![1716312252](https://github.com/ppy/osu-server-spectator/assets/20418176/eaa64c87-25b6-434b-bdc9-d9cb150b3835)

and @ThePooN pointed out that this wasn't exactly new, and started happening a few days before already as bursts of pending uploads that then go back down eventually, which also has the effect of increasing the memory footprint of the spectator server instance:

![1716312268](https://github.com/ppy/osu-server-spectator/assets/20418176/245361ff-d964-486d-abfb-97d357c20806)
![1716312279](https://github.com/ppy/osu-server-spectator/assets/20418176/df9c8ac9-f872-4012-994d-a448dbde3092)

With no apparent direct cause (as in, no apparent deploy or change that broke it), the working theory is that something may be throttling the upload process (apparently it was doing ~1 score per second which seems _way_ too slow) and maybe throwing more threads at it may help. So this diff attempts to do that, using [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) (think `BlockingCollection` but async).

I admittedly don't have much experience working with `Channel<T>` so I'm not super sure how well this is gonna behave. One notable thing to read in the docs of that class is this:

> Whenever a [Channel<TWrite,TRead>.Writer](https://learn.microsoft.com/en-us/dotnet/api/system.threading.channels.channel-2.writer) produces faster than a [Channel<TWrite,TRead>.Reader](https://learn.microsoft.com/en-us/dotnet/api/system.threading.channels.channel-2.reader) can consume, the channel's writer experiences back pressure.

I'm not sure I understand the full implications of whatever that means; I know what backpressure means, but depending on how it's done, it might be decent, or it might be not. This probably needs more testing in general but I'm not super sure _how_ to test this sort of thing because this is the sort of thing you only can observe working properly under load, but I wrote it and it might be useful so I'm PRing it to see if there's at least interest to pursue this further and maybe do some stress testing on.

The degree of concurrency is controlled via an envvar (`REPLAY_UPLOAD_THREADS`). Yes, this means that changing the degree means restarting the instance. That was considered acceptable in discussion.

(As an aside I considered merging  `REPLAY_UPLOAD_THREADS` with `SAVE_REPLAYS` to have `REPLAY_UPLOAD_THREADS=0` mean "replays off" but it's annoying because tests depend on `SAVE_REPLAYS` being toggleable in runtime, which just works if it's done as it was in `Enqueue()` but is quite annoying to do if you need to kill/spin up threads on demand on the reader end just for tests, and I wasn't super sure that was a reasonable thing to do to begin with, so I didn't in the end. Can reconsider if that would be considered nicer.)