### PR TITLE
Fix possible exception on dangling countdowns

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerHubContext.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         /// Retrieves a <see cref="ServerMultiplayerRoom"/> usage.
         /// </summary>
         /// <param name="roomId">The ID of the room to retrieve.</param>
-        Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId);
+        Task<ItemUsage<ServerMultiplayerRoom>?> TryGetRoom(long roomId);
 
         /// <summary>
         /// Unreadies all users in a room.

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
@@ -100,9 +100,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMultiplayerClient.SettingsChanged), room.Settings);
         }
 
-        public Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId)
+        public Task<ItemUsage<ServerMultiplayerRoom>?> TryGetRoom(long roomId)
         {
-            return rooms.GetForUse(roomId);
+            return rooms.TryGetForUse(roomId);
         }
 
         public async Task UnreadyAllUsers(ServerMultiplayerRoom room, bool resetBeatmapAvailability)

--- a/osu.Server.Spectator/Hubs/Multiplayer/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/ServerMultiplayerRoom.cs
@@ -140,11 +140,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
                 // Notify users that the countdown has finished (or cancelled) and run the continuation.
                 // Note: The room must be re-retrieved rather than using our own instance to enforce single-thread access.
-                using (var roomUsage = await hub.GetRoom(RoomID))
+                using (var roomUsage = await hub.TryGetRoom(RoomID))
                 {
                     try
                     {
-                        if (roomUsage.Item == null)
+                        if (roomUsage?.Item == null)
                             return;
 
                         if (countdownInfo.StopSource.IsCancellationRequested)


### PR DESCRIPTION
Split from https://github.com/ppy/osu-server-spectator/pull/298

Countdowns just sit in the background, so by the time they try to retrieve the room it may have already been closed and no longer exist in the entity store.