### PR TITLE
Refactor multiplayer room initialisation and context

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/MatchTypeRoomEventHookTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchTypeRoomEventHookTests.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Hubs.Multiplayer;
 using Xunit;
 
@@ -19,19 +18,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task NewUserJoinedTriggersRulesetHook()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             Mock<IMatchController> controller = new Mock<IMatchController>();
             await room.ChangeMatchType(controller.Object);
@@ -45,19 +32,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task UserLeavesTriggersRulesetHook()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             var user = new MultiplayerRoomUser(1);
 
@@ -74,19 +49,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task TypeChangeTriggersInitialJoins()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             // join a number of users initially to the room
             for (int i = 0; i < 5; i++)

--- a/osu.Server.Spectator.Tests/Multiplayer/MatchTypeTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MatchTypeTests.cs
@@ -32,7 +32,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 room.MatchState = mockRoomState.Object;
 
-                await Hub.HubContext.NotifyMatchRoomStateChanged(room);
+                await HubContext.NotifyMatchRoomStateChanged(room);
 
                 Receiver.Verify(c => c.MatchRoomStateChanged(mockRoomState.Object), Times.Once);
             }
@@ -50,7 +50,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 var mockEvent = new Mock<MatchServerEvent>();
 
-                await Hub.HubContext.NotifyNewMatchEvent(room, mockEvent.Object);
+                await HubContext.NotifyNewMatchEvent(room, mockEvent.Object);
 
                 Receiver.Verify(c => c.MatchEvent(mockEvent.Object), Times.Once);
             }
@@ -72,7 +72,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 
                 user.MatchState = mockRoomState.Object;
 
-                await Hub.HubContext.NotifyMatchUserStateChanged(room, user);
+                await HubContext.NotifyMatchUserStateChanged(room, user);
 
                 Receiver.Verify(c => c.MatchUserStateChanged(user.UserID, mockRoomState.Object), Times.Once);
             }

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -32,6 +32,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         protected const long ROOM_ID = 8888;
         protected const long ROOM_ID_2 = 9999;
 
+        protected IMultiplayerHubContext HubContext { get; }
         protected TestMultiplayerHub Hub { get; }
         protected EntityStore<ServerMultiplayerRoom> Rooms { get; }
         protected EntityStore<MultiplayerClientState> UserStates { get; }
@@ -138,15 +139,25 @@ namespace osu.Server.Spectator.Tests.Multiplayer
             LegacyIO.Setup(io => io.CreateRoomAsync(It.IsAny<int>(), It.IsAny<MultiplayerRoom>()))
                     .Returns<int, MultiplayerRoom>((_, room) => Task.FromResult(room.RoomID));
 
+            MultiplayerEventLogger eventLogger = new MultiplayerEventLogger(loggerFactoryMock.Object, DatabaseFactory.Object);
+
+            HubContext = new MultiplayerHubContext(
+                hubContext.Object,
+                Rooms,
+                UserStates,
+                loggerFactoryMock.Object,
+                DatabaseFactory.Object,
+                eventLogger);
+
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,
                 Rooms,
                 UserStates,
                 DatabaseFactory.Object,
                 new ChatFilters(DatabaseFactory.Object),
-                hubContext.Object,
+                HubContext,
                 LegacyIO.Object,
-                new MultiplayerEventLogger(loggerFactoryMock.Object, DatabaseFactory.Object),
+                eventLogger,
                 new Mock<IMatchmakingQueueBackgroundService>().Object);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;

--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -166,25 +166,6 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         }
 
         [Fact]
