### PR TITLE
Update game packages & fix test failures

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.530.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.607.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.530.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.607.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/Multiplayer/FreestyleTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/FreestyleTests.cs
@@ -33,7 +33,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "checksum",
                 BeatmapID = 1234,
                 Freestyle = true,
-                RequiredMods = [new APIMod(new OsuModHidden())],
+                RequiredMods = [new APIMod(new OsuModDoubleTime())],
             });
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.AddPlaylistItem(new MultiplayerPlaylistItem
@@ -41,7 +41,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "checksum",
                 BeatmapID = 1234,
                 Freestyle = true,
-                AllowedMods = [new APIMod(new OsuModHidden())],
+                AllowedMods = [new APIMod(new OsuModDoubleTime())],
             }));
         }
 
@@ -228,7 +228,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 BeatmapChecksum = "checksum",
                 BeatmapID = 1234,
                 Freestyle = true,
-                RequiredMods = [new APIMod(new OsuModHidden())],
+                RequiredMods = [new APIMod(new OsuModDoubleTime())],
             });
 
             await Assert.ThrowsAsync<InvalidStateException>(() => Hub.EditPlaylistItem(new MultiplayerPlaylistItem

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -15,11 +15,11 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="ppy.osu.Game" Version="2025.530.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.530.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.530.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.530.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.530.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2025.607.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.607.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.607.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.607.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.607.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2025.317.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="5.0.1" />
     </ItemGroup>


### PR DESCRIPTION
The game packages are not the latest, strictly speaking - they correspond to the latest *lazer* (not *tachyon*) release. I feel like this makes sense as lazer is supposed to be the....... lord forbid "stable" one?

This will get interesting versioning wise soon enough I'm sure.

The test failures are fallout from https://github.com/ppy/osu/pull/33450, which made Hidden no longer selectable in freestyle as a required mod.