### PR TITLE
Fix model binding warnings

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
@@ -14,6 +15,7 @@ using osu.Server.Spectator.Database.Models;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
 {
+    [NonController]
     public class MatchmakingMatchController : IMatchController
     {
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/Standard/StandardMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Standard/StandardMatchController.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
@@ -16,6 +17,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Standard
     /// <summary>
     /// Abstract class that implements the logic for a generic multiplayer room.
     /// </summary>
+    [NonController]
     public abstract class StandardMatchController : IMatchController
     {
         public const int HOST_PLAYLIST_LIMIT = 50;


### PR DESCRIPTION
```
2>HeadToHeadMatchController.cs(23,73): Warning MVC1004 : Property on type 'MultiplayerRoomUser' has the same name as parameter 'user'. This may result in incorrect model binding. Consider renaming the parameter or the property to avoid conflicts. If the type 'MultiplayerRoomUser' has a custom type converter or custom model binder, you can suppress this message. (https://aka.ms/AA20pbc)
```

Thanks to @bdach for pointing out this is likely due to ASP.NET MVC "controller" name usage.