### PR TITLE
Add support for creating, joining, and parting osu!web rooms via interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ To deploy this as part of a full osu! server stack deployment, [this wiki page](
 
 For advanced testing purposes.
 
-| Envvar name | Description | Default value |
-| :- | :- | :- |
-| `SAVE_REPLAYS` | Whether to save received replay frames from clients to replay files. `1` to enable, any other value to disable. | `""` (disabled) |
-| `REPLAY_UPLOAD_THREADS` | Number of threads to use when uploading complete replays. Must be positive number. | `1` |
-| `REPLAYS_PATH` | Local path to store complete replay files (`.osr`) to. Only used if [`FileScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/FileScoreStorage.cs) is active. | `./replays/` |
-| `S3_KEY` | An access key ID to use for uploading replays to [AWS S3](https://aws.amazon.com/s3/). Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""` |
-| `S3_SECRET` | The secret access key to use for uploading replays to [AWS S3](https://aws.amazon.com/s3/). Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""` |
-| `REPLAYS_BUCKET` | The name of the [AWS S3](https://aws.amazon.com/s3/) bucket to upload replays to. Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""` |
-| `TRACK_BUILD_USER_COUNTS` | Whether to track how many users are on a particular build of the game and report that information to the database at `DB_{HOST,PORT}`. `1` to enable, any other value to disable. | `""` (disabled) |
-| `SERVER_PORT` | Which port the server should listen on for incoming connections. | `80` |
-| `REDIS_HOST` | Connection string to `osu-web` Redis instance. | `localhost` |
-| `DD_AGENT_HOST` | Hostname under which the [Datadog](https://www.datadoghq.com/) agent host can be found. | `localhost` |
-| `DB_HOST` | Hostname under which the `osu-web` MySQL instance can be found. | `localhost` |
-| `DB_PORT` | Port under which the `osu-web` MySQL instance can be found. | `3306` |
-| `DB_USER` | Username to use when logging into the `osu-web` MySQL instance. | `osuweb` |
+| Envvar name | Description | Default value     |
+| :- | :- |:------------------|
+| `SAVE_REPLAYS` | Whether to save received replay frames from clients to replay files. `1` to enable, any other value to disable. | `""` (disabled)   |
+| `REPLAY_UPLOAD_THREADS` | Number of threads to use when uploading complete replays. Must be positive number. | `1`               |
+| `REPLAYS_PATH` | Local path to store complete replay files (`.osr`) to. Only used if [`FileScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/FileScoreStorage.cs) is active. | `./replays/`      |
+| `S3_KEY` | An access key ID to use for uploading replays to [AWS S3](https://aws.amazon.com/s3/). Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""`              |
+| `S3_SECRET` | The secret access key to use for uploading replays to [AWS S3](https://aws.amazon.com/s3/). Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""`              |
+| `REPLAYS_BUCKET` | The name of the [AWS S3](https://aws.amazon.com/s3/) bucket to upload replays to. Only used if [`S3ScoreStorage`](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Storage/S3ScoreStorage.cs) is active. | `""`              |
+| `TRACK_BUILD_USER_COUNTS` | Whether to track how many users are on a particular build of the game and report that information to the database at `DB_{HOST,PORT}`. `1` to enable, any other value to disable. | `""` (disabled)   |
+| `SERVER_PORT` | Which port the server should listen on for incoming connections. | `80`              |
+| `REDIS_HOST` | Connection string to `osu-web` Redis instance. | `localhost`       |
+| `DD_AGENT_HOST` | Hostname under which the [Datadog](https://www.datadoghq.com/) agent host can be found. | `localhost`       |
+| `DB_HOST` | Hostname under which the `osu-web` MySQL instance can be found. | `localhost`       |
+| `DB_PORT` | Port under which the `osu-web` MySQL instance can be found. | `3306`            |
+| `DB_USER` | Username to use when logging into the `osu-web` MySQL instance. | `osuweb`          |
+| `LEGACY_IO_DOMAIN` | The root URL of the osu-web instance to which legacy IO call should be submitted | `null` (required) |
+| `SHARED_INTEROP_SECRET` | The value of the same environment variable that the target osu-web instance specifies in `.env`. | `null` (required) |

--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -61,6 +61,11 @@ namespace SampleMultiplayerClient
 
         public MultiplayerRoom? Room { get; private set; }
 
+        public Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task<MultiplayerRoom> JoinRoom(long roomId)
         {
             return await JoinRoomWithPassword(roomId, string.Empty);

--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -62,19 +62,13 @@ namespace SampleMultiplayerClient
         public MultiplayerRoom? Room { get; private set; }
 
         public Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)
-        {
-            throw new NotImplementedException();
-        }
+            => connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.CreateRoom), room);
 
         public async Task<MultiplayerRoom> JoinRoom(long roomId)
-        {
-            return await JoinRoomWithPassword(roomId, string.Empty);
-        }
+            => await JoinRoomWithPassword(roomId, string.Empty);
 
         public async Task<MultiplayerRoom> JoinRoomWithPassword(long roomId, string? password = null)
-        {
-            return Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty);
-        }
+            => Room = await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty);
 
         public async Task LeaveRoom()
         {

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -16,6 +16,7 @@ using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs.Multiplayer;
+using osu.Server.Spectator.Services;
 
 namespace osu.Server.Spectator.Tests.Multiplayer
 {
@@ -130,13 +131,16 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
                              .Returns(new Mock<ILogger>().Object);
 
+            var legacyIOMock = new Mock<ILegacyIO>();
+
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,
                 Rooms,
                 UserStates,
                 DatabaseFactory.Object,
                 new ChatFilters(DatabaseFactory.Object),
-                hubContext.Object);
+                hubContext.Object,
+                legacyIOMock.Object);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;
 

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -38,6 +38,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         protected readonly Mock<IDatabaseFactory> DatabaseFactory;
         protected readonly Mock<IDatabaseAccess> Database;
 
+        protected readonly Mock<ILegacyIO> LegacyIO;
+
         /// <summary>
         /// A general non-gameplay receiver for the room with ID <see cref="ROOM_ID"/>.
         /// </summary>
@@ -131,7 +133,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
                              .Returns(new Mock<ILogger>().Object);
 
-            var legacyIOMock = new Mock<ILegacyIO>();
+            LegacyIO = new Mock<ILegacyIO>();
 
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,
@@ -140,7 +142,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 DatabaseFactory.Object,
                 new ChatFilters(DatabaseFactory.Object),
                 hubContext.Object,
-                legacyIOMock.Object);
+                LegacyIO.Object);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;
 

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomInteropTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomInteropTest.cs
@@ -20,7 +20,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
             await Hub.CreateRoom(new MultiplayerRoom(0));
             LegacyIO.Verify(io => io.CreateRoomAsync(USER_ID, It.IsAny<MultiplayerRoom>()), Times.Once);
-            LegacyIO.Verify(io => io.JoinRoomAsync(ROOM_ID, USER_ID), Times.Once);
+            LegacyIO.Verify(io => io.AddUserToRoomAsync(ROOM_ID, USER_ID), Times.Once);
 
             using (var usage = await Hub.GetRoom(ROOM_ID))
             {
@@ -33,10 +33,10 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task LeaveRoom()
         {
             await Hub.JoinRoom(ROOM_ID);
-            LegacyIO.Verify(io => io.PartRoomAsync(ROOM_ID, USER_ID), Times.Never);
+            LegacyIO.Verify(io => io.RemoveUserFromRoomAsync(ROOM_ID, USER_ID), Times.Never);
 
             await Hub.LeaveRoom();
-            LegacyIO.Verify(io => io.PartRoomAsync(ROOM_ID, USER_ID), Times.Once);
+            LegacyIO.Verify(io => io.RemoveUserFromRoomAsync(ROOM_ID, USER_ID), Times.Once);
 
             await Assert.ThrowsAsync<KeyNotFoundException>(() => Hub.GetRoom(ROOM_ID));
         }

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomInteropTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomInteropTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using osu.Game.Online.Multiplayer;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests.Multiplayer
+{
+    public class RoomInteropTest : MultiplayerTest
+    {
+        [Fact]
+        public async Task CreateRoom()
+        {
+            LegacyIO.Setup(io => io.CreateRoomAsync(It.IsAny<int>(), It.IsAny<MultiplayerRoom>()))
+                    .ReturnsAsync(() => ROOM_ID);
+
+            await Hub.CreateRoom(new MultiplayerRoom(0));
+            LegacyIO.Verify(io => io.CreateRoomAsync(USER_ID, It.IsAny<MultiplayerRoom>()), Times.Once);
+            LegacyIO.Verify(io => io.JoinRoomAsync(ROOM_ID, USER_ID), Times.Once);
+
+            using (var usage = await Hub.GetRoom(ROOM_ID))
+            {
+                Assert.NotNull(usage.Item);
+                Assert.Equal(USER_ID, usage.Item.Users.Single().UserID);
+            }
+        }
+
+        [Fact]
+        public async Task LeaveRoom()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+            LegacyIO.Verify(io => io.PartRoomAsync(ROOM_ID, USER_ID), Times.Never);
+
+            await Hub.LeaveRoom();
+            LegacyIO.Verify(io => io.PartRoomAsync(ROOM_ID, USER_ID), Times.Once);
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => Hub.GetRoom(ROOM_ID));
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Hubs.Multiplayer;
+using osu.Server.Spectator.Services;
 
 namespace osu.Server.Spectator.Tests.Multiplayer
 {
@@ -19,8 +20,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             EntityStore<MultiplayerClientState> users,
             IDatabaseFactory databaseFactory,
             ChatFilters chatFilters,
-            IHubContext<MultiplayerHub> hubContext)
-            : base(loggerFactory, rooms, users, databaseFactory, chatFilters, hubContext)
+            IHubContext<MultiplayerHub> hubContext,
+            ILegacyIO legacyIO)
+            : base(loggerFactory, rooms, users, databaseFactory, chatFilters, hubContext, legacyIO)
         {
         }
 

--- a/osu.Server.Spectator.sln.DotSettings
+++ b/osu.Server.Spectator.sln.DotSettings
@@ -354,6 +354,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HUD/@EntryIndexedValue">HUD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IL/@EntryIndexedValue">IL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IOS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -34,6 +34,9 @@ namespace osu.Server.Spectator
         public static string DatabaseUser { get; }
         public static string DatabasePort { get; }
 
+        public static string LegacyIODomain { get; }
+        public static string SharedInteropSecret { get; }
+
         static AppSettings()
         {
             SaveReplays = Environment.GetEnvironmentVariable("SAVE_REPLAYS") == "1";
@@ -53,6 +56,14 @@ namespace osu.Server.Spectator
             DatabaseHost = Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost";
             DatabaseUser = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             DatabasePort = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
+
+            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN")
+                             ?? throw new InvalidOperationException("LEGACY_IO_DOMAIN environment variable not set. "
+                                                                    + "Please set the value of this variable to the root URL of the osu-web instance to which legacy IO call should be submitted.");
+
+            SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET")
+                                  ?? throw new InvalidOperationException("SHARED_INTEROP_SECRET environment variable not set. "
+                                                                         + "Please set the value of this variable to the value of the same environment variable that the target osu-web instance specifies in `.env`.");
         }
     }
 }

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -57,13 +57,8 @@ namespace osu.Server.Spectator
             DatabaseUser = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             DatabasePort = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
 
-            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN")
-                             ?? throw new InvalidOperationException("LEGACY_IO_DOMAIN environment variable not set. "
-                                                                    + "Please set the value of this variable to the root URL of the osu-web instance to which legacy IO call should be submitted.");
-
-            SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET")
-                                  ?? throw new InvalidOperationException("SHARED_INTEROP_SECRET environment variable not set. "
-                                                                         + "Please set the value of this variable to the value of the same environment variable that the target osu-web instance specifies in `.env`.");
+            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN") ?? string.Empty;
+            SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET") ?? string.Empty;
         }
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using osu.Server.Spectator.Hubs;
 using osu.Server.Spectator.Hubs.Metadata;
 using osu.Server.Spectator.Hubs.Multiplayer;
 using osu.Server.Spectator.Hubs.Spectator;
+using osu.Server.Spectator.Services;
 using osu.Server.Spectator.Storage;
 using StackExchange.Redis;
 
@@ -17,20 +18,23 @@ namespace osu.Server.Spectator.Extensions
     {
         public static IServiceCollection AddHubEntities(this IServiceCollection serviceCollection)
         {
-            return serviceCollection.AddSingleton<EntityStore<SpectatorClientState>>()
-                                    .AddSingleton<EntityStore<MultiplayerClientState>>()
-                                    .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
-                                    .AddSingleton<EntityStore<ConnectionState>>()
-                                    .AddSingleton<EntityStore<MetadataClientState>>()
-                                    .AddSingleton<GracefulShutdownManager>()
-                                    .AddSingleton<MetadataBroadcaster>()
-                                    .AddSingleton<IScoreStorage, S3ScoreStorage>()
-                                    .AddSingleton<ScoreUploader>()
-                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
-                                    .AddSingleton<BuildUserCountUpdater>()
-                                    .AddSingleton<ChatFilters>()
-                                    .AddSingleton<IDailyChallengeUpdater, DailyChallengeUpdater>()
-                                    .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>());
+            return serviceCollection
+                   .AddHttpClient()
+                   .AddTransient<ILegacyIO, LegacyIO>()
+                   .AddSingleton<EntityStore<SpectatorClientState>>()
+                   .AddSingleton<EntityStore<MultiplayerClientState>>()
+                   .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
+                   .AddSingleton<EntityStore<ConnectionState>>()
+                   .AddSingleton<EntityStore<MetadataClientState>>()
+                   .AddSingleton<GracefulShutdownManager>()
+                   .AddSingleton<MetadataBroadcaster>()
+                   .AddSingleton<IScoreStorage, S3ScoreStorage>()
+                   .AddSingleton<ScoreUploader>()
+                   .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
+                   .AddSingleton<BuildUserCountUpdater>()
+                   .AddSingleton<ChatFilters>()
+                   .AddSingleton<IDailyChallengeUpdater, DailyChallengeUpdater>()
+                   .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>());
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -18,23 +18,22 @@ namespace osu.Server.Spectator.Extensions
     {
         public static IServiceCollection AddHubEntities(this IServiceCollection serviceCollection)
         {
-            return serviceCollection
-                   .AddHttpClient()
-                   .AddTransient<ILegacyIO, LegacyIO>()
-                   .AddSingleton<EntityStore<SpectatorClientState>>()
-                   .AddSingleton<EntityStore<MultiplayerClientState>>()
-                   .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
-                   .AddSingleton<EntityStore<ConnectionState>>()
-                   .AddSingleton<EntityStore<MetadataClientState>>()
-                   .AddSingleton<GracefulShutdownManager>()
-                   .AddSingleton<MetadataBroadcaster>()
-                   .AddSingleton<IScoreStorage, S3ScoreStorage>()
-                   .AddSingleton<ScoreUploader>()
-                   .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
-                   .AddSingleton<BuildUserCountUpdater>()
-                   .AddSingleton<ChatFilters>()
-                   .AddSingleton<IDailyChallengeUpdater, DailyChallengeUpdater>()
-                   .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>());
+            return serviceCollection.AddHttpClient()
+                                    .AddTransient<ILegacyIO, LegacyIO>()
+                                    .AddSingleton<EntityStore<SpectatorClientState>>()
+                                    .AddSingleton<EntityStore<MultiplayerClientState>>()
+                                    .AddSingleton<EntityStore<ServerMultiplayerRoom>>()
+                                    .AddSingleton<EntityStore<ConnectionState>>()
+                                    .AddSingleton<EntityStore<MetadataClientState>>()
+                                    .AddSingleton<GracefulShutdownManager>()
+                                    .AddSingleton<MetadataBroadcaster>()
+                                    .AddSingleton<IScoreStorage, S3ScoreStorage>()
+                                    .AddSingleton<ScoreUploader>()
+                                    .AddSingleton<IScoreProcessedSubscriber, ScoreProcessedSubscriber>()
+                                    .AddSingleton<BuildUserCountUpdater>()
+                                    .AddSingleton<ChatFilters>()
+                                    .AddSingleton<IDailyChallengeUpdater, DailyChallengeUpdater>()
+                                    .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>());
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         public async Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)
         {
             Log($"{Context.GetUserId()} creating room");
-            return await JoinRoomWithPassword(await legacyIO.CreateRoom(Context.GetUserId(), room), room.Settings.Password);
+            return await JoinRoomWithPassword(await legacyIO.CreateRoomAsync(Context.GetUserId(), room), room.Settings.Password);
         }
 
         public Task<MultiplayerRoom> JoinRoom(long roomId) => JoinRoomWithPassword(roomId, string.Empty);
