### PR TITLE
Stability improvements for multiplayer room interop

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -67,6 +67,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     throw new InvalidStateException("Can't join a room when restricted.");
             }
 
+            ServerMultiplayerRoom? room = null;
+
             using (var userUsage = await GetOrCreateLocalUserState())
             {
                 if (userUsage.Item != null)
@@ -80,8 +82,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
                 // track whether this join necessitated starting the process of fetching the room and adding it to the room store.
                 bool newRoomFetchStarted = false;
-
-                ServerMultiplayerRoom? room = null;
 
                 using (var roomUsage = await Rooms.GetForUse(roomId, true))
                 {
@@ -163,25 +163,25 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                         throw;
                     }
                 }
-
-                try
-                {
-                    await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
-                }
-                catch (Exception ex)
-                {
-                    Error("Failed to add user to the databased room", ex);
-                }
-
-                var settings = new JsonSerializerSettings
-                {
-                    // explicitly use Auto here as we are not interested in the top level type being conveyed to the user.
-                    TypeNameHandling = TypeNameHandling.Auto,
-                };
-
-                return JsonConvert.DeserializeObject<MultiplayerRoom>(JsonConvert.SerializeObject(room, settings), settings)
-                       ?? throw new InvalidOperationException();
             }
+
+            try
+            {
+                await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
+            }
+            catch (Exception ex)
+            {
+                Error("Failed to add user to the databased room", ex);
+            }
+
+            var settings = new JsonSerializerSettings
+            {
+                // explicitly use Auto here as we are not interested in the top level type being conveyed to the user.
+                TypeNameHandling = TypeNameHandling.Auto,
+            };
+
+            return JsonConvert.DeserializeObject<MultiplayerRoom>(JsonConvert.SerializeObject(room, settings), settings)
+                   ?? throw new InvalidOperationException();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -67,8 +67,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     throw new InvalidStateException("Can't join a room when restricted.");
             }
 
-            await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
-
             using (var userUsage = await GetOrCreateLocalUserState())
             {
                 if (userUsage.Item != null)
@@ -89,6 +87,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 {
                     try
                     {
+                        await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
+
                         if (roomUsage.Item == null)
                         {
                             newRoomFetchStarted = true;

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -138,6 +138,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     {
                         try
                         {
+                            await sharedInterop.RemoveUserFromRoomAsync(Context.GetUserId(), roomId);
+
                             if (userUsage.Item != null)
                             {
                                 // the user was joined to the room, so we can run the standard leaveRoom method.


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/pull/31637#discussion_r1969294493

- Delaying adding users to rooms until after the exclusive lock has been acquired. This would prevent races caused by the single _other_ user leaving the room during the whole process.
- Removing users from rooms if adding fails. This could due to various conditions like the [room having ended](https://github.com/ppy/osu-server-spectator/blob/2be697979fb8b2fec7986f1da78d7c320975bd6d/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs#L202-L206).