### PR TITLE
Don't use "legacy IO" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ For advanced testing purposes.
 | `DB_PORT` | Port under which the `osu-web` MySQL instance can be found. | `3306`            |
 | `DB_USER` | Username to use when logging into the `osu-web` MySQL instance. | `osuweb`          |
 | `SENTRY_DSN` | A valid Sentry DSN to use for logging application events. | `null` (required in production) |
-| `LEGACY_IO_DOMAIN` | The root URL of the osu-web instance to which legacy IO call should be submitted | `null` (required) |
+| `SHARED_INTEROP_DOMAIN` | The root URL of the osu-web instance to which shared interop calls should be submitted | `http://localhost:80` |
 | `SHARED_INTEROP_SECRET` | The value of the same environment variable that the target osu-web instance specifies in `.env`. | `null` (required) |

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -38,7 +38,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         protected readonly Mock<IDatabaseFactory> DatabaseFactory;
         protected readonly Mock<IDatabaseAccess> Database;
 
-        protected readonly Mock<ILegacyIO> LegacyIO;
+        protected readonly Mock<ISharedInterop> LegacyIO;
 
         /// <summary>
         /// A general non-gameplay receiver for the room with ID <see cref="ROOM_ID"/>.
@@ -133,7 +133,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>()))
                              .Returns(new Mock<ILogger>().Object);
 
-            LegacyIO = new Mock<ILegacyIO>();
+            LegacyIO = new Mock<ISharedInterop>();
 
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,

--- a/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
@@ -21,8 +21,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             IDatabaseFactory databaseFactory,
             ChatFilters chatFilters,
             IHubContext<MultiplayerHub> hubContext,
-            ILegacyIO legacyIO)
-            : base(loggerFactory, rooms, users, databaseFactory, chatFilters, hubContext, legacyIO)
+            ISharedInterop sharedInterop)
+            : base(loggerFactory, rooms, users, databaseFactory, chatFilters, hubContext, sharedInterop)
         {
         }
 

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator
             DatabaseUser = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             DatabasePort = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
 
-            SharedInteropDomain = Environment.GetEnvironmentVariable("SHADERD_INTEROP_DOMAIN") ?? "http://localhost:8080";
+            SharedInteropDomain = Environment.GetEnvironmentVariable("SHARED_INTEROP_DOMAIN") ?? "http://localhost:8080";
             SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET") ?? string.Empty;
 
             SentryDsn = Environment.GetEnvironmentVariable("SENTRY_DSN");

--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Spectator
         public static string DatabaseUser { get; }
         public static string DatabasePort { get; }
 
-        public static string LegacyIODomain { get; }
+        public static string SharedInteropDomain { get; }
         public static string SharedInteropSecret { get; }
 
         public static string? SentryDsn { get; }
@@ -59,7 +59,7 @@ namespace osu.Server.Spectator
             DatabaseUser = Environment.GetEnvironmentVariable("DB_USER") ?? "osuweb";
             DatabasePort = Environment.GetEnvironmentVariable("DB_PORT") ?? "3306";
 
