### PR TITLE
Fix game completed / aborted events doubling up on each other

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerFlowTests.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
+using osu.Server.Spectator.Database.Models;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests.Multiplayer
@@ -95,6 +96,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 Assert.NotNull(room.Item);
                 Assert.All(room.Item.Users, u => Assert.Equal(MultiplayerUserState.Idle, u.State));
             }
+
+            Database.Verify(db => db.LogRoomEventAsync(It.Is<multiplayer_realtime_room_event>(ev => ev.event_type == "game_completed")), Times.Once);
         }
 
         /// <summary>


### PR DESCRIPTION
Should address https://discord.com/channels/188630481301012481/188630616286167041/1398583488147619852.

I'm going to admit, I'm not *that* confident in this change, the state flow in `MultiplayerHub` is quite complex and `updateRoomStateAsRequired()` has many callers - but maybe it works...? At least the test coverage added here says that it might...

A side effect of this is that e.g. if in a game every player quits out individually, the game gets marked as aborted and not completed. Which I think makes sense.