### PR TITLE
Better approximate client animation delay for single candidate

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -45,7 +45,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
         /// <summary>
         /// Duration before the beatmap is revealed to users (should approximate client animation time).
         /// </summary>
-        private const int stage_select_beatmap_time = 7;
+        private const int stage_select_beatmap_time_single_item = 3;
+
+        /// <summary>
+        /// Duration before the beatmap is revealed to users (should approximate client animation time).
+        /// </summary>
+        private const int stage_select_beatmap_time_multiple_items = 7;
 
         /// <summary>
         /// Duration users are given to download the beatmap before they're excluded from the match.
@@ -269,7 +274,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
             state.CandidateItem = pickIds[Random.Shared.Next(0, pickIds.Length)];
 
             await changeStage(MatchmakingStage.ServerBeatmapFinalised);
-            await startCountdown(TimeSpan.FromSeconds(stage_select_beatmap_time), stageWaitingForClientsBeatmapDownload);
+            await startCountdown(state.CandidateItems.Length == 1
+                    ? TimeSpan.FromSeconds(stage_select_beatmap_time_single_item)
+                    : TimeSpan.FromSeconds(stage_select_beatmap_time_multiple_items),
+                stageWaitingForClientsBeatmapDownload);
         }
 
         private async Task stageWaitingForClientsBeatmapDownload(ServerMultiplayerRoom _)


### PR DESCRIPTION
Annoys me every time I test locally with one client.

The client-side [animation delays](https://github.com/ppy/osu/blob/933fbd274d0444b843c915c0791f5032456d09c5/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs#L149-L164) when single and multiple candidates are roughly 2.4s and 6.4s respectively. This now better approximates the single-candidate case, removing around 4s of delay before the beatmap is set as the gameplay selection (passed through `MultiplayerRoomSettings`).

This becomes more relevant when a "random" beatmap panel is introduced, which only updates to the final beatmap ID after this delay.