### PR TITLE
Always broadcast user presence to users' friends

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.114.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.114.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -30,9 +30,7 @@ namespace osu.Server.Spectator.Tests
         private readonly Mock<IMetadataClient> mockCaller;
         private readonly Mock<IMetadataClient> mockWatchersGroup;
         private readonly Mock<IGroupManager> mockGroupManager;
-
         private readonly Mock<IHubCallerClients<IMetadataClient>> mockClients;
-        private readonly Mock<HubCallerContext> mockUserContext;
 
         public MetadataHubTest()
         {
@@ -55,6 +53,7 @@ namespace osu.Server.Spectator.Tests
 
             mockWatchersGroup = new Mock<IMetadataClient>();
             mockCaller = new Mock<IMetadataClient>();
+            mockGroupManager = new Mock<IGroupManager>();
 
             mockClients = new Mock<IHubCallerClients<IMetadataClient>>();
             mockClients.Setup(clients => clients.Group(MetadataHub.ONLINE_PRESENCE_WATCHERS_GROUP))
@@ -64,10 +63,7 @@ namespace osu.Server.Spectator.Tests
             mockClients.Setup(clients => clients.Caller)
                        .Returns(mockCaller.Object);
 
-            mockGroupManager = new Mock<IGroupManager>();
-            mockUserContext = createUserContext(user_id);
-
-            hub.Context = mockUserContext.Object;
+            hub.Context = createUserContext(user_id).Object;
             hub.Clients = mockClients.Object;
             hub.Groups = mockGroupManager.Object;
         }

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
@@ -55,6 +57,8 @@ namespace osu.Server.Spectator.Tests
 
             var mockClients = new Mock<IHubCallerClients<IMetadataClient>>();
             mockClients.Setup(clients => clients.Group(MetadataHub.ONLINE_PRESENCE_WATCHERS_GROUP))
+                       .Returns(mockWatchersGroup.Object);
+            mockClients.Setup(clients => clients.Groups(It.Is<IReadOnlyList<string>>(list => list.Contains(MetadataHub.ONLINE_PRESENCE_WATCHERS_GROUP))))
                        .Returns(mockWatchersGroup.Object);
             mockClients.Setup(clients => clients.Caller)
                        .Returns(mockCaller.Object);

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -184,11 +184,13 @@ namespace osu.Server.Spectator.Tests
             // Friend connects...
             hub.Context = friendContext.Object;
             await hub.OnConnectedAsync();
+            await hub.UpdateStatus(UserStatus.Online);
             mockCaller.Verify(c => c.UserPresenceUpdated(friend_id, It.Is<UserPresence>(p => p.Status == UserStatus.Online)), Times.Once);
 
             // Non-friend connects...
             hub.Context = nonFriendContext.Object;
             await hub.OnConnectedAsync();
+            await hub.UpdateStatus(UserStatus.Online);
             mockCaller.Verify(c => c.UserPresenceUpdated(non_friend_id, It.IsAny<UserPresence>()), Times.Never);
 
             // Friend disconnects...

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.18.3" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -358,6 +358,16 @@ namespace osu.Server.Spectator.Database
             });
         }
 
+        public async Task<IEnumerable<phpbb_zebra>> GetUserFriendsAsync(int userId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QueryAsync<phpbb_zebra>("SELECT * FROM `phpbb_zebra` WHERE `user_id` = @UserId AND `friend` = 1", new
+            {
+                UserId = userId
+            });
+        }
+
         public async Task<bool> GetUserAllowsPMs(int userId)
         {
             var connection = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -358,14 +358,20 @@ namespace osu.Server.Spectator.Database
             });
         }
 
