### PR TITLE
Ensure user state is never conveyed for "appear offline" users

### DIFF
--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -105,6 +105,8 @@ namespace osu.Server.Spectator.Tests
 
             using (var usage = await userStates.GetForUse(user_id, true))
                 Assert.Null(usage.Item);
+
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Once);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/MetadataHubTest.cs
+++ b/osu.Server.Spectator.Tests/MetadataHubTest.cs
@@ -79,8 +79,9 @@ namespace osu.Server.Spectator.Tests
             using (var usage = await userStates.GetForUse(user_id))
                 Assert.NotNull(usage.Item);
 
-            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Once);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
 
+            await hub.UpdateStatus(UserStatus.Online);
             await hub.UpdateActivity(new UserActivity.ChoosingBeatmap());
 
             using (var usage = await userStates.GetForUse(user_id))
@@ -110,13 +111,19 @@ namespace osu.Server.Spectator.Tests
         }
 
         [Fact]
-        public async Task OfflineUserUpdatesAreNotBroadcast()
+        public async Task UserSwitchingToAppearOfflineHandledCorrectly()
         {
             await hub.OnConnectedAsync();
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Never);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
 
+            await hub.UpdateStatus(UserStatus.Online);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Never);
             mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Once);
 
             await hub.UpdateStatus(UserStatus.Offline);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Once);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Once);
 
             using (var usage = await userStates.GetForUse(user_id))
             {
@@ -124,9 +131,9 @@ namespace osu.Server.Spectator.Tests
                 Assert.Equal(UserStatus.Offline, usage.Item!.UserStatus);
             }
 
-            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Once);
-
             await hub.UpdateActivity(new UserActivity.ChoosingBeatmap());
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Once);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Once);
 
             using (var usage = await userStates.GetForUse(user_id))
             {
@@ -134,7 +141,37 @@ namespace osu.Server.Spectator.Tests
                 Assert.IsType<UserActivity.ChoosingBeatmap>(usage.Item!.UserActivity);
             }
 
-            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Exactly(2));
+            await hub.OnDisconnectedAsync(null);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, null), Times.Once);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AppearOfflineUserUpdatesAreNeverBroadcast()
+        {
+            await hub.OnConnectedAsync();
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
+
+            await hub.UpdateStatus(UserStatus.Offline);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
+
+            using (var usage = await userStates.GetForUse(user_id))
+            {
+                Assert.NotNull(usage.Item!.UserStatus);
+                Assert.Equal(UserStatus.Offline, usage.Item!.UserStatus);
+            }
+
+            await hub.UpdateActivity(new UserActivity.ChoosingBeatmap());
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
+
+            using (var usage = await userStates.GetForUse(user_id))
+            {
+                Assert.NotNull(usage.Item!.UserActivity);
+                Assert.IsType<UserActivity.ChoosingBeatmap>(usage.Item!.UserActivity);
+            }
+
+            await hub.OnDisconnectedAsync(null);
+            mockWatchersGroup.Verify(client => client.UserPresenceUpdated(user_id, It.IsAny<UserPresence>()), Times.Never);
         }
 
         [Fact]

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -115,7 +115,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
                 usage.Item.UserActivity = activity;
 
-                if (shouldBroadcastPresentToOtherUsers(usage.Item))
+                if (shouldBroadcastPresenceToOtherUsers(usage.Item))
                     await broadcastUserPresenceUpdate(usage.Item.UserId, usage.Item.ToUserPresence());
             }
         }
@@ -212,7 +212,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
         protected override async Task CleanUpState(MetadataClientState state)
         {
             await base.CleanUpState(state);
-            if (shouldBroadcastPresentToOtherUsers(state))
+            if (shouldBroadcastPresenceToOtherUsers(state))
                 await broadcastUserPresenceUpdate(state.UserId, null);
             await scoreProcessedSubscriber.UnregisterFromAllMultiplayerRoomsAsync(state.UserId);
         }
@@ -225,7 +225,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
             return Clients.Group(ONLINE_PRESENCE_WATCHERS_GROUP).UserPresenceUpdated(userId, userPresence);
         }
 
-        private bool shouldBroadcastPresentToOtherUsers(MetadataClientState state)
+        private bool shouldBroadcastPresenceToOtherUsers(MetadataClientState state)
         {
             if (state.UserStatus == null)
                 return false;


### PR DESCRIPTION
Noticed during testing that "appear offline" doesn't actually work under the surface. If someone was to watch packets, they would be able to see invisible users and track their activity.

This change ensures that

- For fresh logins where the user already has their client set to "appear offline", nothing will be conveyed to other users.
- For existing logins, after a user changes their state to "appear offline" they will no longer convey anything to other users.

Of important note, I think this is only the start of the issue, as spectator server is probably still revealing play state to anyone that subscribes for it.. Fixing this either requires merging hubs (has been discussed IRL for other reasons) or possibly having the client conveying its "online" state when beginning a play session.

(Not touching on that today, will open an issue)

- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/256 for mergeability