### PR TITLE
Remove status check for metadata update queue watching

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -292,7 +292,7 @@ namespace osu.Server.Spectator.Database
 
             if (lastQueueId.HasValue)
             {
-                var items = (await connection.QueryAsync<bss_process_queue_item>("SELECT * FROM bss_process_queue WHERE status = 2 AND queue_id > @lastQueueId LIMIT @limit", new
+                var items = (await connection.QueryAsync<bss_process_queue_item>("SELECT * FROM bss_process_queue WHERE queue_id > @lastQueueId LIMIT @limit", new
                 {
                     lastQueueId,
                     limit
@@ -301,7 +301,7 @@ namespace osu.Server.Spectator.Database
                 return new BeatmapUpdates(items.Select(i => i.beatmapset_id).ToArray(), items.LastOrDefault()?.queue_id ?? lastQueueId.Value);
             }
 
-            var lastEntry = await connection.QueryFirstOrDefaultAsync<bss_process_queue_item>("SELECT * FROM bss_process_queue WHERE status = 2 ORDER BY queue_id DESC LIMIT 1");
+            var lastEntry = await connection.QueryFirstOrDefaultAsync<bss_process_queue_item>("SELECT * FROM bss_process_queue ORDER BY queue_id DESC LIMIT 1");
 
             return new BeatmapUpdates(Array.Empty<int>(), lastEntry?.queue_id ?? 0);
         }


### PR DESCRIPTION
Went to check on this since there’s been a few reports recently of beatmaps in lazer getting stuck in “qualified” state that have since been ranked. Related code:  [web](https://github.com/ppy/osu-web/blob/a8256c7d461206607b118716ee5a94b2e4996cdf/app/Models/Beatmapset.php#L855-L854) / [spectator](https://github.com/ppy/osu-server-spectator/blob/dce812d8aba98f68a998db9db8105bab55def830/osu.Server.Spectator/Database/DatabaseAccess.cs#L295-L299) / [web-10 queue processing](https://github.com/peppy/osu-web-10/blob/master/www/web/update_bss_queue.php#L29-L53)

I think this is an issue with the `status=2` check and parallel processing of the queue. Imagine this scenario:

- osu-web inserts newly ranked beatmaps (let's say 10 get ranked at once) with `status=1`
- web-10 processes the queue with its every-minute-cron
- one beatmap takes a few minutes to generate due to having very large mp3
- a second web-10 cron process fires up and also begins processing, quickly processing beatmaps with short mp3s that are pending
- **spectator-server skips over the long mp3 entry and continues processing due to tracking `status=2` only
- first process finishes and updates long mp3 entry to `status=2` but spectator no longer cares about it because it's already tracking a newer ID

There's no reason for us to be waiting for completion of the queue items, as at the point of qualified -> ranked it's just a failsafe to ensure thumbnails/previews are in a pristine state, so the best solution is to drop this check.

Probably closes https://github.com/ppy/osu/issues/21332
