### PR TITLE
Fix test failures due to crosstalk via static `AppSettings.SaveReplays`

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -54,8 +54,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreDataMergedCorrectly()
         {
-            enableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             await uploader.EnqueueAsync(1, new Score
             {
@@ -81,8 +83,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreUploads()
         {
-            enableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             await uploader.EnqueueAsync(1, new Score());
             await uploadsCompleteAsync(uploader);
@@ -96,8 +100,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreDoesNotUploadIfDisabled()
         {
-            disableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = false
+            };
 
             await uploader.EnqueueAsync(1, new Score());
             await Task.Delay(1000);
@@ -107,8 +113,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreUploadsWithDelayedScoreToken()
         {
-            enableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             // Score with no token.
             await uploader.EnqueueAsync(2, new Score());
@@ -129,8 +137,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task TimedOutScoreDoesNotUpload()
         {
-            enableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             uploader.TimeoutInterval = 0;
 
@@ -162,8 +172,10 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task FailedScoreHandledGracefully()
         {
-            enableUpload();
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             bool shouldThrow = true;
             int uploadCount = 0;
@@ -197,9 +209,11 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task TestMassUploads()
         {
-            enableUpload();
             AppSettings.ReplayUploaderConcurrency = 4;
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object);
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            {
+                SaveReplays = true
+            };
 
             for (int i = 0; i < 1000; ++i)
                 await uploader.EnqueueAsync(1, new Score());
@@ -208,9 +222,6 @@ namespace osu.Server.Spectator.Tests
             mockStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 2)), Times.Exactly(1000));
             AppSettings.ReplayUploaderConcurrency = 1;
         }
-
-        private void enableUpload() => AppSettings.SaveReplays = true;
-        private void disableUpload() => AppSettings.SaveReplays = false;
 
         private async Task uploadsCompleteAsync(ScoreUploader uploader, int attempts = 5)
         {

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -115,7 +115,7 @@ namespace osu.Server.Spectator.Tests
         [InlineData(true)]
         public async Task ReplayDataIsSaved(bool savingEnabled)
         {
-            AppSettings.SaveReplays = savingEnabled;
+            scoreUploader.SaveReplays = savingEnabled;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
@@ -171,7 +171,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ReplaysWithoutAnyHitsAreDiscarded()
         {
-            AppSettings.SaveReplays = true;
+            scoreUploader.SaveReplays = true;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
@@ -335,7 +335,7 @@ namespace osu.Server.Spectator.Tests
         [InlineData(BeatmapOnlineStatus.Loved, true)]
         public async Task ScoresAreOnlySavedOnRankedBeatmaps(BeatmapOnlineStatus status, bool saved)
         {
-            AppSettings.SaveReplays = true;
+            scoreUploader.SaveReplays = true;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
@@ -421,7 +421,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoresHaveAllUserRelatedMetadataFilledOutConsistently()
         {
-            AppSettings.SaveReplays = true;
+            scoreUploader.SaveReplays = true;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
@@ -484,7 +484,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task FailedScoresAreNotSaved()
         {
-            AppSettings.SaveReplays = true;
+            scoreUploader.SaveReplays = true;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
@@ -530,7 +530,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreRankPopulatedCorrectly()
         {
-            AppSettings.SaveReplays = true;
+            scoreUploader.SaveReplays = true;
 
             Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
             Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -23,6 +23,8 @@ namespace osu.Server.Spectator.Hubs
         /// </summary>
         public double TimeoutInterval = 30000;
 
+        public bool SaveReplays = AppSettings.SaveReplays;
+
         private const string statsd_prefix = "score_uploads";
 
         private readonly Channel<UploadItem> channel = Channel.CreateUnbounded<UploadItem>();
@@ -58,7 +60,7 @@ namespace osu.Server.Spectator.Hubs
         /// <param name="score">The score.</param>
         public async Task EnqueueAsync(long token, Score score)
         {
-            if (!AppSettings.SaveReplays)
+            if (!SaveReplays)
                 return;
 
             Interlocked.Increment(ref remainingUsages);


### PR DESCRIPTION
As seen in https://github.com/ppy/osu-server-spectator/actions/runs/9201004114/job/25308499074.

Only locally reproducible if running full test suite.

The serialising nature of `.Flush()` that used to be there previously probably concealed this.