@@ -63,7 +63,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     throw new InvalidStateException("Can't join a room when restricted.");
             }
 
-            await legacyIO.JoinRoom(roomId, Context.GetUserId());
+            await legacyIO.JoinRoomAsync(roomId, Context.GetUserId());
 
             using (var userUsage = await GetOrCreateLocalUserState())
             {
@@ -894,7 +894,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         private async Task leaveRoom(MultiplayerClientState state, bool wasKick)
         {
-            await legacyIO.PartRoom(state.CurrentRoomID, state.UserId);
+            await legacyIO.PartRoomAsync(state.CurrentRoomID, state.UserId);
 
             using (var roomUsage = await getLocalUserRoom(state))
                 await leaveRoom(state, roomUsage, wasKick);

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -45,6 +45,20 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             HubContext = new MultiplayerHubContext(hubContext, rooms, users, databaseFactory, loggerFactory);
         }
 
+        public async Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)
+        {
+            Log($"{Context.GetUserId()} creating room");
+
+            try
+            {
+                return await JoinRoomWithPassword(await legacyIO.CreateRoom(Context.GetUserId(), room), room.Settings.Password);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidStateException($"Failed to create the multiplayer room ({ex.Message}).");
+            }
+        }
+
         public Task<MultiplayerRoom> JoinRoom(long roomId) => JoinRoomWithPassword(roomId, string.Empty);
 
         public async Task<MultiplayerRoom> JoinRoomWithPassword(long roomId, string password)

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -48,15 +48,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         public async Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)
         {
             Log($"{Context.GetUserId()} creating room");
-
-            try
-            {
-                return await JoinRoomWithPassword(await legacyIO.CreateRoom(Context.GetUserId(), room), room.Settings.Password);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidStateException($"Failed to create the multiplayer room ({ex.Message}).");
-            }
+            return await JoinRoomWithPassword(await legacyIO.CreateRoom(Context.GetUserId(), room), room.Settings.Password);
         }
 
         public Task<MultiplayerRoom> JoinRoom(long roomId) => JoinRoomWithPassword(roomId, string.Empty);
