### PR TITLE
Include full message in shared interop errors

### DIFF
--- a/osu.Server.Spectator/Services/SharedInterop.cs
+++ b/osu.Server.Spectator/Services/SharedInterop.cs
@@ -209,8 +209,7 @@ namespace osu.Server.Spectator.Services
                 }
 
                 // Outer exception message is serialised to clients, inner exception is logged to the server and NOT serialised to the client.
-                return new SharedInteropRequestFailedException(response.StatusCode, errorMessage,
-                    new Exception($"Shared interop request to {url} failed with {response.StatusCode} ({response.ReasonPhrase})."));
+                return new SharedInteropRequestFailedException(response.StatusCode, errorMessage, new Exception(await response.Content.ReadAsStringAsync()));
             }
 
             [Serializable]


### PR DESCRIPTION
Split from https://github.com/ppy/osu-server-spectator/pull/298

This puts the whole osu!web debug error message in the console. It isn't serialised to clients (see existing comment).

"Shared interop request to {url} failed" message removed because it's duplicated in the logger message:

https://github.com/ppy/osu-server-spectator/blob/825a70d12625e1c56e613aaef7972c2e41f9bd6e/osu.Server.Spectator/Services/SharedInterop.cs#L122-L130