### PR TITLE
Fix failing to write `DateTimeOffset` objects to database

### DIFF
--- a/osu.Server.Spectator/Database/DapperExtensions.cs
+++ b/osu.Server.Spectator/Database/DapperExtensions.cs
@@ -24,11 +24,12 @@ namespace osu.Server.Spectator.Database
                         break;
 
                     case DbType.DateTimeOffset:
+                    case DbType.String: // TODO: i don't know why it's coming in as a string but let's just try and handle it for now?
                         parameter.Value = value;
                         break;
 
                     default:
-                        throw new InvalidOperationException("DateTimeOffset must be assigned to a DbType.DateTime SQL field.");
+                        throw new InvalidOperationException("Must be DateTime or DateTimeOffset object to be mapped.");
                 }
             }
 


### PR DESCRIPTION
Split out from https://github.com/smoogipoo/osu-server-spectator/pull/15

Tried to write a `DateTimeOffset?` to the database and encountered this. We already have this mapping in [`osu-queue-score-statistics`](https://github.com/ppy/osu-queue-score-statistics/blob/master/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DapperExtensions.cs#L16-L34)