### PR TITLE
Fix unused contest performance ceiling

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloSystem.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Elo/EloSystem.cs
@@ -66,7 +66,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo
                 EloPlayer player = contest.Standings[i];
 
                 int index = i;
-                double muPerf = SolveNewton(x => ComputeLikelihoodSum(x, tanhTerms, index, index));
+                double muPerf = Math.Min(contest.PerformanceCeiling, SolveNewton(x => ComputeLikelihoodSum(x, tanhTerms, index, index)));
                 double weight = computeWeight(contest.Weight, player.ContestCount);
                 double sigPerf = computeSigPerf(weight);
                 player.UpdatePerformance(contest.Time, new EloRating(muPerf, sigPerf), MaxHistory);


### PR DESCRIPTION
Noticed this wasn't used while going through the code.

Ref: https://github.com/EbTech/Elo-MMR/blob/f6f83bb2c54bf173e60a9e8614065e8d168a349b/multi-skill/src/systems/simple_elo_mmr.rs#L128

This property isn't used yet.