### PR TITLE
Allow clients to receive realtime updates for a given playlist

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.625.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.625.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -15,6 +15,7 @@ using osu.Game.Users;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs.Metadata;
+using osu.Server.Spectator.Hubs.Spectator;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests
@@ -41,7 +42,13 @@ namespace osu.Server.Spectator.Tests
             loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
                              .Returns(new Mock<ILogger>().Object);
 
-            hub = new MetadataHub(loggerFactoryMock.Object, cache, userStates, databaseFactory.Object, new Mock<IDailyChallengeUpdater>().Object);
+            hub = new MetadataHub(
+                loggerFactoryMock.Object,
+                cache,
+                userStates,
+                databaseFactory.Object,
+                new Mock<IDailyChallengeUpdater>().Object,
+                new Mock<IScoreProcessedSubscriber>().Object);
 
             var mockContext = new Mock<HubCallerContext>();
             mockContext.Setup(ctx => ctx.UserIdentifier).Returns(user_id.ToString());

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchTypeTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchTypeTests.cs
@@ -138,7 +138,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task JoinRoomWithTypeCreatesCorrectInstance()
         {
-            Database.Setup(db => db.GetRoomAsync(ROOM_ID))
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(new multiplayer_room
                     {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerInviteTest.cs
@@ -127,7 +127,7 @@ public class MultiplayerInviteTest : MultiplayerTest
     {
         const string password = "password";
 
-        Database.Setup(db => db.GetRoomAsync(It.IsAny<long>()))
+        Database.Setup(db => db.GetRealtimeRoomAsync(It.IsAny<long>()))
                 .Callback<long>(InitialiseRoom)
                 .ReturnsAsync(new multiplayer_room
                 {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerQueueTests.cs
@@ -74,7 +74,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task RoomStartsWithCorrectQueueingMode()
         {
             Database.Setup(d => d.GetBeatmapAsync(3333)).ReturnsAsync(new database_beatmap { checksum = "3333" });
-            Database.Setup(db => db.GetRoomAsync(ROOM_ID))
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(() => new multiplayer_room
                     {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -214,7 +214,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         {
             DatabaseFactory.Setup(factory => factory.GetInstance()).Returns(Database.Object);
 
-            Database.Setup(db => db.GetRoomAsync(ROOM_ID))
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(() => new multiplayer_room
                     {
@@ -223,7 +223,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                         user_id = int.Parse(Hub.Context.UserIdentifier!),
                     });
 
-            Database.Setup(db => db.GetRoomAsync(ROOM_ID_2))
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID_2))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(() => new multiplayer_room
                     {

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserCanJoinWithCorrectPassword()
         {
-            Database.Setup(db => db.GetRoomAsync(It.IsAny<long>()))
+            Database.Setup(db => db.GetRealtimeRoomAsync(It.IsAny<long>()))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(new multiplayer_room
                     {
@@ -36,7 +36,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserCantJoinWithIncorrectPassword()
         {
-            Database.Setup(db => db.GetRoomAsync(It.IsAny<long>()))
+            Database.Setup(db => db.GetRealtimeRoomAsync(It.IsAny<long>()))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(new multiplayer_room
                     {
@@ -61,7 +61,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserCantJoinAlreadyEnded()
         {
-            Database.Setup(db => db.GetRoomAsync(It.IsAny<long>()))
+            Database.Setup(db => db.GetRealtimeRoomAsync(It.IsAny<long>()))
                     .ReturnsAsync(new multiplayer_room
                     {
                         ends_at = DateTimeOffset.Now.AddMinutes(-5),
@@ -159,7 +159,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserJoinPreRetrievalFailureCleansUpRoom()
         {
-            Database.Setup(db => db.GetRoomAsync(ROOM_ID))
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
                     .Callback<long>(InitialiseRoom)
                     .ReturnsAsync(() => new multiplayer_room
                     {

--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -26,7 +26,7 @@ namespace osu.Server.Spectator.Tests
         public ScoreUploaderTests()
         {
             mockDatabase = new Mock<IDatabaseAccess>();
-            mockDatabase.Setup(db => db.GetScoreFromToken(1)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 2,
                 passed = true
@@ -124,7 +124,7 @@ namespace osu.Server.Spectator.Tests
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // Give the score a token.
-            mockDatabase.Setup(db => db.GetScoreFromToken(2)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(2)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 3,
                 passed = true
@@ -150,7 +150,7 @@ namespace osu.Server.Spectator.Tests
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // Give the score a token now. It should still not upload because it has timed out.
-            mockDatabase.Setup(db => db.GetScoreFromToken(2)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(2)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 3,
                 passed = true
@@ -158,7 +158,7 @@ namespace osu.Server.Spectator.Tests
             mockStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
 
             // New score that has a token (ensure the loop keeps running).
-            mockDatabase.Setup(db => db.GetScoreFromToken(3)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(3)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 4,
                 passed = true

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -128,7 +128,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = true
@@ -184,7 +184,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = true
@@ -348,7 +348,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = true
@@ -434,7 +434,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = true
@@ -497,7 +497,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = false
@@ -543,7 +543,7 @@ namespace osu.Server.Spectator.Tests
             hub.Context = mockContext.Object;
             hub.Clients = mockClients.Object;
 
-            mockDatabase.Setup(db => db.GetScoreFromToken(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
             {
                 id = 456,
                 passed = true

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -48,6 +48,16 @@ namespace osu.Server.Spectator.Database
             }) != 0;
         }
 
+        public async Task<multiplayer_room?> GetRoomAsync(long roomId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryFirstOrDefaultAsync<multiplayer_room>("SELECT * FROM multiplayer_rooms WHERE id = @RoomID", new
+            {
+                RoomID = roomId
+            });
+        }
+
         public async Task<multiplayer_room?> GetRealtimeRoomAsync(long roomId)
         {
             var connection = await getConnectionAsync();
@@ -294,7 +304,7 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task<SoloScore?> GetScoreFromToken(long token)
+        public async Task<SoloScore?> GetScoreFromTokenAsync(long token)
         {
             var connection = await getConnectionAsync();
 
@@ -303,6 +313,16 @@ namespace osu.Server.Spectator.Database
                 {
                     Id = token
                 });
+        }
+
+        public async Task<SoloScore?> GetScoreAsync(long id)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleOrDefaultAsync<SoloScore?>("SELECT * FROM `scores` WHERE `id` = @Id", new
+            {
+                Id = id
+            });
         }
 
         public async Task<bool> IsScoreProcessedAsync(long scoreId)
@@ -380,6 +400,78 @@ namespace osu.Server.Spectator.Database
                 + "AND `type` = 'playlists' "
                 + "AND `starts_at` <= NOW() "
                 + "AND `ends_at` > NOW()");
+        }
+
+        public async Task<(long roomID, long playlistItemID)?> GetMultiplayerRoomIdForScoreAsync(long scoreId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleOrDefaultAsync<(long, long)?>(
+                "SELECT `multiplayer_playlist_items`.`room_id`, `multiplayer_playlist_items`.`id` "
+                + "FROM `multiplayer_score_links` "
+                + "JOIN `multiplayer_playlist_items` "
+                + "ON `multiplayer_score_links`.`playlist_item_id` = `multiplayer_playlist_items`.`id` "
+                + "WHERE `multiplayer_score_links`.`score_id` = @scoreId",
+                new { scoreId = scoreId });
+        }
+
+        public async Task<MultiplayerPlaylistItemStats[]> GetMultiplayerRoomStatsAsync(long roomId)
+        {
+            var connection = await getConnectionAsync();
+
+            long[] playlistItemIds = (await GetAllPlaylistItemsAsync(roomId)).Select(item => item.id).ToArray();
+            var result = new MultiplayerPlaylistItemStats[playlistItemIds.Length];
+
+            for (int i = 0; i < playlistItemIds.Length; ++i)
+            {
+                long[] totalScores = (await connection.QueryAsync<long>(
+                    "SELECT `scores`.`total_score` FROM `scores` "
+                    + "JOIN `multiplayer_score_links` ON `multiplayer_score_links`.`score_id` = `scores`.`id` "
+                    + "WHERE `multiplayer_score_links`.`playlist_item_id` = @playlistItemId", new
+                    {
+                        playlistItemId = playlistItemIds[i]
+                    })).ToArray();
+
+                var totals = totalScores.GroupBy(score => (int)Math.Clamp(Math.Floor((float)score / 100000), 0, MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS - 1))
+                                        .OrderBy(grp => grp.Key)
+                                        .ToDictionary(grp => grp.Key, grp => grp.LongCount());
+
+                var stats = new MultiplayerPlaylistItemStats
+                {
+                    PlaylistItemID = playlistItemIds[i],
+                    TotalScoreDistribution = Enumerable.Range(0, MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS).Select(i => totals.GetValueOrDefault(i)).ToArray(),
+                };
+
+                result[i] = stats;
+            }
+
+            return result;
+        }
+
+        public async Task<multiplayer_scores_high?> GetUserBestScoreAsync(long playlistItemId, int userId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleOrDefaultAsync<multiplayer_scores_high>(
+                "SELECT * FROM `multiplayer_scores_high` WHERE `playlist_item_id` = @playlistItemId AND `user_id` = @userId", new
+                {
+                    playlistItemId = playlistItemId,
+                    userId = userId
+                });
+        }
+
+        public async Task<int> GetUserRankInRoomAsync(long roomId, int userId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleAsync<int>(
+                "SELECT COUNT(1) + 1 FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` != @userId "
+                + "AND `total_score` > (SELECT `total_score` FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` = @userId)",
+                new
+                {
+                    roomId = roomId,
+                    userId = userId,
+                });
         }
 
         public void Dispose()

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Database
             }) != 0;
         }
 
-        public async Task<multiplayer_room?> GetRoomAsync(long roomId)
+        public async Task<multiplayer_room?> GetRealtimeRoomAsync(long roomId)
         {
             var connection = await getConnectionAsync();
 

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -33,6 +33,12 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Returns the <see cref="multiplayer_room"/> with the given <paramref name="roomId"/>.
         /// </summary>
+        Task<multiplayer_room?> GetRoomAsync(long roomId);
+
+        /// <summary>
+        /// Returns the <see cref="multiplayer_room"/> with the given <paramref name="roomId"/>.
+        /// Rooms of type <see cref="database_match_type.playlists"/> are not returned by this method.
+        /// </summary>
         Task<multiplayer_room?> GetRealtimeRoomAsync(long roomId);
 
         /// <summary>
@@ -126,7 +132,12 @@ namespace osu.Server.Spectator.Database
         /// </summary>
         /// <param name="token">The score token.</param>
         /// <returns>The <see cref="SoloScore"/>.</returns>
-        Task<SoloScore?> GetScoreFromToken(long token);
+        Task<SoloScore?> GetScoreFromTokenAsync(long token);
+
+        /// <summary>
+        /// Returns the <see cref="SoloScore"/> for the given ID.
+        /// </summary>
+        Task<SoloScore?> GetScoreAsync(long scoreId);
 
         /// <summary>
         /// Returns <see langword="true"/> if the score with the supplied <paramref name="scoreId"/> has been successfully processed.
@@ -167,5 +178,26 @@ namespace osu.Server.Spectator.Database
         /// Retrieves all active rooms from the <see cref="room_category.daily_challenge"/> category.
         /// </summary>
         Task<IEnumerable<multiplayer_room>> GetActiveDailyChallengeRoomsAsync();
+
+        /// <summary>
+        /// If <paramref name="scoreId"/> is associated with a multiplayer score, returns the room ID and playlist item ID which the score was set on.
+        /// Otherwise, returns <see langword="null"/>.
+        /// </summary>
+        Task<(long roomID, long playlistItemID)?> GetMultiplayerRoomIdForScoreAsync(long scoreId);
+
+        /// <summary>
+        /// Returns <see cref="MultiplayerPlaylistItemStats"/> for all playlist items in the room with the given <paramref name="roomId"/>.
+        /// </summary>
+        Task<MultiplayerPlaylistItemStats[]> GetMultiplayerRoomStatsAsync(long roomId);
+
+        /// <summary>
+        /// Returns the best score of user with <paramref name="userId"/> on the playlist item with <paramref name="playlistItemId"/>.
+        /// </summary>
+        Task<multiplayer_scores_high?> GetUserBestScoreAsync(long playlistItemId, int userId);
+
+        /// <summary>
+        /// Gets the overall rank of user <paramref name="userId"/> in the room with <paramref name="roomId"/>.
+        /// </summary>
+        Task<int> GetUserRankInRoomAsync(long roomId, int userId);
     }
 }

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -33,7 +33,7 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Returns the <see cref="multiplayer_room"/> with the given <paramref name="roomId"/>.
         /// </summary>
-        Task<multiplayer_room?> GetRoomAsync(long roomId);
+        Task<multiplayer_room?> GetRealtimeRoomAsync(long roomId);
 
         /// <summary>
         /// Retrieves a beatmap corresponding to the given <paramref name="beatmapId"/>.

--- a/osu.Server.Spectator/Database/Models/multiplayer_scores_high.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_scores_high.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Server.Spectator.Database.Models
+{
+    // ReSharper disable InconsistentNaming
+    [Serializable]
+    public class multiplayer_scores_high
+    {
+        public ulong id { get; set; }
+        public ulong? score_id { get; set; }
+        public uint user_id { get; set; }
+        public ulong playlist_item_id { get; set; }
+        public uint total_score { get; set; }
+        public float accuracy { get; set; }
+        public float? pp { get; set; }
+        public uint attempts { get; set; }
+        public DateTimeOffset created_at { get; set; }
+        public DateTimeOffset updated_at { get; set; }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -181,7 +181,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 // This will allow for other instances to know not to reinitialise the room if the host arrives there.
                 // Alternatively, we can move lobby retrieval away from osu-web and not require this in the first place.
                 // Needs further discussion and consideration either way.
-                var databaseRoom = await db.GetRoomAsync(roomId);
+                var databaseRoom = await db.GetRealtimeRoomAsync(roomId);
 
                 if (databaseRoom == null)
                     throw new InvalidOperationException("Specified match does not exist.");

--- a/osu.Server.Spectator/Hubs/ScoreUploader.cs
+++ b/osu.Server.Spectator/Hubs/ScoreUploader.cs
@@ -81,7 +81,7 @@ namespace osu.Server.Spectator.Hubs
 
                 try
                 {
-                    SoloScore? dbScore = await db.GetScoreFromToken(item.Token);
+                    SoloScore? dbScore = await db.GetScoreFromTokenAsync(item.Token);
 
                     if (dbScore == null && !item.Cancellation.IsCancellationRequested)
                     {

--- a/osu.Server.Spectator/Hubs/Spectator/IScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/IScoreProcessedSubscriber.cs
@@ -16,12 +16,6 @@ namespace osu.Server.Spectator.Hubs.Spectator
         /// <param name="receiverConnectionId">The ID of the connection that should receive the notifications.</param>
         /// <param name="userId">The ID of the user who set the score.</param>
         /// <param name="scoreId">The ID of the score which is being processed.</param>
-        Task RegisterForNotificationAsync(string receiverConnectionId, int userId, long scoreId);
+        Task RegisterForSingleScoreAsync(string receiverConnectionId, int userId, long scoreId);
     }
-
-    /// <summary>
-    /// Callback delegate that will be invoked when a score has been successfully processed.
-    /// </summary>
-    /// <param name="scoreId">The ID of the score that was processed.</param>
-    public delegate Task ScoreProcessedAsyncCallback(string receiverConnectionId, int userId, long scoreId);
 }

--- a/osu.Server.Spectator/Hubs/Spectator/IScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/IScoreProcessedSubscriber.cs
@@ -17,5 +17,20 @@ namespace osu.Server.Spectator.Hubs.Spectator
         /// <param name="userId">The ID of the user who set the score.</param>
         /// <param name="scoreId">The ID of the score which is being processed.</param>
         Task RegisterForSingleScoreAsync(string receiverConnectionId, int userId, long scoreId);
+
+        /// <summary>
+        /// Registers a hub client for future notifications about incoming scores in a given <paramref name="roomId"/>.
+        /// </summary>
+        Task RegisterForMultiplayerRoomAsync(int userId, long roomId);
+
+        /// <summary>
+        /// Unregisters a hub client from future notifications about incoming scores in a given <paramref name="roomId"/>.
+        /// </summary>
+        Task UnregisterFromMultiplayerRoomAsync(int userId, long roomId);
+
+        /// <summary>
+        /// Unregisters a hub client from all multiplayer room subscriptions.
+        /// </summary>
+        Task UnregisterFromAllMultiplayerRoomsAsync(int userId);
     }
 }

--- a/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/ScoreProcessedSubscriber.cs
@@ -3,15 +3,19 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using osu.Game.Online.Metadata;
 using osu.Game.Online.Spectator;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Metadata;
 using StackExchange.Redis;
 using StatsdClient;
 using Timer = System.Timers.Timer;
@@ -31,18 +35,24 @@ namespace osu.Server.Spectator.Hubs.Spectator
         private readonly ISubscriber? subscriber;
 
         private readonly ConcurrentDictionary<long, SingleScoreSubscription> singleScoreSubscriptions = new ConcurrentDictionary<long, SingleScoreSubscription>();
+
+        private readonly Dictionary<long, MultiplayerRoomSubscription> multiplayerRoomSubscriptions = new Dictionary<long, MultiplayerRoomSubscription>();
+
         private readonly Timer timer;
         private readonly ILogger logger;
         private readonly IHubContext<SpectatorHub> spectatorHubContext;
+        private readonly IHubContext<MetadataHub> metadataHubContext;
 
         public ScoreProcessedSubscriber(
             IDatabaseFactory databaseFactory,
             IConnectionMultiplexer redis,
             IHubContext<SpectatorHub> spectatorHubContext,
+            IHubContext<MetadataHub> metadataHubContext,
             ILoggerFactory loggerFactory)
         {
             this.databaseFactory = databaseFactory;
             this.spectatorHubContext = spectatorHubContext;
+            this.metadataHubContext = metadataHubContext;
 
             timer = new Timer(1000);
             timer.AutoReset = true;
@@ -73,6 +83,8 @@ namespace osu.Server.Spectator.Hubs.Spectator
                         subscription.InvokeAsync().Wait();
                 }
 
+                Task.Run(async () => await notifyMultiplayerRoomSubscribers(scoreProcessed));
+
                 DogStatsd.Increment($"{statsd_prefix}.messages.single-score.delivered");
             }
             catch (Exception ex)
@@ -82,13 +94,69 @@ namespace osu.Server.Spectator.Hubs.Spectator
             }
         }
 
+        private async Task notifyMultiplayerRoomSubscribers(ScoreProcessed scoreProcessed)
+        {
+            try
+            {
+                using var db = databaseFactory.GetInstance();
+
+                (long roomID, long playlistItemID)? multiplayerLookup = await db.GetMultiplayerRoomIdForScoreAsync(scoreProcessed.ScoreId);
+
+                if (multiplayerLookup == null)
+                    return;
+
+                // do one early check to attempt to ensure the database queries we are about to do are not for naught.
+                lock (multiplayerRoomSubscriptions)
+                {
+                    if (!multiplayerRoomSubscriptions.TryGetValue(multiplayerLookup.Value.roomID, out _))
+                        return;
+                }
+
+                var score = await db.GetScoreAsync(scoreProcessed.ScoreId);
+                Debug.Assert(score != null);
+
+                if (!score.passed)
+                    return;
+
+                int? newRank = null;
+                var userBest = await db.GetUserBestScoreAsync(multiplayerLookup.Value.playlistItemID, (int)score.user_id);
+
+                if (userBest?.score_id == score.id)
+                    newRank = await db.GetUserRankInRoomAsync(multiplayerLookup.Value.roomID, (int)score.user_id);
+
+                lock (multiplayerRoomSubscriptions)
+                {
+                    // do another check just in case something has shifted under us while we were fetching all of the data.
+                    if (!multiplayerRoomSubscriptions.TryGetValue(multiplayerLookup.Value.roomID, out var roomSubscription))
+                        return;
+
+                    roomSubscription.InvokeAsync(new MultiplayerRoomScoreSetEvent
+                    {
+                        RoomID = multiplayerLookup.Value.roomID,
+                        PlaylistItemID = multiplayerLookup.Value.playlistItemID,
+                        ScoreID = (long)score.id,
+                        UserID = (int)score.user_id,
+                        TotalScore = score.total_score,
+                        NewRank = newRank,
+                    });
+                }
+
+                DogStatsd.Increment($"{statsd_prefix}.messages.room.delivered", tags: [multiplayerLookup.Value.roomID.ToString()]);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error when attempting to deliver room subscription update");
+                DogStatsd.Increment($"{statsd_prefix}.messages.room.dropped");
+            }
+        }
+
         public async Task RegisterForSingleScoreAsync(string receiverConnectionId, int userId, long scoreToken)
         {
             try
             {
                 using var db = databaseFactory.GetInstance();
 
-                SoloScore? score = await db.GetScoreFromToken(scoreToken);
+                SoloScore? score = await db.GetScoreFromTokenAsync(scoreToken);
 
                 if (score == null)
                 {
@@ -122,12 +190,73 @@ namespace osu.Server.Spectator.Hubs.Spectator
             }
         }
 
+        public async Task RegisterForMultiplayerRoomAsync(int userId, long roomId)
+        {
+            using var db = databaseFactory.GetInstance();
+            var room = await db.GetRoomAsync(roomId);
+
+            if (room == null)
+                return;
+
+            if (room.type != database_match_type.playlists)
+            {
+                logger.LogError("User {userId} attempted to subscribe for notifications for non-playlists multiplayer room {roomId}. This is currently unsupported.", userId, roomId);
+                return;
+            }
+
+            lock (multiplayerRoomSubscriptions)
+            {
+                if (!multiplayerRoomSubscriptions.TryGetValue(roomId, out var existing))
+                    multiplayerRoomSubscriptions[roomId] = existing = new MultiplayerRoomSubscription(roomId, metadataHubContext);
+
+                existing.AddUser(userId);
+                DogStatsd.Gauge($"{statsd_prefix}.subscriptions.room.total", existing.UserIds.Count, tags: [roomId.ToString()]);
+            }
+        }
+
+        public Task UnregisterFromMultiplayerRoomAsync(int userId, long roomId)
+        {
+            lock (multiplayerRoomSubscriptions)
+            {
+                if (!multiplayerRoomSubscriptions.TryGetValue(roomId, out var subscription))
+                    return Task.CompletedTask;
+
+                subscription.RemoveUser(userId);
+                if (subscription.UserIds.Count == 0)
+                    multiplayerRoomSubscriptions.Remove(roomId);
+                DogStatsd.Gauge($"{statsd_prefix}.subscriptions.room.total", subscription.UserIds.Count, tags: [roomId.ToString()]);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task UnregisterFromAllMultiplayerRoomsAsync(int userId)
+        {
+            lock (multiplayerRoomSubscriptions)
+            {
+                foreach (var (roomId, subscription) in multiplayerRoomSubscriptions)
+                {
+                    subscription.RemoveUser(userId);
+                    DogStatsd.Gauge($"{statsd_prefix}.subscriptions.room.total", subscription.UserIds.Count, tags: [roomId.ToString()]);
+                }
+
+                long[] emptySubscriptions = multiplayerRoomSubscriptions.Where(kv => kv.Value.UserIds.Count == 0)
+                                                                        .Select(kv => kv.Key)
+                                                                        .ToArray();
+
+                foreach (long key in emptySubscriptions)
+                    multiplayerRoomSubscriptions.Remove(key);
+            }
+
+            return Task.CompletedTask;
+        }
+
         private void purgeTimedOutSubscriptions()
         {
-            var scoreIds = singleScoreSubscriptions.Keys.ToArray();
+            long[] scoreIds = singleScoreSubscriptions.Keys.ToArray();
             int purgedCount = 0;
 
-            foreach (var scoreId in scoreIds)
+            foreach (long scoreId in scoreIds)
             {
                 if (singleScoreSubscriptions.TryGetValue(scoreId, out var subscription) && subscription.TimedOut)
                 {
@@ -186,6 +315,27 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 => spectatorHubContext.Clients.Client(receiverConnectionId).SendAsync(nameof(ISpectatorClient.UserScoreProcessed), userId, scoreId);
 
             public void Dispose() => cancellationTokenSource.Dispose();
+        }
+
+        private class MultiplayerRoomSubscription
+        {
+            public IReadOnlySet<int> UserIds => userIds;
+
+            private readonly HashSet<int> userIds = new HashSet<int>();
+            private readonly long roomId;
+            private readonly IHubContext<MetadataHub> metadataHubContext;
+
+            public MultiplayerRoomSubscription(long roomId, IHubContext<MetadataHub> metadataHubContext)
+            {
+                this.roomId = roomId;
+                this.metadataHubContext = metadataHubContext;
+            }
+
+            public void AddUser(int userId) => userIds.Add(userId);
+            public void RemoveUser(int userId) => userIds.Remove(userId);
+
+            public Task InvokeAsync(MultiplayerRoomScoreSetEvent roomScoreSetEvent)
+                => metadataHubContext.Clients.Group(MetadataHub.MultiplayerRoomWatchersGroup(roomId)).SendAsync(nameof(IMetadataClient.MultiplayerRoomScoreSet), roomScoreSetEvent);
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -176,7 +176,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
             score.ScoreInfo.Rank = StandardisedScoreMigrationTools.ComputeRank(score.ScoreInfo);
 
             await scoreUploader.EnqueueAsync(scoreToken, score);
-            await scoreProcessedSubscriber.RegisterForNotificationAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
+            await scoreProcessedSubscriber.RegisterForSingleScoreAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
         }
 
         public async Task StartWatchingUser(int userId)

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.625.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.625.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.625.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.625.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.625.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.628.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="4.3.0" />
     </ItemGroup>


### PR DESCRIPTION
- Continuation of https://github.com/ppy/osu/issues/28136
- [x] Depends on https://github.com/ppy/osu/pull/28636
- [x] Depends on game package w/ above

This pull is intended to be the thing powering recently-added game-side components like https://github.com/ppy/osu/pull/28561 or https://github.com/ppy/osu/pull/28468.

The general design is not intended to explicitly be specific to daily challenge; the API of the feature is supposed to - in theory - apply to any playlist, so if we wanted to we could add these displays to any old playlist room. The one exception is multiplayer; I kinda forget the reason since I wrote the code for this a *while* back, but I believe it had something to do with the fact that in realtime multi the playlist items are not fixed in time. Now I'm not sure it's an issue anymore but to be honest I don't think realtime rooms are ever going to need this sort of feedback either, so I'm leaving that limitation be there.

Few open questions in my mind remain, which is why I'm PRing this early and not PRing the final piece that integrates this into the game yet

- Not sure of the general placement of this (considered metadata hub and spectator hub, decided on the former in the end)
- The general data structure design is a bit ad-hoc to easily support what I want to show client-side and may need adjusting / generalising
- Not sure how the db queries will perform on production scale, things may need to be shifted depending on that

so before all of that is set in stone I'd wanna refrain from getting too deep into it so that I don't have to change things five times over.