### PR TITLE
Fix room not cleared on disconnections

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -339,14 +339,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                         if (targetUserUsage.Item.CurrentRoomID == null)
                             throw new InvalidOperationException();
 
-                        try
-                        {
-                            await leaveRoom(targetUserUsage.Item, roomUsage, true);
-                        }
-                        finally
-                        {
-                            targetUserUsage.Item.ClearRoom();
-                        }
+                        await leaveRoom(targetUserUsage.Item, roomUsage, true);
                     }
                 }
             }


### PR DESCRIPTION
The only path that was clearing the room was via `LeaveRoom` (the client invocation). We need to do it in all cases.