### PR TITLE
Fix cleared star rating when current item is duplicated

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.401.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.403.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.401.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.403.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerQueue.cs
@@ -256,6 +256,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             // Add the item to the end of the list initially.
             item.PlaylistOrder = ushort.MaxValue;
             item.Expired = false;
+            item.PlayedAt = null;
             item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));
 
             room.Playlist.Add(item);

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.401.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.321.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.401.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.321.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.401.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.403.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.403.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.403.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.403.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.403.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2025.317.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="5.0.1" />
     </ItemGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/32372

Notice how after I finish the current playlist item, the SR range display reads `{ 0.0 -> 4.14 }`:

https://github.com/user-attachments/assets/433f8001-f5ea-4802-8cf0-e9ea237ac8cd