### PR TITLE
Read & use client-provided session GUID for concurrency control

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.718.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.718.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -55,7 +55,7 @@ namespace osu.Server.Spectator
                     return;
                 }
 
-                if (context.Context.GetTokenId() == userState.Item.TokenId)
+                if (userState.Item.IsConnectionFromSameClient(context))
                 {
                     // The assumption is that the client has already dropped the old connection,
                     // so we don't bother to ask for a disconnection.
@@ -99,15 +99,7 @@ namespace osu.Server.Spectator
 
             using (var userState = await connectionStates.GetForUse(userId))
             {
-                string? registeredConnectionId = null;
-
-                bool tokenIdMatches = invocationContext.Context.GetTokenId() == userState.Item?.TokenId;
-                bool hubRegistered = userState.Item?.ConnectionIds.TryGetValue(invocationContext.Hub.GetType(), out registeredConnectionId) == true;
-                bool connectionIdMatches = registeredConnectionId == invocationContext.Context.ConnectionId;
-
-                bool connectionIsValid = tokenIdMatches && hubRegistered && connectionIdMatches;
-
-                if (!connectionIsValid)
+                if (userState.Item?.IsInvocationPermitted(invocationContext) != true)
                     throw new InvalidOperationException($"State is not valid for this connection, context: {LoggingHubFilter.GetMethodCallDisplayString(invocationContext)})");
             }
 
@@ -129,15 +121,7 @@ namespace osu.Server.Spectator
 
             using (var userState = await connectionStates.GetForUse(userId, true))
             {
-                string? registeredConnectionId = null;
-
-                bool tokenIdMatches = context.Context.GetTokenId() == userState.Item?.TokenId;
-                bool hubRegistered = userState.Item?.ConnectionIds.TryGetValue(context.Hub.GetType(), out registeredConnectionId) == true;
-                bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;
-
-                bool connectionCanBeCleanedUp = tokenIdMatches && hubRegistered && connectionIdMatches;
-
-                if (connectionCanBeCleanedUp)
+                if (userState.Item?.CanCleanUpConnection(context) == true)
                 {
                     log(context, "disconnected from hub");
                     userState.Item!.ConnectionIds.Remove(context.Hub.GetType());

--- a/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
+++ b/osu.Server.Spectator/ConcurrentConnectionLimiter.cs
@@ -99,7 +99,7 @@ namespace osu.Server.Spectator
 
             using (var userState = await connectionStates.GetForUse(userId))
             {
-                if (userState.Item?.IsInvocationPermitted(invocationContext) != true)
+                if (userState.Item?.ExistingConnectionMatches(invocationContext) != true)
                     throw new InvalidOperationException($"State is not valid for this connection, context: {LoggingHubFilter.GetMethodCallDisplayString(invocationContext)})");
             }
 
@@ -121,7 +121,7 @@ namespace osu.Server.Spectator
 
             using (var userState = await connectionStates.GetForUse(userId, true))
             {
-                if (userState.Item?.CanCleanUpConnection(context) == true)
+                if (userState.Item?.ExistingConnectionMatches(context) == true)
                 {
                     log(context, "disconnected from hub");
                     userState.Item!.ConnectionIds.Remove(context.Hub.GetType());

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -59,13 +59,6 @@ namespace osu.Server.Spectator.Entities
         public void RegisterConnectionId(HubLifetimeContext context)
             => ConnectionIds[context.Hub.GetType()] = context.Context.ConnectionId;
 
-        private bool tryGetClientSessionID(HubLifetimeContext context, out Guid clientSessionId)
-        {
-            clientSessionId = Guid.Empty;
-            return context.Context.GetHttpContext()?.Request.Headers.TryGetValue(HubClientConnector.CLIENT_SESSION_ID_HEADER, out var value) == true
-                   && Guid.TryParse(value, out clientSessionId);
-        }
-
         public bool IsConnectionFromSameClient(HubLifetimeContext context)
         {
             if (tryGetClientSessionID(context, out var clientSessionId))
@@ -88,6 +81,13 @@ namespace osu.Server.Spectator.Entities
             bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;
 
             return hubRegistered && connectionIdMatches;
+        }
+
+        private static bool tryGetClientSessionID(HubLifetimeContext context, out Guid clientSessionId)
+        {
+            clientSessionId = Guid.Empty;
+            return context.Context.GetHttpContext()?.Request.Headers.TryGetValue(HubClientConnector.CLIENT_SESSION_ID_HEADER, out var value) == true
+                   && Guid.TryParse(value, out clientSessionId);
         }
     }
 }

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -29,7 +29,7 @@ namespace osu.Server.Spectator.Entities
         /// This was previously used as a method of controlling user uniqueness / limiting concurrency,
         /// but it turned out to be a bad fit for the purpose (see https://github.com/ppy/osu/issues/26338#issuecomment-2222935517).
         /// </remarks>
-        [Obsolete("Use ClientSessionId instead.")]
+        [Obsolete("Use ClientSessionId instead.")] // Can be removed 2024-08-18
         public readonly string TokenId;
 
         /// <summary>
@@ -64,6 +64,7 @@ namespace osu.Server.Spectator.Entities
             if (tryGetClientSessionID(context, out var clientSessionId))
                 return ClientSessionId == clientSessionId;
 
+            // Legacy pathway using JTI claim left for compatibility with older clients – can be removed 2024-08-18
             return TokenId == context.Context.GetTokenId();
         }
 

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.SignalR;
+using osu.Game.Online;
 using osu.Server.Spectator.Extensions;
+
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace osu.Server.Spectator.Entities
 {
@@ -14,9 +17,19 @@ namespace osu.Server.Spectator.Entities
     public class ConnectionState
     {
         /// <summary>
-        /// The unique ID of the JWT the user is using to authenticate.
+        /// A client-side generated GUID identifying the client instance connecting to this server.
         /// This is used to control user uniqueness.
         /// </summary>
+        public readonly Guid? ClientSessionId;
+
+        /// <summary>
+        /// The unique ID of the JWT the user is using to authenticate.
+        /// </summary>
+        /// <remarks>
+        /// This was previously used as a method of controlling user uniqueness / limiting concurrency,
+        /// but it turned out to be a bad fit for the purpose (see https://github.com/ppy/osu/issues/26338#issuecomment-2222935517).
+        /// </remarks>
+        [Obsolete("Use ClientSessionId instead.")]
         public readonly string TokenId;
 
         /// <summary>
@@ -33,6 +46,9 @@ namespace osu.Server.Spectator.Entities
         {
             TokenId = context.Context.GetTokenId();
 
+            if (tryGetClientSessionID(context, out var clientSessionId))
+                ClientSessionId = clientSessionId;
+
             RegisterConnectionId(context);
         }
 
@@ -42,5 +58,36 @@ namespace osu.Server.Spectator.Entities
         /// <param name="context">The hub context to retrieve information from.</param>
         public void RegisterConnectionId(HubLifetimeContext context)
             => ConnectionIds[context.Hub.GetType()] = context.Context.ConnectionId;
+
+        private bool tryGetClientSessionID(HubLifetimeContext context, out Guid clientSessionId)
+        {
+            clientSessionId = Guid.Empty;
+            return context.Context.GetHttpContext()?.Request.Headers.TryGetValue(HubClientConnector.CLIENT_SESSION_ID_HEADER, out var value) == true
+                   && Guid.TryParse(value, out clientSessionId);
+        }
+
+        public bool IsConnectionFromSameClient(HubLifetimeContext context)
+        {
+            if (tryGetClientSessionID(context, out var clientSessionId))
+                return ClientSessionId == clientSessionId;
+
+            return TokenId == context.Context.GetTokenId();
+        }
+
+        public bool IsInvocationPermitted(HubInvocationContext context)
+        {
+            bool hubRegistered = ConnectionIds.TryGetValue(context.Hub.GetType(), out string? registeredConnectionId);
+            bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;
+
+            return hubRegistered && connectionIdMatches;
+        }
+
+        public bool CanCleanUpConnection(HubLifetimeContext context)
+        {
+            bool hubRegistered = ConnectionIds.TryGetValue(context.Hub.GetType(), out string? registeredConnectionId);
+            bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;
+
+            return hubRegistered && connectionIdMatches;
+        }
     }
 }

--- a/osu.Server.Spectator/Entities/ConnectionState.cs
+++ b/osu.Server.Spectator/Entities/ConnectionState.cs
@@ -68,7 +68,7 @@ namespace osu.Server.Spectator.Entities
             return TokenId == context.Context.GetTokenId();
         }
 
-        public bool IsInvocationPermitted(HubInvocationContext context)
+        public bool ExistingConnectionMatches(HubInvocationContext context)
         {
             bool hubRegistered = ConnectionIds.TryGetValue(context.Hub.GetType(), out string? registeredConnectionId);
             bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;
@@ -76,7 +76,7 @@ namespace osu.Server.Spectator.Entities
             return hubRegistered && connectionIdMatches;
         }
 
-        public bool CanCleanUpConnection(HubLifetimeContext context)
+        public bool ExistingConnectionMatches(HubLifetimeContext context)
         {
             bool hubRegistered = ConnectionIds.TryGetValue(context.Hub.GetType(), out string? registeredConnectionId);
             bool connectionIdMatches = registeredConnectionId == context.Context.ConnectionId;

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Logging;
+using osu.Game.Online;
 using osu.Game.Online.Metadata;
 using osu.Game.Users;
 using osu.Server.Spectator.Database;
@@ -48,7 +49,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
             {
                 string? versionHash = null;
 
-                if (Context.GetHttpContext()?.Request.Headers.TryGetValue("OsuVersionHash", out StringValues headerValue) == true)
+                if (Context.GetHttpContext()?.Request.Headers.TryGetValue(HubClientConnector.VERSION_HASH_HEADER, out StringValues headerValue) == true)
                 {
                     versionHash = headerValue;
 

--- a/osu.Server.Spectator/ServerShuttingDownException.cs
+++ b/osu.Server.Spectator/ServerShuttingDownException.cs
@@ -2,13 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Microsoft.AspNetCore.SignalR;
+using osu.Game.Online;
 
 namespace osu.Server.Spectator
 {
     public class ServerShuttingDownException : HubException
     {
         public ServerShuttingDownException()
-            : base("Server is shutting down.")
+            : base(HubClientConnector.SERVER_SHUTDOWN_MESSAGE)
         {
         }
     }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.628.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.628.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.628.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.628.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.628.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.718.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.718.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.718.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.718.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.718.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="4.3.0" />
     </ItemGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/28892
- Second part of https://github.com/ppy/osu/issues/26338

Read description of aforementioned PR for explanation what is going on here.

This change is designed to be backwards-compatible, in the sense that old client will continue to use the `jti` cialm (with all of the deficiencies which that incurs), and new clients with the aforementioned change will use the new one which is hopefully rid of the deficiencies in question. We can probably shutter the old path in a few months - or I can just delete it now if that is considered acceptable.