@@ -739,8 +731,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         protected override async Task CleanUpState(MultiplayerClientState state)
         {
-            await leaveRoom(state, true);
             await base.CleanUpState(state);
+            await leaveRoom(state, true);
         }
 
         private async Task setNewHost(MultiplayerRoom room, MultiplayerRoomUser newHost)

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -16,6 +16,7 @@ using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Entities;
 using osu.Server.Spectator.Extensions;
+using osu.Server.Spectator.Services;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer
 {
@@ -25,6 +26,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         protected readonly MultiplayerHubContext HubContext;
         private readonly IDatabaseFactory databaseFactory;
         private readonly ChatFilters chatFilters;
+        private readonly ILegacyIO legacyIO;
 
         public MultiplayerHub(
             ILoggerFactory loggerFactory,
@@ -32,12 +34,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             EntityStore<MultiplayerClientState> users,
             IDatabaseFactory databaseFactory,
             ChatFilters chatFilters,
-            IHubContext<MultiplayerHub> hubContext)
+            IHubContext<MultiplayerHub> hubContext,
+            ILegacyIO legacyIO)
             : base(loggerFactory, users)
         {
             Rooms = rooms;
             this.databaseFactory = databaseFactory;
             this.chatFilters = chatFilters;
+            this.legacyIO = legacyIO;
             HubContext = new MultiplayerHubContext(hubContext, rooms, users, databaseFactory, loggerFactory);
         }
 

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -9,25 +9,34 @@ namespace osu.Server.Spectator.Services
     public interface ILegacyIO
     {
         /// <summary>
-        /// Creates an osu!web Room.
+        /// Creates an osu!web room.
         /// </summary>
+        /// <remarks>
+        /// This does not join the creating user to the room. A subsequent call to <see cref="AddUserToRoomAsync"/> should be made if required.
+        /// </remarks>
         /// <param name="userId">The ID of the user that wants to create the room.</param>
         /// <param name="room">The room.</param>
         /// <returns>The room's ID.</returns>
         Task<long> CreateRoomAsync(int userId, MultiplayerRoom room);
 
         /// <summary>
-        /// Joins an osu!web Room.
+        /// Adds a user to an osu!web room.
         /// </summary>
+        /// <remarks>
+        /// This performs setup tasks like adding the user to the relevant chat channel.
+        /// </remarks>
         /// <param name="roomId">The ID of the room to join.</param>
         /// <param name="userId">The ID of the user wanting to join the room.</param>
-        Task JoinRoomAsync(long roomId, int userId);
+        Task AddUserToRoomAsync(long roomId, int userId);
 
         /// <summary>
-        /// Parts an osu!web Room.
+        /// Parts an osu!web room.
         /// </summary>
+        /// <remarks>
+        /// This performs setup tasks like removing the user from any relevant chat channels.
+        /// </remarks>
         /// <param name="roomId">The ID of the room to part.</param>
         /// <param name="userId">The ID of the user wanting to part the room.</param>
-        Task PartRoomAsync(long roomId, int userId);
+        Task RemoveUserFromRoomAsync(long roomId, int userId);
     }
 }

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -14,10 +14,10 @@ namespace osu.Server.Spectator.Services
         /// <remarks>
         /// This does not join the creating user to the room. A subsequent call to <see cref="AddUserToRoomAsync"/> should be made if required.
         /// </remarks>