-            LegacyIODomain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN") ?? "http://localhost:8080";
+            SharedInteropDomain = Environment.GetEnvironmentVariable("SHADERD_INTEROP_DOMAIN") ?? "http://localhost:8080";
             SharedInteropSecret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET") ?? string.Empty;
 
             SentryDsn = Environment.GetEnvironmentVariable("SENTRY_DSN");

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Spectator.Extensions
         public static IServiceCollection AddHubEntities(this IServiceCollection serviceCollection)
         {
             return serviceCollection.AddHttpClient()
-                                    .AddTransient<ILegacyIO, LegacyIO>()
+                                    .AddTransient<ISharedInterop, SharedInterop>()
                                     .AddSingleton<EntityStore<SpectatorClientState>>()
                                     .AddSingleton<EntityStore<MultiplayerClientState>>()
                                     .AddSingleton<EntityStore<ServerMultiplayerRoom>>()

--- a/osu.Server.Spectator/Services/ISharedInterop.cs
+++ b/osu.Server.Spectator/Services/ISharedInterop.cs
@@ -6,7 +6,7 @@ using osu.Game.Online.Multiplayer;
 
 namespace osu.Server.Spectator.Services
 {
-    public interface ILegacyIO
+    public interface ISharedInterop
     {
         /// <summary>
         /// Creates an osu!web room.

--- a/osu.Server.Spectator/Services/LegacyIO.cs
+++ b/osu.Server.Spectator/Services/LegacyIO.cs
@@ -31,7 +31,7 @@ namespace osu.Server.Spectator.Services
             this.httpClient = httpClient;
             logger = loggerFactory.CreateLogger("LIO");
 
-            interopDomain = AppSettings.LegacyIODomain;
+            interopDomain = AppSettings.SharedInteropDomain;
             interopSecret = AppSettings.SharedInteropSecret;
         }
 

--- a/osu.Server.Spectator/Services/SharedInterop.cs
+++ b/osu.Server.Spectator/Services/SharedInterop.cs
@@ -18,7 +18,7 @@ using osu.Game.Online.Rooms;
 
 namespace osu.Server.Spectator.Services
 {
-    public class LegacyIO : ILegacyIO
+    public class SharedInterop : ISharedInterop
     {
         private readonly HttpClient httpClient;
         private readonly ILogger logger;
@@ -26,7 +26,7 @@ namespace osu.Server.Spectator.Services
         private readonly string interopDomain;
         private readonly string interopSecret;
 
-        public LegacyIO(HttpClient httpClient, ILoggerFactory loggerFactory)
+        public SharedInterop(HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             this.httpClient = httpClient;
             logger = loggerFactory.CreateLogger("LIO");
@@ -35,7 +35,7 @@ namespace osu.Server.Spectator.Services
             interopSecret = AppSettings.SharedInteropSecret;
         }
 
-        private async Task<string> runLegacyIO(HttpMethod method, string command, dynamic? postObject = null)
+        private async Task<string> runCommand(HttpMethod method, string command, dynamic? postObject = null)
         {
             int retryCount = 3;
 
@@ -89,13 +89,13 @@ namespace osu.Server.Spectator.Services
                 if (response.IsSuccessStatusCode)
                     return await response.Content.ReadAsStringAsync();
 
-                throw await LegacyIORequestFailedException.Create(url, response);
+                throw await SharedInteropRequestFailedException.Create(url, response);
             }
             catch (Exception e)
             {
                 if (retryCount-- > 0)
                 {
-                    logger.LogError(e, "Legacy IO request to {url} failed, retrying ({retries} remaining)", url, retryCount);
+                    logger.LogError(e, "Shared interop request to {url} failed, retrying ({retries} remaining)", url, retryCount);
                     Thread.Sleep(1000);
                     goto retry;
                 }
@@ -112,12 +112,12 @@ namespace osu.Server.Spectator.Services
             return hashArray.Aggregate(string.Empty, (s, e) => s + $"{e:x2}", s => s);
         }
 
-        // Methods below purposefully async-await on `runLegacyIO()` calls rather than directly returning the underlying calls.
+        // Methods below purposefully async-await on `runCommand()` calls rather than directly returning the underlying calls.
         // This is done for better readability of exception stacks. Directly returning the tasks elides the name of the proxying method.
 
         public async Task<long> CreateRoomAsync(int hostUserId, MultiplayerRoom room)
         {
-            return long.Parse(await runLegacyIO(HttpMethod.Post, "multiplayer/rooms", Newtonsoft.Json.JsonConvert.SerializeObject(new RoomWithHostId(room)
+            return long.Parse(await runCommand(HttpMethod.Post, "multiplayer/rooms", Newtonsoft.Json.JsonConvert.SerializeObject(new RoomWithHostId(room)
             {
                 HostUserId = hostUserId
             })));
@@ -125,12 +125,12 @@ namespace osu.Server.Spectator.Services
 
         public async Task AddUserToRoomAsync(long roomId, int userId)
         {
-            await runLegacyIO(HttpMethod.Put, $"multiplayer/rooms/{roomId}/users/{userId}");
+            await runCommand(HttpMethod.Put, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
         public async Task RemoveUserFromRoomAsync(long roomId, int userId)
         {
-            await runLegacyIO(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
+            await runCommand(HttpMethod.Delete, $"multiplayer/rooms/{roomId}/users/{userId}");
         }
 
         /// <summary>
@@ -162,14 +162,14 @@ namespace osu.Server.Spectator.Services
         }
 
         [Serializable]
-        private class LegacyIORequestFailedException : HubException
+        private class SharedInteropRequestFailedException : HubException
         {
-            private LegacyIORequestFailedException(string message, Exception innerException)
+            private SharedInteropRequestFailedException(string message, Exception innerException)
                 : base(message, innerException)
             {
             }
 
-            public static async Task<LegacyIORequestFailedException> Create(string url, HttpResponseMessage response)
+            public static async Task<SharedInteropRequestFailedException> Create(string url, HttpResponseMessage response)
             {
                 string errorMessage = $"{(int)response.StatusCode}: {response.ReasonPhrase}";
 
@@ -184,7 +184,7 @@ namespace osu.Server.Spectator.Services
                 }
 
                 // Outer exception message is serialised to clients, inner exception is logged to the server and NOT serialised to the client.
-                return new LegacyIORequestFailedException(errorMessage, new Exception($"Legacy IO request to {url} failed with {response.StatusCode} ({response.ReasonPhrase})."));
+                return new SharedInteropRequestFailedException(errorMessage, new Exception($"Shared interop request to {url} failed with {response.StatusCode} ({response.ReasonPhrase})."));
             }
 
             [Serializable]


### PR DESCRIPTION
Given we're using more of this going forward, and this is what osu-web tends to call it these days, let's stick with nomenclature that makes sense.