### PR TITLE
Store initial Elo rating to JSON blob

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloPlayer.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloPlayer.cs
@@ -15,22 +15,22 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo
     public class EloPlayer
     {
         [JsonProperty("initial_rating")]
-        public EloRating InitialRating;
+        public EloRating InitialRating { get; set; }
 
         [JsonProperty("contest_count")]
-        public int ContestCount;
+        public int ContestCount { get; set; }
 
         [JsonProperty("last_contest_time")]
-        public DateTimeOffset? LastContestTime;
+        public DateTimeOffset? LastContestTime { get; set; }
 
         [JsonProperty("normal_factor")]
-        public EloRating NormalFactor = new EloRating();
+        public EloRating NormalFactor { get; set; } = new EloRating();
 
         [JsonProperty("approximate_posterior")]
-        public EloRating ApproximatePosterior = new EloRating();
+        public EloRating ApproximatePosterior { get; set; } = new EloRating();
 
         [JsonProperty("logistic_factors")]
-        public List<EloTanhTerm> LogisticFactors = [];
+        public List<EloTanhTerm> LogisticFactors { get; set; } = [];
 
         // https://github.com/EbTech/Elo-MMR/blob/f6f83bb2c54bf173e60a9e8614065e8d168a349b/multi-skill/src/systems/common/player.rs#L139
         public void AddNoiseBest(double sigNoise, double transferSpeed)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloRating.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloRating.cs
@@ -22,6 +22,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo
         {
         }
 
+        public EloRating(double mu)
+        {
+            Mu = mu;
+        }
+
         public EloRating(double mu, double sig)
         {
             Mu = mu;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloTanhTerm.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloTanhTerm.cs
@@ -18,10 +18,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo
         public double Mu { get; set; }
 
         [JsonProperty("warg")]
-        public double Warg;
+        public double Warg { get; set; }
 
         [JsonProperty("wout")]
-        public double Wout;
+        public double Wout { get; set; }
 
         // https://github.com/EbTech/Elo-MMR/blob/f6f83bb2c54bf173e60a9e8614065e8d168a349b/multi-skill/src/systems/common/mod.rs#L46
         public EloTanhTerm(EloRating rating)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -14,6 +14,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 using osu.Server.Spectator.Services;
 using Sentry;
 using StatsdClient;
@@ -96,9 +97,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                         ruleset_id = (ushort)pool.ruleset_id,
                         EloData =
                         {
-                            InitialRating = { Mu = eloEstimate },
-                            NormalFactor = { Mu = eloEstimate },
-                            ApproximatePosterior = { Mu = eloEstimate }
+                            InitialRating = new EloRating(eloEstimate),
+                            NormalFactor = new EloRating(eloEstimate),
+                            ApproximatePosterior = new EloRating(eloEstimate)
                         }
                     });
                 }


### PR DESCRIPTION
I think we might want this for historical purposes, such as displaying a scatter plot average rating change over time at the end of a season.