### PR TITLE
Explicitly set S3 timeouts & retry counts

### DIFF
--- a/osu.Server.Spectator/S3.cs
+++ b/osu.Server.Spectator/S3.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Amazon;
@@ -20,7 +21,10 @@ namespace osu.Server.Spectator
                 HttpClientCacheSize = 32,
                 RegionEndpoint = endpoint ?? RegionEndpoint.USWest1,
                 UseHttp = true,
-                ForcePathStyle = true
+                ForcePathStyle = true,
+                RetryMode = RequestRetryMode.Legacy,
+                MaxErrorRetry = 5,
+                Timeout = TimeSpan.FromSeconds(10),
             });
         }
 


### PR DESCRIPTION
The timeout in particular seems to be set to a [stupidly large value by default](https://github.com/aws/aws-sdk-net/blob/ca4005485bca2295d2985250ac25e774f01e2c4d/sdk/src/Services/S3/Custom/AmazonS3Config.cs#L262-L264). Not sure if the new values are better, but at least they're not ~24 days...?