-        /// <param name="userId">The ID of the user that wants to create the room.</param>
+        /// <param name="hostUserId">The ID of the user that wants to create the room.</param>
         /// <param name="room">The room.</param>
         /// <returns>The room's ID.</returns>
-        Task<long> CreateRoomAsync(int userId, MultiplayerRoom room);
+        Task<long> CreateRoomAsync(int hostUserId, MultiplayerRoom room);
 
         /// <summary>
         /// Adds a user to an osu!web room.

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -14,20 +14,20 @@ namespace osu.Server.Spectator.Services
         /// <param name="userId">The ID of the user that wants to create the room.</param>
         /// <param name="room">The room.</param>
         /// <returns>The room's ID.</returns>
-        Task<long> CreateRoom(int userId, MultiplayerRoom room);
+        Task<long> CreateRoomAsync(int userId, MultiplayerRoom room);
 
         /// <summary>
         /// Joins an osu!web Room.
         /// </summary>
         /// <param name="roomId">The ID of the room to join.</param>
         /// <param name="userId">The ID of the user wanting to join the room.</param>
-        Task JoinRoom(long roomId, int userId);
+        Task JoinRoomAsync(long roomId, int userId);
 
         /// <summary>
         /// Parts an osu!web Room.
         /// </summary>
         /// <param name="roomId">The ID of the room to part.</param>
         /// <param name="userId">The ID of the user wanting to part the room.</param>
