### PR TITLE
Write client version to server-side replays

### DIFF
--- a/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
+++ b/osu.Server.Spectator.Tests/ScoreUploaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Online.API.Requests.Responses;
@@ -22,6 +23,7 @@ namespace osu.Server.Spectator.Tests
         private readonly Mock<IScoreStorage> mockStorage;
         private readonly Mock<IDatabaseFactory> databaseFactory;
         private readonly Mock<ILoggerFactory> loggerFactory;
+        private readonly IMemoryCache memoryCache;
 
         public ScoreUploaderTests()
         {
@@ -40,6 +42,8 @@ namespace osu.Server.Spectator.Tests
                          .Returns(new Mock<ILogger>().Object);
 
             mockStorage = new Mock<IScoreStorage>();
+
+            memoryCache = new MemoryCache(new MemoryCacheOptions());
         }
 
         /// <summary>
@@ -54,7 +58,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreDataMergedCorrectly()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };
@@ -83,7 +87,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreUploads()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };
@@ -100,7 +104,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreDoesNotUploadIfDisabled()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = false
             };
@@ -113,7 +117,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task ScoreUploadsWithDelayedScoreToken()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };
@@ -137,7 +141,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task TimedOutScoreDoesNotUpload()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };
@@ -172,7 +176,7 @@ namespace osu.Server.Spectator.Tests
         [Fact]
         public async Task FailedScoreHandledGracefully()
         {
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };
@@ -210,7 +214,7 @@ namespace osu.Server.Spectator.Tests
         public async Task TestMassUploads()
         {
             AppSettings.ReplayUploaderConcurrency = 4;
-            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object)
+            var uploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockStorage.Object, memoryCache)
             {
                 SaveReplays = true
             };

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Beatmaps;
@@ -60,7 +61,7 @@ namespace osu.Server.Spectator.Tests
                          .Returns(new Mock<ILogger>().Object);
 
             mockScoreStorage = new Mock<IScoreStorage>();
-            scoreUploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockScoreStorage.Object);
+            scoreUploader = new ScoreUploader(loggerFactory.Object, databaseFactory.Object, mockScoreStorage.Object, new MemoryCache(new MemoryCacheOptions()));
 
             var mockScoreProcessedSubscriber = new Mock<IScoreProcessedSubscriber>();
 

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -403,6 +403,17 @@ namespace osu.Server.Spectator.Database
             });
         }
 
+        public async Task<osu_build?> GetBuildByIdAsync(int buildId)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleAsync<osu_build?>("SELECT `build_id`, `version`, `hash`, `users` FROM `osu_builds` WHERE `build_id` = @BuildId",
+                new
+                {
+                    BuildId = buildId
+                });
+        }
+
         public async Task<IEnumerable<osu_build>> GetAllMainLazerBuildsAsync()
         {
             var connection = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -166,6 +166,13 @@ namespace osu.Server.Spectator.Database
         Task<bool> GetUserAllowsPMs(int userId);
 
         /// <summary>
+        /// Returns a single build with the given ID.
+        /// </summary>
+        /// <param name="buildId"></param>
+        /// <returns></returns>
+        Task<osu_build?> GetBuildByIdAsync(int buildId);
+
+        /// <summary>
         /// Returns all available main builds from the lazer and tachyon release streams.
         /// </summary>
         Task<IEnumerable<osu_build>> GetAllMainLazerBuildsAsync();

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -180,7 +180,7 @@ namespace osu.Server.Spectator.Hubs.Metadata
 
             using var db = databaseFactory.GetInstance();
 
-            MultiplayerRoomStats stats = (await cache.GetOrCreateAsync<MultiplayerRoomStats>(id.ToString(), e =>
+            MultiplayerRoomStats stats = (await cache.GetOrCreateAsync<MultiplayerRoomStats>($@"{nameof(MultiplayerRoomStats)}#{id}", e =>
             {
                 e.SlidingExpiration = TimeSpan.FromHours(24);
                 return Task.FromResult(new MultiplayerRoomStats { RoomID = id });


### PR DESCRIPTION
Closes https://github.com/ppy/osu-server-spectator/issues/289.

As far as I'm aware the data in the `version` column in `osu_builds` should match [the client-side implementation](https://github.com/ppy/osu/blob/b1435d35e56eed08a57d1909fa0b16e67bd9c2a2/osu.Game/OsuGameBase.cs#L121-L139) but it may be worth double checking.