### PR TITLE
Add support for `MatchmakingCursorPositionRequest`

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -149,6 +149,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
                         Action = avatarAction.Action
                     });
                     break;
+
+                case MatchmakingCursorPositionRequest cursorPosition:
+                    await hub.NotifyNewMatchEvent(room, new MatchmakingCursorPositionEvent
+                    {
+                        UserId = user.UserID,
+                        X = cursorPosition.X,
+                        Y = cursorPosition.Y,
+                    });
+                    break;
             }
         }
 


### PR DESCRIPTION
Companion to ppy/osu#35550

Allows handling MatchmakingCursorPositionRequests for displaying cursor position in beatmap selection screen.