-        Task PartRoom(long roomId, int userId);
+        Task PartRoomAsync(long roomId, int userId);
     }
 }

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -1,9 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
+using osu.Game.Online.Multiplayer;
+
 namespace osu.Server.Spectator.Services
 {
     public interface ILegacyIO
     {
+        Task<long> CreateRoom(int userId, MultiplayerRoom room);
     }
 }

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -9,5 +9,9 @@ namespace osu.Server.Spectator.Services
     public interface ILegacyIO
     {
         Task<long> CreateRoom(int userId, MultiplayerRoom room);
+
+        Task JoinRoom(long roomId, int userId);
+
+        Task PartRoom(long roomId, int userId);
     }
 }

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -1,0 +1,9 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.Spectator.Services
+{
+    public interface ILegacyIO
+    {
+    }
+}

--- a/osu.Server.Spectator/Services/ILegacyIO.cs
+++ b/osu.Server.Spectator/Services/ILegacyIO.cs
@@ -8,10 +8,26 @@ namespace osu.Server.Spectator.Services
 {
     public interface ILegacyIO
     {
+        /// <summary>
+        /// Creates an osu!web Room.
+        /// </summary>
+        /// <param name="userId">The ID of the user that wants to create the room.</param>
+        /// <param name="room">The room.</param>
+        /// <returns>The room's ID.</returns>
         Task<long> CreateRoom(int userId, MultiplayerRoom room);
 
+        /// <summary>
+        /// Joins an osu!web Room.
+        /// </summary>
+        /// <param name="roomId">The ID of the room to join.</param>
+        /// <param name="userId">The ID of the user wanting to join the room.</param>
         Task JoinRoom(long roomId, int userId);
 
+        /// <summary>
+        /// Parts an osu!web Room.
+        /// </summary>
+        /// <param name="roomId">The ID of the room to part.</param>
+        /// <param name="userId">The ID of the user wanting to part the room.</param>
         Task PartRoom(long roomId, int userId);
     }
 }

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -137,8 +137,14 @@ namespace osu.Server.Spectator.Services
             await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
