### PR TITLE
Fix server-side replays for beatmaps of version <5 being offset by 24ms from client-side replays

### DIFF
--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -156,9 +156,9 @@ namespace osu.Server.Spectator.Tests
             await uploadsCompleteAsync();
 
             if (savingEnabled)
-                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Once);
+                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.OnlineID == 456)), Times.Once);
             else
-                mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+                mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<ScoreUploader.UploadItem>()), Times.Never);
 
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
@@ -205,7 +205,7 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<Score>()), Times.Never);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<ScoreUploader.UploadItem>()), Times.Never);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 
@@ -255,7 +255,7 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(s => s.ScoreInfo.Mods.Any(m => m is OsuModTouchDevice))), Times.Once);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.Mods.Any(m => m is OsuModTouchDevice))), Times.Once);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 
@@ -310,7 +310,7 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(s => s.ScoreInfo.Mods.Any(m => m is OsuModDoubleTime))), Times.Once);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.Mods.Any(m => m is OsuModDoubleTime))), Times.Once);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 
@@ -496,9 +496,9 @@ namespace osu.Server.Spectator.Tests
             await uploadsCompleteAsync();
 
             if (saved)
-                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Once);
+                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.OnlineID == 456)), Times.Once);
             else
-                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Never);
+                mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.OnlineID == 456)), Times.Never);
 
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
@@ -581,11 +581,11 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.UserID == streamer_id
-                                                                            && score.ScoreInfo.User.OnlineID == streamer_id
-                                                                            && score.ScoreInfo.User.Username == streamer_username
-                                                                            && score.ScoreInfo.RealmUser.OnlineID == streamer_id
-                                                                            && score.ScoreInfo.RealmUser.Username == streamer_username)), Times.Once);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.UserID == streamer_id
+                                                                                              && item.Score.ScoreInfo.User.OnlineID == streamer_id
+                                                                                              && item.Score.ScoreInfo.User.Username == streamer_username
+                                                                                              && item.Score.ScoreInfo.RealmUser.OnlineID == streamer_id
+                                                                                              && item.Score.ScoreInfo.RealmUser.Username == streamer_username)), Times.Once);
 
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
@@ -632,7 +632,7 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.OnlineID == 456)), Times.Never);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.OnlineID == 456)), Times.Never);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Failed)), Times.Once());
         }
 
@@ -686,7 +686,7 @@ namespace osu.Server.Spectator.Tests
 
             await uploadsCompleteAsync();
 
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<Score>(score => score.ScoreInfo.Rank == ScoreRank.A)), Times.Once);
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.Rank == ScoreRank.A)), Times.Once);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
 

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Spectator.Database
             var connection = await getConnectionAsync();
 
             return await connection.QuerySingleOrDefaultAsync<database_beatmap>(
-                "SELECT beatmap_id, beatmapset_id, checksum, approved, difficultyrating, playmode FROM osu_beatmaps WHERE beatmap_id = @BeatmapId AND deleted_at IS NULL", new
+                "SELECT beatmap_id, beatmapset_id, checksum, approved, difficultyrating, playmode, osu_file_version FROM osu_beatmaps WHERE beatmap_id = @BeatmapId AND deleted_at IS NULL", new
                 {
                     BeatmapId = beatmapId
                 });
@@ -89,7 +89,7 @@ namespace osu.Server.Spectator.Database
             var connection = await getConnectionAsync();
 
             return (await connection.QueryAsync<database_beatmap>(
-                "SELECT beatmap_id, beatmapset_id, checksum, approved, difficultyrating, playmode FROM osu_beatmaps WHERE beatmapset_id = @BeatmapSetId AND deleted_at IS NULL", new
+                "SELECT beatmap_id, beatmapset_id, checksum, approved, difficultyrating, playmode, osu_file_version FROM osu_beatmaps WHERE beatmapset_id = @BeatmapSetId AND deleted_at IS NULL", new
                 {
                     BeatmapSetId = beatmapSetId
                 })).ToArray();

