### PR TITLE
Invoke interop to remove user from room when kicked

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -165,14 +165,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 }
             }
 
-            try
-            {
-                await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
-            }
-            catch (Exception ex)
-            {
-                Error("Failed to add user to the databased room", ex);
-            }
+            await sharedInterop.AddUserToRoomAsync(Context.GetUserId(), roomId, password);
 
             var settings = new JsonSerializerSettings
             {
@@ -978,14 +971,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             else
                 await Clients.Group(GetGroupId(room.RoomID)).UserLeft(user);
 
-            try
-            {
-                await sharedInterop.RemoveUserFromRoomAsync(state.UserId, state.CurrentRoomID);
-            }
-            catch (Exception ex)
-            {
-                Error("Failed to remove user from the databased room", ex);
-            }
+            await sharedInterop.RemoveUserFromRoomAsync(state.UserId, state.CurrentRoomID);
         }
 
         internal Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId) => Rooms.GetForUse(roomId);

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -926,15 +926,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         {
             using (var roomUsage = await getLocalUserRoom(state))
                 await leaveRoom(state, roomUsage, wasKick);
-
-            try
-            {
-                await sharedInterop.RemoveUserFromRoomAsync(state.UserId, state.CurrentRoomID);
-            }
-            catch (Exception ex)
-            {
-                Error("Failed to remove user from the databased room", ex);
-            }
         }
 
         private async Task leaveRoom(MultiplayerClientState state, ItemUsage<ServerMultiplayerRoom> roomUsage, bool wasKick)
@@ -986,6 +977,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             }
             else
                 await Clients.Group(GetGroupId(room.RoomID)).UserLeft(user);
+
+            try
+            {
+                await sharedInterop.RemoveUserFromRoomAsync(state.UserId, state.CurrentRoomID);
+            }
+            catch (Exception ex)
+            {
+                Error("Failed to remove user from the databased room", ex);
+            }
         }
 
         internal Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId) => Rooms.GetForUse(roomId);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/22279

One method calls another method >_<...

Because this is now in the inner method, migrating the existing implementation would hold onto both user and room locks. This was previously a contentious topic in https://github.com/ppy/osu-server-spectator/pull/273, so I've tried my best to address it here.  

I realise what I've done may be ugly, but I don't know of a better way to do this. The problem is if we use something akin to our `FireAndForget()` extension, the `HttpClient` is disposed because it's a transient service. To get around this, I've added a `runCommandScoped()` which creates a local scope to run the requested command in the background, following [this suggestion](https://stackoverflow.com/a/59878652) on StackOverflow.

Do let me know of any suggestions on how to improve this.