+        /// <summary>
+        /// A special <see cref="Room"/> that can be serialised with Newtonsoft.Json to create rooms hosted by a given <see cref="HostUserId">user</see>.
+        /// </summary>
         private class RoomWithHostId : Room
         {
+            /// <summary>
+            /// The ID of the user to host the room.
+            /// </summary>
             [Newtonsoft.Json.JsonProperty("user_id")]
             public required int HostUserId { get; init; }
 

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace osu.Server.Spectator.Services
+{
+    public class LegacyIO : ILegacyIO
+    {
+        private readonly HttpClient httpClient;
+        private readonly ILogger logger;
+
+        public LegacyIO(HttpClient httpClient, ILoggerFactory loggerFactory)
+        {
+            this.httpClient = httpClient;
+            logger = loggerFactory.CreateLogger("LIO");
+        }
+
+        private async Task<string> runLegacyIO(HttpMethod method, string command, dynamic? postObject = null)
+        {
+            int retryCount = 3;
+
+            retry:
+
+            long time = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            string url = $"{AppSettings.LegacyIODomain}/_lio/{command}{(command.Contains('?') ? "&" : "?")}timestamp={time}";
+
+            string? serialisedPostObject = postObject == null ? null : JsonSerializer.Serialize(postObject);
+            logger.LogDebug("Performing LIO request to {method} {url} (params: {params})", method, url, serialisedPostObject);
+
+            try
+            {
+                string signature = hmacEncode(url, Encoding.UTF8.GetBytes(AppSettings.SharedInteropSecret));
+
+                var httpRequestMessage = new HttpRequestMessage
+                {
+                    RequestUri = new Uri(url),
+                    Method = method,
+                    Headers =
+                    {
+                        { "X-LIO-Signature", signature },
+                        { "Accept", "application/json" },
+                    },
+                };
+
+                if (serialisedPostObject != null)
+                {
+                    httpRequestMessage.Content = new ByteArrayContent(Encoding.UTF8.GetBytes(serialisedPostObject));
+                    httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                }
+
+                var response = await httpClient.SendAsync(httpRequestMessage);
+
+                if (!response.IsSuccessStatusCode)
+                    throw new InvalidOperationException($"Legacy IO request to {url} failed with {response.StatusCode} ({response.Content.ReadAsStringAsync().Result})");
+
+                if ((int)response.StatusCode >= 300)
+                    throw new Exception($"Legacy IO request to {url} returned unexpected response {response.StatusCode} ({response.ReasonPhrase})");
+
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch (Exception e)
+            {
+                if (retryCount-- > 0)
+                {
+                    logger.LogError(e, "Legacy IO request to {url} failed, retrying ({retries} remaining)", url, retryCount);
+                    Thread.Sleep(1000);
+                    goto retry;
+                }
+
+                throw;
+            }
+        }
+
+        private static string hmacEncode(string input, byte[] key)
+        {
+            byte[] byteArray = Encoding.ASCII.GetBytes(input);
+
+            using (var hmac = new HMACSHA1(key))
+            {
+                byte[] hashArray = hmac.ComputeHash(byteArray);
+                return hashArray.Aggregate(string.Empty, (s, e) => s + $"{e:x2}", s => s);
+            }
+        }
+
+        // Methods below purposefully async-await on `runLegacyIO()` calls rather than directly returning the underlying calls.
+        // This is done for better readability of exception stacks. Directly returning the tasks elides the name of the proxying method.
+    }
+}

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -102,7 +102,7 @@ namespace osu.Server.Spectator.Services
         // Methods below purposefully async-await on `runLegacyIO()` calls rather than directly returning the underlying calls.
         // This is done for better readability of exception stacks. Directly returning the tasks elides the name of the proxying method.
 
-        public async Task<long> CreateRoom(int userId, MultiplayerRoom room)
+        public async Task<long> CreateRoomAsync(int userId, MultiplayerRoom room)
         {
             return long.Parse(await runLegacyIO(HttpMethod.Post, "multiplayer/rooms", Newtonsoft.Json.JsonConvert.SerializeObject(new CreateRoomRequest(room)
             {
@@ -110,12 +110,12 @@ namespace osu.Server.Spectator.Services
             })));
         }
 
-        public async Task JoinRoom(long roomId, int userId)
+        public async Task JoinRoomAsync(long roomId, int userId)
         {
             await runLegacyIO(HttpMethod.Put, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
-        public async Task PartRoom(long roomId, int userId)
+        public async Task PartRoomAsync(long roomId, int userId)
         {
             await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
         }

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -127,12 +127,12 @@ namespace osu.Server.Spectator.Services
             })));
         }
 
