### PR TITLE
Start logging logins to `osu_logins` table

### DIFF
--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -27,12 +27,13 @@ namespace osu.Server.Spectator.Tests
         private readonly Mock<IMetadataClient> mockCaller;
         private readonly Mock<IMetadataClient> mockWatchersGroup;
         private readonly Mock<IGroupManager> mockGroupManager;
+        private readonly Mock<IDatabaseAccess> mockDatabase;
 
         public MetadataHubTest()
         {
             userStates = new EntityStore<MetadataClientState>();
 
-            var mockDatabase = new Mock<IDatabaseAccess>();
+            mockDatabase = new Mock<IDatabaseAccess>();
             var databaseFactory = new Mock<IDatabaseFactory>();
             databaseFactory.Setup(factory => factory.GetInstance()).Returns(mockDatabase.Object);
             var loggerFactoryMock = new Mock<ILoggerFactory>();
@@ -132,6 +133,15 @@ namespace osu.Server.Spectator.Tests
             }
 
             mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task UserLoginLogging()
+        {
+            await hub.OnConnectedAsync();
+
+            // verify that the caller got the initial data update.
+            mockDatabase.Verify(caller => caller.AddLoginForUserAsync(user_id, It.IsAny<string>()), Times.Once);
         }
 
         [Fact]

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -165,6 +165,30 @@ namespace osu.Server.Spectator.Database
             }
         }
 
+        public async Task AddLoginForUserAsync(int userId, string? userIp)
+        {
+            if (string.IsNullOrEmpty(userIp))
+                return;
+
+            var connection = await getConnectionAsync();
+
+            try
+            {
+                await connection.ExecuteAsync("INSERT INTO osu_logins (user_id, ip) VALUES (@UserID, @IP)", new
+                {
+                    UserID = userId,
+                    IP = userIp
+                });
+            }
+            catch (MySqlException)
+            {
+                // we really don't care about failures in this as it's throwaway logging.
+                //
+                // although arguably we should at least be logging failures somewhere because this kind of thing could stop working
+                // without anyone noticing. same goes for other try-catch methods in this class..
+            }
+        }
+
         public async Task RemoveRoomParticipantAsync(MultiplayerRoom room, MultiplayerRoomUser user)
         {
             var connection = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using MySqlConnector;
 using osu.Game.Online.Metadata;
@@ -19,6 +20,12 @@ namespace osu.Server.Spectator.Database
     public class DatabaseAccess : IDatabaseAccess
     {
         private MySqlConnection? openConnection;
+        private readonly ILogger<DatabaseAccess> logger;
+
+        public DatabaseAccess(ILoggerFactory loggerFactory)
+        {
+            logger = loggerFactory.CreateLogger<DatabaseAccess>();
+        }
 
         public async Task<int?> GetUserIdFromTokenAsync(JsonWebToken jwtToken)
         {
@@ -180,12 +187,9 @@ namespace osu.Server.Spectator.Database
                     IP = userIp
                 });
             }
-            catch (MySqlException)
+            catch (MySqlException ex)
             {
-                // we really don't care about failures in this as it's throwaway logging.
-                //
-                // although arguably we should at least be logging failures somewhere because this kind of thing could stop working
-                // without anyone noticing. same goes for other try-catch methods in this class..
+                logger.LogWarning(ex, "Could not log login for user {UserId}", userId);
             }
         }
 

--- a/osu.Server.Spectator/Database/DatabaseFactory.cs
+++ b/osu.Server.Spectator/Database/DatabaseFactory.cs
@@ -1,10 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Microsoft.Extensions.Logging;
+
 namespace osu.Server.Spectator.Database
 {
     public class DatabaseFactory : IDatabaseFactory
     {
-        public IDatabaseAccess GetInstance() => new DatabaseAccess();
+        private readonly ILoggerFactory loggerFactory;
+
+        public DatabaseFactory(ILoggerFactory loggerFactory)
+        {
+            this.loggerFactory = loggerFactory;
+        }
+
+        public IDatabaseAccess GetInstance() => new DatabaseAccess(loggerFactory);
     }
 }

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -72,6 +72,11 @@ namespace osu.Server.Spectator.Database
         Task AddRoomParticipantAsync(MultiplayerRoom room, MultiplayerRoomUser user);
 
         /// <summary>
+        /// Adds a login entry for the specified user.
+        /// </summary>
+        Task AddLoginForUserAsync(int userId, string? userIp);
+
+        /// <summary>
         /// Remove a new participant for the specified <paramref name="room"/> in the database.
         /// </summary>
         Task RemoveRoomParticipantAsync(MultiplayerRoom room, MultiplayerRoomUser user);

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -75,15 +75,11 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
         private async Task logLogin(ItemUsage<MetadataClientState> usage)
         {
-            string? userIp;
-
-            if (Context.GetHttpContext()?.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues forwardedForIp) == true)
-                userIp = forwardedForIp;
-            else
-            {
+            string? userIp = Context.GetHttpContext()?.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues forwardedForIp) == true
+                // header may contain multiple IPs by spec, first is usually what we care for.
+                ? forwardedForIp.ToString().Split(',').First()
                 // fallback to getting the raw IP.
-                userIp = Context.GetHttpContext()?.Connection.RemoteIpAddress?.ToString();
-            }
+                : Context.GetHttpContext()?.Connection.RemoteIpAddress?.ToString();
 
             using (var db = databaseFactory.GetInstance())
                 await db.AddLoginForUserAsync(usage.Item!.UserId, userIp);

--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -69,7 +69,7 @@ namespace osu.Server.Spectator
                 logging.ClearProviders();
                 logging.AddConsole();
 #if !DEBUG
-                logging.AddSentry();
+                logging.AddSentry(options => options.MinimumEventLevel = LogLevel.Warning);
 #endif
 
                 // IdentityModelEventSource.ShowPII = true;


### PR DESCRIPTION
This table is mostly used for bookkeeping, but it's worth populating it since there's a few systems which expect the data to be present.

As it stands, users which only play on lazer look as if they never login.

- [x] Test against full stack (in progress)