### PR TITLE
Avoid sending user presence updates when nothing has changed

### DIFF
--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -136,6 +136,17 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
+        public async Task FreshUserClientOnlyTriggersSinglePresence()
+        {
+            await hub.OnConnectedAsync();
+            await hub.UpdateStatus(UserStatus.DoNotDisturb);
+            await hub.UpdateActivity(null);
+
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Never);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.Is<UserPresence>(p => p.Status == UserStatus.DoNotDisturb)), Times.Exactly(1));
+        }
+
+        [Fact]
         public async Task UserLoginLogging()
         {
             await hub.OnConnectedAsync();

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -110,6 +110,10 @@ namespace osu.Server.Spectator.Hubs.Metadata
             using (var usage = await GetOrCreateLocalUserState())
             {
                 Debug.Assert(usage.Item != null);
+
+                if (usage.Item.UserActivity == null && activity == null)
+                    return;
+
                 usage.Item.UserActivity = activity;
 
                 await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
@@ -121,9 +125,12 @@ namespace osu.Server.Spectator.Hubs.Metadata
             using (var usage = await GetOrCreateLocalUserState())
             {
                 Debug.Assert(usage.Item != null);
-                usage.Item.UserStatus = status;
 
-                await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
+                if (usage.Item.UserStatus != status)
+                {
+                    usage.Item.UserStatus = status;
+                    await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
+                }
             }
         }
 


### PR DESCRIPTION
Noticed while testing that every client will send three presence updates on fresh connect to main menu.

This is testing the "user just starts game". If a user is, for instance, at song select, it will still trigger two updates (second being for the activity). The goal here is to optimise the most common flow to reduce overhead incurred on both client and server.