### PR TITLE
Add tests for matchmaking queue background service

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Tests.Multiplayer;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests.Matchmaking
+{
+    public class MatchmakingQueueBackgroundServiceTests : MultiplayerTest
+    {
+        public MatchmakingQueueBackgroundServiceTests()
+        {
+            Database.Setup(db => db.GetMatchmakingPoolAsync(It.IsAny<int>()))
+                    .Returns<int>(id => Task.FromResult<matchmaking_pool?>(new matchmaking_pool
+                    {
+                        id = id,
+                        name = $"pool-{id}",
+                        active = true,
+                        lobby_size = 2,
+                    }));
+
+            Database.Setup(db => db.GetRealtimeRoomAsync(0))
+                    .Callback<long>(roomId => InitialiseRoom(roomId, 10))
+                    .ReturnsAsync(() => new multiplayer_room
+                    {
+                        type = database_match_type.matchmaking,
+                        ends_at = DateTimeOffset.Now.AddMinutes(5),
+                        user_id = int.Parse(Hub.Context.UserIdentifier!),
+                    });
+        }
+
+        [Fact]
+        public async Task AddToQueue()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
+            UserReceiver.Verify(u => u.MatchmakingQueueLeft(), Times.Never);
+        }
+
+        [Fact]
+        public async Task RemoveFromQueue()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.RemoveFromQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
+            UserReceiver.Verify(u => u.MatchmakingQueueLeft(), Times.Once);
+        }
+
+        [Fact]
+        public async Task MatchReady()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Never);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Never);
+
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+        }
+
+        [Fact]
+        public async Task AcceptInvitation()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+
+            await MatchmakingBackgroundService.AcceptInvitationAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+
+            await MatchmakingBackgroundService.AcceptInvitationAsync(UserStates.GetEntityUnsafe(USER_ID_2)!);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeclineInvitation()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+
+            await MatchmakingBackgroundService.AcceptInvitationAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+            await MatchmakingBackgroundService.DeclineInvitationAsync(UserStates.GetEntityUnsafe(USER_ID_2)!);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Exactly(2));
+            UserReceiver.Verify(u => u.MatchmakingQueueLeft(), Times.Never);
+
+            User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            User2Receiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingQueueLeft(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LeaveQueueAfterInvite()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+
+            await MatchmakingBackgroundService.AcceptInvitationAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+            await MatchmakingBackgroundService.RemoveFromQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            // Should be the same as DeclineInvitation()
+            UserReceiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Exactly(2));
+            UserReceiver.Verify(u => u.MatchmakingQueueLeft(), Times.Never);
+
+            // Should be the same as DeclineInvitation()
+            User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            User2Receiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingQueueLeft(), Times.Once);
+        }
+
+        [Fact]
+        public async Task QueueLeftOnDisconnect()
+        {
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvited(), Times.Once);
+
+            await MatchmakingBackgroundService.AcceptInvitationAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+            SetUserContext(ContextUser2);
+            await Hub.OnDisconnectedAsync(null);
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            // Should be the same as DeclineInvitation()
+            UserReceiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Exactly(2));
+            UserReceiver.Verify(u => u.MatchmakingQueueLeft(), Times.Never);
+
+            // Should be the same as DeclineInvitation()
+            User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+            User2Receiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingQueueLeft(), Times.Once);
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/MultiplayerTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Beatmaps;
@@ -36,6 +37,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         protected TestMultiplayerHub Hub { get; }
         protected EntityStore<ServerMultiplayerRoom> Rooms { get; }
         protected EntityStore<MultiplayerClientState> UserStates { get; }
+        protected MatchmakingQueueBackgroundService MatchmakingBackgroundService { get; }
 
         protected readonly Mock<IDatabaseFactory> DatabaseFactory;
         protected readonly Mock<IDatabaseAccess> Database;
@@ -159,6 +161,15 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 DatabaseFactory.Object,
                 eventLogger);
 
+            MatchmakingBackgroundService = new MatchmakingQueueBackgroundService(
+                hubContext.Object,
+                LegacyIO.Object,
+                DatabaseFactory.Object,
+                loggerFactoryMock.Object,
+                Rooms,
+                HubContext,
+                new MemoryCache(new MemoryCacheOptions()));
+
             Hub = new TestMultiplayerHub(
                 loggerFactoryMock.Object,
                 Rooms,
@@ -168,7 +179,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
                 HubContext,
                 LegacyIO.Object,
                 eventLogger,
-                new Mock<IMatchmakingQueueBackgroundService>().Object);
+                MatchmakingBackgroundService);
             Hub.Groups = Groups.Object;
             Hub.Clients = Clients.Object;
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -151,37 +151,44 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                try
-                {
-                    await updateLobby();
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to update the matchmaking lobby.");
-                }
-
-                try
-                {
-                    await refreshQueues();
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to refresh the matchmaking queue.");
-                }
-
-                foreach ((_, MatchmakingQueue queue) in poolQueues)
-                {
-                    try
-                    {
-                        await processBundle(queue.Update());
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to update the matchmaking queue for pool {poolId}.", queue.Pool.id);
-                    }
-                }
-
+                await ExecuteOnceAsync();
                 await Task.Delay(queue_update_rate, stoppingToken);
+            }
+        }
+
+        /// <summary>
+        /// Executes a single update of the queues.
+        /// </summary>
+        public async Task ExecuteOnceAsync()
+        {
+            try
+            {
+                await updateLobby();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to update the matchmaking lobby.");
+            }
+
+            try
+            {
+                await refreshQueues();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to refresh the matchmaking queue.");
+            }
+
+            foreach ((_, MatchmakingQueue queue) in poolQueues)
+            {
+                try
+                {
+                    await processBundle(queue.Update());
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to update the matchmaking queue for pool {poolId}.", queue.Pool.id);
+                }
             }
         }
 


### PR DESCRIPTION
I have plans to make this service handle a user queueing for multiple pools at once, which will complicate everything a bit. I think it's appropriate to first add some tests before I do any of that...