### PR TITLE
Expire remaining playlist items on ending match rather than deleting them

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -297,9 +297,11 @@ namespace osu.Server.Spectator.Database
         {
             var connection = await getConnectionAsync();
 
-            // Remove all non-expired items from the playlist as they have no scores.
+            // Expire all non-expired items from the playlist.
+            // We're not removing them because they may be linked to other tables (e.g. `multiplayer_realtime_room_events`, `multiplayer_scores_high`, etc.)
             await connection.ExecuteAsync(
-                "DELETE FROM multiplayer_playlist_items p"
+                "UPDATE multiplayer_playlist_items p"
+                + " SET p.expired = 1, played_at = NOW(), updated_at = NOW()"
                 + " WHERE p.room_id = @RoomID"
                 + " AND p.expired = 0"
                 + " AND (SELECT COUNT(*) FROM multiplayer_score_links l WHERE l.playlist_item_id = p.id) = 0",


### PR DESCRIPTION
Should close https://github.com/ppy/osu-web/issues/12301.

As per @smoogipoo this was [never strictly necessary and only done for space saving](https://discord.com/channels/90072389919997952/1327149041511043134/1397166770627936277).

The other direction would be to delete rows from all other related tables but I think not deleting is better because of history preservation, and I'm not sure the space gains from this special case will be relevant.