### PR TITLE
Adjust quick play stage times

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -29,17 +29,17 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
         /// <summary>
         /// Duration users are given to view standings at the round start screen.
         /// </summary>
-        private const int stage_round_start_time = 10;
+        private const int stage_round_start_time = 20;
 
         /// <summary>
         /// Duration users are given to pick their beatmap.
         /// </summary>
-        private const int stage_user_picks_time = 20;
+        private const int stage_user_picks_time = 60;
 
         /// <summary>
         /// Duration before the beatmap is revealed to users (should approximate client animation time).
         /// </summary>
-        private const int stage_select_beatmap_time = 5;
+        private const int stage_select_beatmap_time = 7;
 
         /// <summary>
         /// Duration users are given to download the beatmap before they're excluded from the match.


### PR DESCRIPTION
Round warmup: 10s -> 20s

- Gives more time for players to participate in the room post-round.

Selection: 20s -> 60s

- Gives more time for players to select beatmaps.
- Playing a bit on the safe side with this, which might be a little excessive. Better would be to both give a way for players to select a random beatmap _and_ to ffwd the timer when all players have a selection, but I'm not sure what it would take to get that to work right now.

Beatmap finalised: 5s -> 7s

- With the previous value the beatmap would start being downloaded slightly before the animation completes.