### PR TITLE
Further iterate on randomised selection algorithm

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -56,7 +56,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                            {
                                double beatmapRating = b.rating ?? 1500;
                                // The clamp attempts to ensure all beatmaps are given some chance of being selected.
-                               double weight = Math.Exp(-Math.Pow(beatmapRating - ratingMu, 2) / (2 * rating_sig * rating_sig));
+                               double weight = Math.Clamp(Math.Exp(-Math.Pow(beatmapRating - ratingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
                                return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
                            })
                            .Take(PoolSize)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-server-spectator/issues/385

Continues from https://github.com/ppy/osu-server-spectator/pull/382

From my experience using the system so far...

## [Reduce selection breadth around user MMR](https://github.com/ppy/osu-server-spectator/commit/6bb1e8626bfef3e7d5881086ec4d5d7b9f96f0a5)

Currently the 3 std. deviation spread around the user's MMR is 8*, which is pretty insane. This reduces it to 4*.

## [Remove base probability](https://github.com/ppy/osu-server-spectator/commit/3a57ab642b25e46d124c6b23047330b9e2bdf729)

For cases where there are tails (i.e. player rating is not smack-bang in the middle of the beatmap set), this would disproportionately favour the beatmaps in the tail. It's to be expected, because it's screwing up the normal distribution.

For instance, in one dataset I can come up with a ~15% chance of a 1200MMR player seeing beatmaps > 1800MMR (6* above their skill level). 

There's probably other things that can be done here, like taking the user's MMR combined with the std-dev of the _beatmap pool_, and then summing that to  still give those maps some weighting, but let's not overthink.

| Before | After |
| --- | --- |
| <img width="603" height="372" alt="image" src="https://github.com/user-attachments/assets/92b37d21-d150-4c92-8158-6f65e6d15842" /> | <img width="601" height="372" alt="image" src="https://github.com/user-attachments/assets/d7d95199-5af1-402a-825c-4a79d25df3c4" /> |

Data generation: https://gist.github.com/smoogipoo/49673771917089363b68da857b810fc6