### PR TITLE
Fix being able to join rooms with no password

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -134,6 +134,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                              .Returns(new Mock<ILogger>().Object);
 
             LegacyIO = new Mock<ISharedInterop>();
+            LegacyIO.Setup(io => io.CreateRoomAsync(It.IsAny<int>(), It.IsAny<MultiplayerRoom>()))
+                    .Returns<int, MultiplayerRoom>((_, room) => Task.FromResult(room.RoomID));
 
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -16,6 +16,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserCanJoinWithPasswordEvenWhenNotRequired()
         {
+            await Hub.CreateRoom(new MultiplayerRoom(ROOM_ID));
+
+            SetUserContext(ContextUser2);
             await Hub.JoinRoomWithPassword(ROOM_ID, "password");
         }
 
@@ -30,6 +33,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                         user_id = USER_ID
                     });
 
+            await Hub.CreateRoom(new MultiplayerRoom(ROOM_ID) { Settings = { Password = "password" } });
+
+            SetUserContext(ContextUser2);
             await Hub.JoinRoomWithPassword(ROOM_ID, "password");
         }
 
@@ -44,6 +50,9 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                         user_id = USER_ID
                     });
 
+            await Hub.CreateRoom(new MultiplayerRoom(ROOM_ID) { Settings = { Password = "password" } });
+
+            SetUserContext(ContextUser2);
             await Assert.ThrowsAsync<InvalidPasswordException>(() => Hub.JoinRoom(ROOM_ID));
         }
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -116,6 +116,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                             // in theory the connection clean-up code should handle this correctly.
                             if (room.Users.Any(u => u.UserID == roomUser.UserID))
                                 throw new InvalidOperationException($"User {roomUser.UserID} attempted to join room {room.RoomID} they are already present in.");
+
+                            if (!string.IsNullOrEmpty(room.Settings.Password))
+                            {
+                                if (room.Settings.Password != password)
+                                    throw new InvalidPasswordException();
+                            }
                         }
 
                         userUsage.Item = new MultiplayerClientState(Context.ConnectionId, Context.GetUserId(), roomId);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32296

Condition was only present in the block for the room's host, where I'm not sure it should even be required in the first place. At some point we may want to split this block out and put the relevant one in `MultiplayerHub.CreateRoom()` rather than going through this `JoinRoomWithPassword()` thing.