### PR TITLE
Handle mid play mod changes

### DIFF
--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -124,6 +124,11 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 score.ScoreInfo.Combo = data.Header.Combo;
                 score.ScoreInfo.TotalScore = data.Header.TotalScore;
 
+                // null here means the frame bundle is from an old client that can't send mod data
+                // can be removed (along with making property non-nullable on `FrameDataBundle`) 20250407
+                if (data.Header.Mods != null)
+                    score.ScoreInfo.APIMods = data.Header.Mods;
+
                 score.Replay.Frames.AddRange(data.Frames);
 
                 await Clients.Group(GetGroupId(Context.GetUserId())).UserSentFrames(Context.GetUserId(), data);


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu/pull/30137
- Closes https://github.com/ppy/osu/issues/29817

Note the backwards-compatible handling of the `null` value, as well as the test coverage for it. (Also tested empirically.)