-        public async Task UserJoinPreRetrievalFailureCleansUpRoom()
-        {
-            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
-                    .Callback<long>(InitialiseRoom)
-                    .ReturnsAsync(() => new multiplayer_room
-                    {
-                        type = database_match_type.head_to_head,
-                        ends_at = DateTimeOffset.Now.AddMinutes(5),
-                        user_id = USER_ID,
-                    });
-
-            SetUserContext(ContextUser2); // not the correct user to join the game first; triggers host mismatch failure.
-            await Assert.ThrowsAnyAsync<Exception>(() => Hub.JoinRoom(ROOM_ID));
-
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => Rooms.GetForUse(ROOM_ID));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => UserStates.GetForUse(USER_ID));
-        }
-
-        [Fact]
         public async Task UserJoinPreJoinFailureCleansUpRoom()
         {
             Database.Setup(db => db.MarkRoomActiveAsync(It.IsAny<MultiplayerRoom>()))

--- a/osu.Server.Spectator.Tests/Multiplayer/TeamVersusMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TeamVersusMatchControllerTests.cs
@@ -20,18 +20,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task UserRequestsValidTeamChange(int team)
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             var teamVersus = new TeamVersusMatchController(room, hub.Object, DatabaseFactory.Object);
 
@@ -56,18 +45,8 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task UserRequestsInvalidTeamChange(int team)
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
+
             var teamVersus = new TeamVersusMatchController(room, hub.Object, DatabaseFactory.Object);
 
             // change the match type
@@ -92,18 +71,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task NewUsersAssignedToTeamWithFewerUsers()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             // change the match type
             await room.ChangeMatchType(MatchType.TeamVersus);
@@ -133,18 +101,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task InitialUsersAssignedToTeamsEqually()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             // join a number of users initially to the room
             for (int i = 0; i < 5; i++)
@@ -164,18 +121,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         public async Task StateMaintainedBetweenRulesetSwitch()
         {
             var hub = new Mock<IMultiplayerHubContext>();
-            var room = new ServerMultiplayerRoom(1, hub.Object, DatabaseFactory.Object)
-            {
-                Playlist =
-                {
-                    new MultiplayerPlaylistItem
-                    {
-                        BeatmapID = 3333,
-                        BeatmapChecksum = "3333"
-                    },
-                }
-            };
-            await room.Initialise();
+            var room = await ServerMultiplayerRoom.InitialiseAsync(ROOM_ID, hub.Object, DatabaseFactory.Object);
 
             await room.ChangeMatchType(MatchType.TeamVersus);
 

--- a/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/TestMultiplayerHub.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Entities;
@@ -13,15 +12,13 @@ namespace osu.Server.Spectator.Tests.Multiplayer
 {
     public class TestMultiplayerHub : MultiplayerHub
     {
-        public new MultiplayerHubContext HubContext => base.HubContext;
-
         public TestMultiplayerHub(
             ILoggerFactory loggerFactory,
             EntityStore<ServerMultiplayerRoom> rooms,
             EntityStore<MultiplayerClientState> users,
             IDatabaseFactory databaseFactory,
             ChatFilters chatFilters,
-            IHubContext<MultiplayerHub> hubContext,
+            IMultiplayerHubContext hubContext,
             ISharedInterop sharedInterop,
             MultiplayerEventLogger multiplayerEventLogger,
             IMatchmakingQueueBackgroundService matchmakingQueueBackgroundService)

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -37,7 +37,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddHostedService<IDailyChallengeUpdater>(ctx => ctx.GetRequiredService<IDailyChallengeUpdater>())
                                     .AddSingleton<MultiplayerEventLogger>()
                                     .AddSingleton<IMatchmakingQueueBackgroundService, MatchmakingQueueBackgroundService>()
-                                    .AddHostedService<IMatchmakingQueueBackgroundService>(ctx => ctx.GetRequiredService<IMatchmakingQueueBackgroundService>());
+                                    .AddHostedService<IMatchmakingQueueBackgroundService>(ctx => ctx.GetRequiredService<IMatchmakingQueueBackgroundService>())
+                                    .AddSingleton<IMultiplayerHubContext, MultiplayerHubContext>();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerHubContext.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -147,5 +149,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         Task NotifyMatchmakingItemSelected(ServerMultiplayerRoom room, int userId, long playlistItemId);
 
         Task NotifyMatchmakingItemDeselected(ServerMultiplayerRoom room, int userId, long playlistItemId);
+
+        void Log(ServerMultiplayerRoom room, MultiplayerRoomUser? user, string message, LogLevel logLevel = LogLevel.Information);
+
+        void Error(MultiplayerRoomUser? user, string message, Exception exception);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MessagePack;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using osu.Game.Online;
 using osu.Game.Online.API;
@@ -26,7 +25,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         private static readonly MessagePackSerializerOptions message_pack_options = new MessagePackSerializerOptions(new SignalRUnionWorkaroundResolver());
 
         protected readonly EntityStore<ServerMultiplayerRoom> Rooms;
-        protected readonly MultiplayerHubContext HubContext;
+        protected readonly IMultiplayerHubContext HubContext;
         private readonly IDatabaseFactory databaseFactory;
         private readonly ChatFilters chatFilters;
         private readonly ISharedInterop sharedInterop;
@@ -39,7 +38,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             EntityStore<MultiplayerClientState> users,
             IDatabaseFactory databaseFactory,
             ChatFilters chatFilters,
-            IHubContext<MultiplayerHub> hubContext,
+            IMultiplayerHubContext hubContext,
             ISharedInterop sharedInterop,
             MultiplayerEventLogger multiplayerEventLogger,
             IMatchmakingQueueBackgroundService matchmakingQueueService)
@@ -52,7 +51,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             this.matchmakingQueueService = matchmakingQueueService;
 
             Rooms = rooms;
-            HubContext = new MultiplayerHubContext(hubContext, rooms, users, loggerFactory, databaseFactory, multiplayerEventLogger);
+            HubContext = hubContext;
         }
 
         public async Task<MultiplayerRoom> CreateRoom(MultiplayerRoom room)

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
@@ -108,14 +108,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         public async Task UnreadyAllUsers(ServerMultiplayerRoom room, bool resetBeatmapAvailability)
         {
-            log(room, null, "Unreadying all users");
+            Log(room, null, "Unreadying all users");
 
             foreach (var u in room.Users.Where(u => u.State == MultiplayerUserState.Ready).ToArray())
                 await ChangeAndBroadcastUserState(room, u, MultiplayerUserState.Idle);
 
             if (resetBeatmapAvailability)
             {
-                log(room, null, "Resetting all users' beatmap availability");
+                Log(room, null, "Resetting all users' beatmap availability");
 
                 foreach (var user in room.Users)
                     await ChangeAndBroadcastUserBeatmapAvailability(room, user, new BeatmapAvailability(DownloadState.Unknown));
@@ -178,7 +178,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             if (user.BeatmapId == beatmapId && user.RulesetId == rulesetId)
                 return;
 
-            log(room, user, $"User style changing from (b:{user.BeatmapId}, r:{user.RulesetId}) to (b:{beatmapId}, r:{rulesetId})");
+            Log(room, user, $"User style changing from (b:{user.BeatmapId}, r:{user.RulesetId}) to (b:{beatmapId}, r:{rulesetId})");
 
             if (rulesetId < 0 || rulesetId > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
                 throw new InvalidStateException("Attempted to select an unsupported ruleset.");
@@ -233,7 +233,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         public async Task ChangeAndBroadcastUserState(ServerMultiplayerRoom room, MultiplayerRoomUser user, MultiplayerUserState state)
         {
-            log(room, user, $"User state changed from {user.State} to {state}");
+            Log(room, user, $"User state changed from {user.State} to {state}");
 
             user.State = state;
 
@@ -254,7 +254,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         public async Task ChangeRoomState(ServerMultiplayerRoom room, MultiplayerRoomState newState)
         {
-            log(room, null, $"Room state changing from {room.State} to {newState}");
+            Log(room, null, $"Room state changing from {room.State} to {newState}");
 
             room.State = newState;
             using (var db = databaseFactory.GetInstance())
@@ -325,7 +325,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 {
                     await ChangeAndBroadcastUserState(room, user, MultiplayerUserState.Idle);
                     await context.Clients.Client(connectionId).SendAsync(nameof(IMultiplayerClient.GameplayAborted), GameplayAbortReason.LoadTookTooLong);
-                    log(room, user, "Gameplay aborted because this user took too long to load.");
+                    Log(room, user, "Gameplay aborted because this user took too long to load.");
                 }
             }
 
@@ -400,7 +400,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             await context.Clients.Group(MultiplayerHub.GetGroupId(room.RoomID)).SendAsync(nameof(IMatchmakingClient.MatchmakingItemDeselected), userId, playlistItemId);
         }
 
-        private void log(ServerMultiplayerRoom room, MultiplayerRoomUser? user, string message, LogLevel logLevel = LogLevel.Information)
+        public void Log(ServerMultiplayerRoom room, MultiplayerRoomUser? user, string message, LogLevel logLevel = LogLevel.Information)
         {
             logger.Log(logLevel, "[user:{userId}] [room:{roomID}] {message}",
                 getLoggableUserIdentifier(user),
@@ -408,7 +408,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 message.Trim());
         }
 
-        private void error(MultiplayerRoomUser? user, string message, Exception exception)
+        public void Error(MultiplayerRoomUser? user, string message, Exception exception)
         {
             logger.LogError(exception, "[user:{userId}] {message}",
                 getLoggableUserIdentifier(user),


### PR DESCRIPTION
## Overview

The primary purpose of this change is to enable the following addition: https://github.com/smoogipoo/osu-server-spectator/commit/e24be0e0d764173e1891431a5d4011f9d1e763a8 - making the matchmaking background service able to initialise rooms and perform post-initialisation adjustments.

As part of this change:

- Room initialisation moved to `ServerMultiplayerRoom.InitialiseAsync()`.
- `ServerMultiplayerRoom` constructor made private.
- `MultiplayerHubContext` moved to global singleton dependency.

This will also allow testing that users are eligible for the room, such as in https://github.com/smoogipoo/osu-server-spectator/commit/522ed4c1e4c0aa44dc8cc2533b3cce8832e3fbeb

## Important changes

This affects normal multiplayer room initialisation. In particular, the first user that joins the room will become the host of the room, and users are allowed to join in any order. Given that room join + creation happens sequentially server-side (as opposed to through a client-server round-trip), I don't expect this to result in too many race conditions (although still possible).

I think this is something that can be further improved by splitting out the `JoinRoom` logic. If requested I can try to do that in this PR.

## Alternatives

I think this is the nicest of three possible directions I had in mind, the others include:

- Adding web-side/database storage for room users.
- Storing these "post-initialisation" states temporarily to an `IMemoryCache` and querying them on room init.