### PR TITLE
Disable JSON protocol

### DIFF
--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -27,6 +27,10 @@ namespace osu.Server.Spectator
         {
             services.AddSignalR(options =>
                     {
+                        // JSON hub protocol is enabled by default, but we use MessagePack.
+                        // Some models are not compatible with the JSON protocol, so we should never negotiate it.
+                        options.SupportedProtocols?.Remove("json");
+
                         options.AddFilter<LoggingHubFilter>();
                         options.AddFilter<ConcurrentConnectionLimiter>();
                     })


### PR DESCRIPTION
See internal conversation starting with https://discord.com/channels/90072389919997952/1327149041511043134/1434563875499409579

This is explicitly listed as a supported action [here](https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-9.0&tabs=dotnet#configure-server-options):

> Protocols supported by this hub. By default, all protocols registered on the server are allowed. Protocols can be removed from this list to disable specific protocols for individual hubs.