### PR TITLE
Fix incorrect reporting of user rank in room in case of score ties

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -465,8 +465,10 @@ namespace osu.Server.Spectator.Database
             var connection = await getConnectionAsync();
 
             return await connection.QuerySingleAsync<int>(
-                "SELECT COUNT(1) + 1 FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` != @userId "
-                + "AND `total_score` > (SELECT `total_score` FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` = @userId)",
+                "WITH `user_score` AS (SELECT `total_score`, `last_score_id` FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` = @userId) "
+                + "SELECT COUNT(1) + 1 FROM `multiplayer_rooms_high` WHERE `room_id` = @roomId AND `user_id` != @userId "
+                + "AND (`total_score` > (SELECT `total_score` FROM `user_score`) OR "
+                + "(`total_score` = (SELECT `total_score` FROM `user_score`) AND `last_score_id` < (SELECT `last_score_id` FROM `user_score`)))",
                 new
                 {
                     roomId = roomId,


### PR DESCRIPTION
Should [match web](https://github.com/ppy/osu-web/blob/8f70623d02f6203cd877c64c6232f96061da0071/app/Models/Multiplayer/UserScoreAggregate.php#L176-L177), in theory.

Not sure about the CTE usage but it's one row and I'd rather try this than duplicate the subquery.