-        public async Task<IEnumerable<phpbb_zebra>> GetUserFriendsAsync(int userId)
+        public async Task<IEnumerable<int>> GetUserFriendsAsync(int userId)
         {
             var connection = await getConnectionAsync();
 
-            return await connection.QueryAsync<phpbb_zebra>("SELECT * FROM `phpbb_zebra` WHERE `user_id` = @UserId AND `friend` = 1", new
-            {
-                UserId = userId
-            });
+            // Query pulled from osu!bancho.
+            return await connection.QueryAsync<int>(
+                "SELECT zebra_id FROM phpbb_zebra z "
+                + "JOIN phpbb_users u ON z.zebra_id = u.user_id "
+                + "WHERE z.user_id = @UserId "
+                + "AND friend = 1 "
+                + "AND (`user_warnings` = '0' and `user_type` = '0')", new
+                {
+                    UserId = userId
+                });
         }
 
         public async Task<bool> GetUserAllowsPMs(int userId)

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -157,7 +157,7 @@ namespace osu.Server.Spectator.Database
         /// <summary>
         /// Lists the specified user's friends.
         /// </summary>
-        Task<IEnumerable<phpbb_zebra>> GetUserFriendsAsync(int userId);
+        Task<IEnumerable<int>> GetUserFriendsAsync(int userId);
 
         /// <summary>
         /// Returns <see langword="true"/> if the user with the supplied <paramref name="userId"/> allows private messages from people not on their friends list.

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -155,6 +155,11 @@ namespace osu.Server.Spectator.Database
         Task<phpbb_zebra?> GetUserRelation(int userId, int zebraId);
 
         /// <summary>
+        /// Lists the specified user's friends.
+        /// </summary>
+        Task<IEnumerable<phpbb_zebra>> GetUserFriendsAsync(int userId);
+
+        /// <summary>
         /// Returns <see langword="true"/> if the user with the supplied <paramref name="userId"/> allows private messages from people not on their friends list.
         /// </summary>
         Task<bool> GetUserAllowsPMs(int userId);

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -29,7 +29,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
         private readonly IScoreProcessedSubscriber scoreProcessedSubscriber;
 
         internal const string ONLINE_PRESENCE_WATCHERS_GROUP = "metadata:online-presence-watchers";
-        private static string friend_presence_watchers(int userId) => $"metadata:online-presence-watchers:{userId}";
+        internal static string FRIEND_PRESENCE_WATCHERS_GROUP(int userId) => $"metadata:online-presence-watchers:{userId}";
 
         internal static string MultiplayerRoomWatchersGroup(long roomId) => $"metadata:multiplayer-room-watchers:{roomId}";
 
@@ -77,7 +77,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
                 using (var db = databaseFactory.GetInstance())
                 {
                     foreach (int friendId in await db.GetUserFriendsAsync(usage.Item.UserId))
-                        await Groups.AddToGroupAsync(Context.ConnectionId, friend_presence_watchers(friendId));
+                        await Groups.AddToGroupAsync(Context.ConnectionId, FRIEND_PRESENCE_WATCHERS_GROUP(friendId));
                 }
             }
         }
@@ -201,7 +201,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
             using (var db = databaseFactory.GetInstance())
             {
                 foreach (int friendId in await db.GetUserFriendsAsync(state.UserId))
-                    await Groups.RemoveFromGroupAsync(state.ConnectionId, friend_presence_watchers(friendId));
+                    await Groups.RemoveFromGroupAsync(state.ConnectionId, FRIEND_PRESENCE_WATCHERS_GROUP(friendId));
             }
         }
 
@@ -210,7 +210,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
             if (userPresence?.Status == UserStatus.Offline)
                 userPresence = null;
 
-            return Clients.Groups(friend_presence_watchers(userId), ONLINE_PRESENCE_WATCHERS_GROUP).UserPresenceUpdated(userId, userPresence);
+            return Clients.Groups(FRIEND_PRESENCE_WATCHERS_GROUP(userId), ONLINE_PRESENCE_WATCHERS_GROUP).UserPresenceUpdated(userId, userPresence);
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -66,11 +66,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
                         versionHash = versionHash.Substring(versionHash.Length - 82, 32);
                 }
 
-                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash)
-                {
-                    UserStatus = UserStatus.Online
-                };
-
+                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash);
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
                 await Clients.Caller.DailyChallengeUpdated(dailyChallengeUpdater.Current);
 

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -78,9 +78,9 @@ namespace osu.Server.Spectator.Hubs.Metadata
                         await Groups.AddToGroupAsync(Context.ConnectionId, FRIEND_PRESENCE_WATCHERS_GROUP(friendId));
 
                         // Check if the friend is online, and if they are, broadcast to the connected user.
