### PR TITLE
Always unready users and transmit `WaitingForClientsBeatmapDownload` stage

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -249,13 +249,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
             room.Settings.PlaylistItemId = state.CandidateItem;
             await hub.NotifySettingsChanged(room, true);
 
-            if (allUsersReady())
-                await stageGameplayWarmupTime(room);
-            else
-            {
-                await changeStage(MatchmakingStage.WaitingForClientsBeatmapDownload);
-                await startCountdown(TimeSpan.FromSeconds(stage_prepare_beatmap_time), _ => anyUsersReady() ? stageGameplayWarmupTime(room) : stageWaitingForClientsBeatmapDownload(room));
-            }
+            await changeStage(MatchmakingStage.WaitingForClientsBeatmapDownload);
+            await startCountdown(TimeSpan.FromSeconds(stage_prepare_beatmap_time), _ => anyUsersReady() ? stageGameplayWarmupTime(room) : stageWaitingForClientsBeatmapDownload(room));
         }
 
         private async Task stageGameplayWarmupTime(ServerMultiplayerRoom _)


### PR DESCRIPTION
Clients are expected to re-ready after responding to the settings change request, so the settings change should unready users.

As a result, we'll also send the `WaitingForClientsBeatmapDownload` stage at all times. It's a simplification but also makes it an invariant that the server will never fully skip stages.  
The reason the branch previously existed was because it could flash the text for clients, but that's more a UI/UX concern that the server shouldn't care about.