### PR TITLE
Update game packages

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1115.2" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1115.2" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1115.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1115.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1115.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1115.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1115.2" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1208.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1208.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1208.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1208.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="4.12.1" />
     </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/31043. Probably. Haven't tested.

Maybe we want a bot to autogenerate these too like osu-web has. Although that'd just be basically dependabot. Maybe we can turn on dependabot but just for `osu.Game.*` packages or something.