### PR TITLE
Update website 'hide presence' setting in line with client user status

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -538,6 +538,19 @@ namespace osu.Server.Spectator.Database
                 ev);
         }
 
+        public async Task ToggleUserPresenceAsync(int userId, bool visible)
+        {
+            var connection = await getConnectionAsync();
+
+            await connection.ExecuteAsync(
+                "UPDATE `phpbb_users` SET `user_allow_viewonline` = @visible WHERE `user_id` = @userId",
+                new
+                {
+                    visible = visible,
+                    userId = userId
+                });
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -225,5 +225,12 @@ namespace osu.Server.Spectator.Database
         /// Logs an event that happened in a multiplayer room.
         /// </summary>
         Task LogRoomEventAsync(multiplayer_realtime_room_event ev);
+
+        /// <summary>
+        /// Toggles the user's "hide user presence" website setting.
+        /// </summary>
+        /// <param name="userId">The user's ID.</param>
+        /// <param name="visible">Whether the user should appear online to other players on the website.</param>
+        Task ToggleUserPresenceAsync(int userId, bool visible);
     }
 }

--- a/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
+++ b/osu.Server.Spectator/Hubs/Metadata/MetadataHub.cs
@@ -169,6 +169,20 @@ namespace osu.Server.Spectator.Hubs.Metadata
                     Clients.Caller.UserPresenceUpdated(usage.Item.UserId, usage.Item.ToUserPresence())
                 );
             }
+
+            switch (status)
+            {
+                case UserStatus.Online:
+                case UserStatus.DoNotDisturb:
+                    using (var db = databaseFactory.GetInstance())
+                        await db.ToggleUserPresenceAsync(Context.GetUserId(), visible: true);
+                    break;
+
+                case UserStatus.Offline:
+                    using (var db = databaseFactory.GetInstance())
+                        await db.ToggleUserPresenceAsync(Context.GetUserId(), visible: false);
+                    break;
+            }
         }
 
         private static readonly object update_stats_lock = new object();


### PR DESCRIPTION
Probably closes https://github.com/ppy/osu-web/issues/12288.

Even with this, changing the 'hide presence' setting on the website will not propagate back to client, but I guess we'll see whether that'll be a real problem in practice.

Additionally, the client will not attempt to read the web's setting status on login, so in a manner of speaking the client takes precedence here, but in internal discussion this was also deemed acceptable. Reading the web setting is not much work though if required later, it's just a few lines in web and client.