### PR TITLE
Set defaults for legacy IO to match osu web development environment

### DIFF
--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator
             DatabaseUser = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             DatabasePort = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
 
-            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN") ?? string.Empty;
+            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN") ?? "http://localhost:8080";
             SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET") ?? string.Empty;
 
             SentryDsn = Environment.GetEnvironmentVariable("SENTRY_DSN");

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -31,12 +31,8 @@ namespace osu.Server.Spectator.Services
             this.httpClient = httpClient;
             logger = loggerFactory.CreateLogger("LIO");
 
-            interopDomain = AppSettings.LegacyIODomain
-                            ?? throw new InvalidOperationException("LEGACY_IO_DOMAIN environment variable not set. "
-                                                                   + "Please set the value of this variable to the root URL of the osu-web instance to which legacy IO call should be submitted.");
-            interopSecret = AppSettings.SharedInteropSecret
-                            ?? throw new InvalidOperationException("SHARED_INTEROP_SECRET environment variable not set. "
-                                                                   + "Please set the value of this variable to the value of the same environment variable that the target osu-web instance specifies in `.env`.");
+            interopDomain = AppSettings.LegacyIODomain;
+            interopSecret = AppSettings.SharedInteropSecret;
         }
 
         private async Task<string> runLegacyIO(HttpMethod method, string command, dynamic? postObject = null)


### PR DESCRIPTION
Note that empty string for the secret here does match and work with a default osu-web deploy.