### PR TITLE
Enable stateful reconnects

### DIFF
--- a/osu.Server.Spectator/Startup.cs
+++ b/osu.Server.Spectator/Startup.cs
@@ -138,10 +138,10 @@ namespace osu.Server.Spectator
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapHub<SpectatorHub>("/spectator");
-                endpoints.MapHub<MultiplayerHub>("/multiplayer");
-                endpoints.MapHub<MetadataHub>("/metadata");
-                endpoints.MapHub<RefereeHub>("/referee");
+                endpoints.MapHub<SpectatorHub>("/spectator", o => o.AllowStatefulReconnects = true);
+                endpoints.MapHub<MultiplayerHub>("/multiplayer", o => o.AllowStatefulReconnects = true);
+                endpoints.MapHub<MetadataHub>("/metadata", o => o.AllowStatefulReconnects = true);
+                endpoints.MapHub<RefereeHub>("/referee", o => o.AllowStatefulReconnects = true);
             });
 
             // Create shutdown manager singleton.


### PR DESCRIPTION
RFC.

This allows the client to be able to negotiate stateful reconnects with the server. It does nothing on its own - the client must also be modified to tell the server it's capable to statefully reconnect.