### PR TITLE
Use base ctor to remove unnecessary property copies

### DIFF
--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -152,16 +152,8 @@ namespace osu.Server.Spectator.Services
             /// Creates a <see cref="Room"/> from a <see cref="MultiplayerRoom"/>.
             /// </summary>
             public RoomWithHostId(MultiplayerRoom room)
+                : base(room)
             {
-                RoomID = room.RoomID;
-                Host = room.Host?.User;
-                Name = room.Settings.Name;
-                Password = room.Settings.Password;
-                Type = room.Settings.MatchType;
-                QueueMode = room.Settings.QueueMode;
-                AutoStartDuration = room.Settings.AutoStartDuration;
-                AutoSkip = room.Settings.AutoSkip;
-                Playlist = room.Playlist.Select(item => new PlaylistItem(item)).ToArray();
             }
         }
 


### PR DESCRIPTION
- Depends on https://github.com/ppy/osu/pull/31637 for new ctor.

See discussion in https://github.com/ppy/osu-server-spectator/pull/265#discussion_r1928348536. Turns out I added these copies to the base class in the osu-side PR (https://github.com/ppy/osu/pull/31637).