### PR TITLE
Track formed/completed quick play groups

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -251,6 +251,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             foreach (var group in bundle.FormedGroups)
             {
+                DogStatsd.Increment($"{statsd_prefix}.groups.formed");
+
                 foreach (var user in group.Users)
                     await hub.Groups.AddToGroupAsync(user.Identifier, group.Identifier, CancellationToken.None);
 
@@ -260,6 +262,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             foreach (var group in bundle.CompletedGroups)
             {
+                DogStatsd.Increment($"{statsd_prefix}.groups.completed");
+
                 foreach (var user in group.Users)
                     DogStatsd.Timer($"{statsd_prefix}.queue.duration", (DateTimeOffset.Now - user.SearchStartTime).TotalMilliseconds, tags: [$"queue:{bundle.Queue.Pool.name}"]);
 


### PR DESCRIPTION
I originally had these metrics but later removed them.

- `groups.formed` - invites sent out
- `groups.completed` - all invites accepted.
- `groups.recycled` - any invites not accepted

Also added a follow-up change here, something I've noticed recently, which is to remove users from recycled groups. This wouldn't cause any problems other than a potential memory leak, and I can't write a test for this.