--- a/osu.Server.Spectator/Database/Models/database_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/database_beatmap.cs
@@ -17,5 +17,6 @@ namespace osu.Server.Spectator.Database.Models
         public BeatmapOnlineStatus approved { get; set; }
         public double difficultyrating { get; set; }
         public ushort playmode { get; set; }
+        public ushort osu_file_version { get; set; } = 14;
     }
 }

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorClientState.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorClientState.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
+using osu.Server.Spectator.Database.Models;
 
 namespace osu.Server.Spectator.Hubs.Spectator
 {
@@ -16,6 +17,11 @@ namespace osu.Server.Spectator.Hubs.Spectator
         /// When a user is in gameplay, this is the state as conveyed at the start of the play session.
         /// </summary>
         public SpectatorState? State;
+
+        /// <summary>
+        /// When a user is in gameplay, this contains information about the beatmap the user is playing retrieved from the database.
+        /// </summary>
+        public database_beatmap? Beatmap;
 
         /// <summary>
         /// When a user is in gameplay, this is the imminent score. It will be updated throughout a play session.

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -151,7 +151,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
                     // Score may be null if the BeginPlaySession call failed but the client is still sending frame data.
                     // For now it's safe to drop these frames.
                     // Note that this *intentionally* skips the `endPlaySession()` call at the end of method.
-                    if (score == null || scoreToken == null)
+                    if (score == null || scoreToken == null || usage.Item?.Beatmap == null)
                         return;
 
                     await processScore(usage.Item!);
@@ -173,7 +173,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
 
         private async Task processScore(SpectatorClientState item)
         {
-            Debug.Assert(item.Score != null && item.ScoreToken != null);
+            Debug.Assert(item.Score != null && item.ScoreToken != null && item.Beatmap != null);
 
             Score score = item.Score;
             long scoreToken = item.ScoreToken.Value;
@@ -193,7 +193,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
             // even though in theory the rank could be recomputed after every replay frame.
             score.ScoreInfo.Rank = StandardisedScoreMigrationTools.ComputeRank(score.ScoreInfo);
 
-            await scoreUploader.EnqueueAsync(scoreToken, score, item?.Beatmap ?? new database_beatmap());
+            await scoreUploader.EnqueueAsync(scoreToken, score, item.Beatmap);
             await scoreProcessedSubscriber.RegisterForSingleScoreAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
         }
 

--- a/osu.Server.Spectator/Storage/FileScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/FileScoreStorage.cs
@@ -4,8 +4,9 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using osu.Game.Scoring;
+using osu.Game.Beatmaps;
 using osu.Game.Scoring.Legacy;
+using osu.Server.Spectator.Hubs;
 
 namespace osu.Server.Spectator.Storage
 {
@@ -18,9 +19,12 @@ namespace osu.Server.Spectator.Storage
             logger = loggerFactory.CreateLogger(nameof(FileScoreStorage));
         }
 
-        public Task WriteAsync(Score score)
+        public Task WriteAsync(ScoreUploader.UploadItem item)
         {
-            var legacyEncoder = new LegacyScoreEncoder(score, null);
+            var score = item.Score;
+            // beatmap version is required for correct encoding of replays for beatmaps with version <5
+            // (see `LegacyBeatmapDecoder.EARLY_VERSION_TIMING_OFFSET`).
+            var legacyEncoder = new LegacyScoreEncoder(score, new Beatmap { BeatmapVersion = item.Beatmap.osu_file_version });
 
             string filename = score.ScoreInfo.OnlineID.ToString();
 

--- a/osu.Server.Spectator/Storage/IScoreStorage.cs
+++ b/osu.Server.Spectator/Storage/IScoreStorage.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
-using osu.Game.Scoring;
+using osu.Server.Spectator.Hubs;
 
 namespace osu.Server.Spectator.Storage
 {
     public interface IScoreStorage
     {
-        Task WriteAsync(Score score);
+        Task WriteAsync(ScoreUploader.UploadItem score);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/33691.

Tested manually full-stack.