-                        using (var friendUsage = await GetStateFromUser(friendId))
+                        using (var friendUsage = await TryGetStateFromUser(friendId))
                         {
-                            if (friendUsage.Item != null && shouldBroadcastPresenceToOtherUsers(friendUsage.Item))
+                            if (friendUsage?.Item != null && shouldBroadcastPresenceToOtherUsers(friendUsage.Item))
                                 await Clients.Caller.UserPresenceUpdated(friendId, friendUsage.Item.ToUserPresence());
                         }
                     }

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -66,7 +66,11 @@ namespace osu.Server.Spectator.Hubs.Metadata
                         versionHash = versionHash.Substring(versionHash.Length - 82, 32);
                 }
 
-                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash);
+                usage.Item = new MetadataClientState(Context.ConnectionId, Context.GetUserId(), versionHash)
+                {
+                    UserStatus = UserStatus.Online
+                };
+
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
                 await Clients.Caller.DailyChallengeUpdated(dailyChallengeUpdater.Current);
 

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -72,8 +72,8 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
                 using (var db = databaseFactory.GetInstance())
                 {
-                    foreach (var friend in await db.GetUserFriendsAsync(usage.Item.UserId))
-                        await Groups.AddToGroupAsync(Context.ConnectionId, friend_presence_watchers(friend.zebra_id));
+                    foreach (int friendId in await db.GetUserFriendsAsync(usage.Item.UserId))
+                        await Groups.AddToGroupAsync(Context.ConnectionId, friend_presence_watchers(friendId));
                 }
             }
         }
@@ -196,8 +196,8 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using (var db = databaseFactory.GetInstance())
             {
-                foreach (var friend in await db.GetUserFriendsAsync(state.UserId))
-                    await Groups.RemoveFromGroupAsync(state.ConnectionId, friend_presence_watchers(friend.zebra_id));
+                foreach (int friendId in await db.GetUserFriendsAsync(state.UserId))
+                    await Groups.RemoveFromGroupAsync(state.ConnectionId, friend_presence_watchers(friendId));
             }
         }
 

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -197,12 +197,6 @@ namespace osu.Server.Spectator.Hubs.Metadata
             await base.CleanUpState(state);
             await broadcastUserPresenceUpdate(state.UserId, null);
             await scoreProcessedSubscriber.UnregisterFromAllMultiplayerRoomsAsync(state.UserId);
-
-            using (var db = databaseFactory.GetInstance())
-            {
-                foreach (int friendId in await db.GetUserFriendsAsync(state.UserId))
-                    await Groups.RemoveFromGroupAsync(state.ConnectionId, FRIEND_PRESENCE_WATCHERS_GROUP(friendId));
-            }
         }
 
         private Task broadcastUserPresenceUpdate(int userId, UserPresence? userPresence)

--- a/osu.Server.Spectator/Hubs/StatefulUserHub.cs
+++ b/osu.Server.Spectator/Hubs/StatefulUserHub.cs
@@ -122,5 +122,7 @@ namespace osu.Server.Spectator.Hubs
         }
 
         protected Task<ItemUsage<TUserState>> GetStateFromUser(int userId) => UserStates.GetForUse(userId);
+
+        protected Task<ItemUsage<TUserState>?> TryGetStateFromUser(int userId) => UserStates.TryGetForUse(userId);
     }
 }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,22 +6,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.405" />
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.411.6" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
         <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="DogStatsD-CSharp-Client" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1208.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.507.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="4.12.1" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.114.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.114.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
+        <PackageReference Include="Sentry.AspNetCore" Version="5.0.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu-server-spectator/pull/252
See client side changes in https://github.com/ppy/osu/pull/31444

Note that this doesn't update when the user adds/removes friends. That's left as a future task for when we figure out a method to signal changes to/from osu-web (redis, polling the database, or otherwise).