### PR TITLE
Resolve unique candidate items from user selections

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
@@ -212,6 +212,36 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Receiver.Verify(u => u.PlaylistItemChanged(It.IsAny<MultiplayerPlaylistItem>()), Times.Exactly(2));
         }
 
+        /// <summary>
+        /// Tests that when multiple users pick the same candidate playlist item, it's only included once in the final selection.
+        /// </summary>
+        [Fact]
+        public async Task DuplicateCandidateIncludedOnce()
+        {
+            await Hub.JoinRoom(ROOM_ID);
+
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+
+            await gotoStage(MatchmakingStage.UserBeatmapSelect);
+
+            long playlistItemId;
+            using (var room = await Rooms.GetForUse(ROOM_ID))
+                playlistItemId = room.Item!.Playlist.First().ID;
+
+            // Both users select the same playlist item
+            SetUserContext(ContextUser);
+            await Hub.MatchmakingToggleSelection(playlistItemId);
+            SetUserContext(ContextUser2);
+            await Hub.MatchmakingToggleSelection(playlistItemId);
+
+            await gotoStage(MatchmakingStage.ServerBeatmapFinalised);
+
+            // Check that only one item appears in the candidates.
+            using (var room = await Rooms.GetForUse(ROOM_ID))
+                Assert.Single(((MatchmakingRoomState)room.Item!.MatchState!).CandidateItems);
+        }
+
         private async Task verifyStage(MatchmakingStage stage)
         {
             using (var room = await Rooms.GetForUse(ROOM_ID))

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -237,7 +237,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
                 pickIds = pickIds.Concat(availablePicks.Take(remainderPickCount)).ToArray();
             }
 
-            state.CandidateItems = pickIds;
+            state.CandidateItems = pickIds.Distinct().ToArray();
             state.CandidateItem = pickIds[Random.Shared.Next(0, pickIds.Length)];
 
             await changeStage(MatchmakingStage.ServerBeatmapFinalised);


### PR DESCRIPTION
There would previously be duplicate items included in the `CandidateItems` list, one for each player, whereas the client expects these to be unique - one item matches up to one panel.

This should fix the candidate roll playing when there is only one item at the end of the day, as seen in the latest [lazer update video](https://youtu.be/Y4n-47cX3TI?t=573).