-        public async Task JoinRoomAsync(long roomId, int userId)
+        public async Task AddUserToRoomAsync(long roomId, int userId)
         {
             await runLegacyIO(HttpMethod.Put, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
-        public async Task PartRoomAsync(long roomId, int userId)
+        public async Task RemoveUserFromRoomAsync(long roomId, int userId)
         {
             await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
         }

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -48,12 +48,22 @@ namespace osu.Server.Spectator.Services
             long time = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             string url = $"{interopDomain}/_lio/{command}{(command.Contains('?') ? "&" : "?")}timestamp={time}";
 
-            string? serialisedPostObject = postObject switch
+            string? serialisedPostObject;
+
+            switch (postObject)
             {
-                null => null,
-                string => postObject,
-                _ => JsonSerializer.Serialize(postObject)
-            };
+                case null:
+                    serialisedPostObject = null;
+                    break;
+
+                case string:
+                    serialisedPostObject = postObject;
+                    break;
+
+                default:
+                    serialisedPostObject = JsonSerializer.Serialize(postObject);
+                    break;
+            }
 
             logger.LogDebug("Performing LIO request to {method} {url} (params: {params})", method, url, serialisedPostObject);
 

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -92,11 +92,8 @@ namespace osu.Server.Spectator.Services
         {
             byte[] byteArray = Encoding.ASCII.GetBytes(input);
 
-            using (var hmac = new HMACSHA1(key))
-            {
-                byte[] hashArray = hmac.ComputeHash(byteArray);
-                return hashArray.Aggregate(string.Empty, (s, e) => s + $"{e:x2}", s => s);
-            }
+            byte[] hashArray = HMACSHA1.HashData(key, byteArray);
+            return hashArray.Aggregate(string.Empty, (s, e) => s + $"{e:x2}", s => s);
         }
 
         // Methods below purposefully async-await on `runLegacyIO()` calls rather than directly returning the underlying calls.

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -119,11 +119,11 @@ namespace osu.Server.Spectator.Services
         // Methods below purposefully async-await on `runLegacyIO()` calls rather than directly returning the underlying calls.
         // This is done for better readability of exception stacks. Directly returning the tasks elides the name of the proxying method.
 
-        public async Task<long> CreateRoomAsync(int userId, MultiplayerRoom room)
+        public async Task<long> CreateRoomAsync(int hostUserId, MultiplayerRoom room)
         {
-            return long.Parse(await runLegacyIO(HttpMethod.Post, "multiplayer/rooms", Newtonsoft.Json.JsonConvert.SerializeObject(new CreateRoomRequest(room)
+            return long.Parse(await runLegacyIO(HttpMethod.Post, "multiplayer/rooms", Newtonsoft.Json.JsonConvert.SerializeObject(new RoomWithHostId(room)
             {
-                UserId = userId
+                HostUserId = hostUserId
             })));
         }
 
@@ -137,15 +137,15 @@ namespace osu.Server.Spectator.Services
             await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
-        private class CreateRoomRequest : Room
+        private class RoomWithHostId : Room
         {
             [Newtonsoft.Json.JsonProperty("user_id")]
-            public required int UserId { get; init; }
+            public required int HostUserId { get; init; }
 
             /// <summary>
             /// Creates a <see cref="Room"/> from a <see cref="MultiplayerRoom"/>.
             /// </summary>
-            public CreateRoomRequest(MultiplayerRoom room)
+            public RoomWithHostId(MultiplayerRoom room)
             {
                 RoomID = room.RoomID;
                 Host = room.Host?.User;

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -111,6 +111,16 @@ namespace osu.Server.Spectator.Services
             })));
         }
 
+        public async Task JoinRoom(long roomId, int userId)
+        {
+            await runLegacyIO(HttpMethod.Put, $"multiplayer/rooms/{roomId}/users/{userId}");
+        }
+
+        public async Task PartRoom(long roomId, int userId)
+        {
+            await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
+        }
+
         private class CreateRoomRequest : Room
         {
             [Newtonsoft.Json.JsonProperty("user_id")]

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -156,7 +156,6 @@ namespace osu.Server.Spectator.Services
                 AutoStartDuration = room.Settings.AutoStartDuration;
                 AutoSkip = room.Settings.AutoSkip;
                 Playlist = room.Playlist.Select(item => new PlaylistItem(item)).ToArray();
-                CurrentPlaylistItem = Playlist.FirstOrDefault(item => item.ID == room.Settings.PlaylistItemId);
             }
         }
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-web/pull/11811
- Depends on https://github.com/ppy/osu/pull/31637 for new method added to the interface.

This server needs the ability to manage rooms for matchmaking. Because I intend to use the existing `MultiplayerHub` for matchmaking messages, I took a bit of a detour and made it the single endpoint for creating multiplayer rooms so that the client will no longer need to juggle two endpoints for doing certain things.

I see a future where we move playlists, daily challenge, and even the lounge to this server, but I'm taking small meaningful steps because matchmaking is the goal for now.