### PR TITLE
Fix Statsd gauge names for pools

### DIFF
--- a/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
@@ -39,5 +39,29 @@ namespace osu.Server.Spectator.Database.Models
             Variant = variant_id,
             Name = name,
         };
+
+        public string DisplayName
+        {
+            get
+            {
+                switch (ruleset_id)
+                {
+                    case 0:
+                        return $"osu! ({name})";
+
+                    case 1:
+                        return $"osu!taiko ({name})";
+
+                    case 2:
+                        return $"osu!catch ({name})";
+
+                    case 3:
+                        return $"osu!mania {variant_id}K ({name})";
+
+                    default:
+                        return name;
+                }
+            }
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -204,7 +204,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 return;
 
             foreach ((_, MatchmakingQueue queue) in poolQueues)
-                DogStatsd.Gauge($"{statsd_prefix}.queue.users", queue.Count, tags: [$"queue:{queue.Pool.name}"]);
+                DogStatsd.Gauge($"{statsd_prefix}.queue.users", queue.Count, tags: [$"queue:{queue.Pool.DisplayName}"]);
 
             MatchmakingQueueUser[] users = poolQueues.Values.SelectMany(queue => queue.GetAllUsers()).ToArray();
             Random.Shared.Shuffle(users);
@@ -283,7 +283,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 DogStatsd.Increment($"{statsd_prefix}.groups.completed");
 
                 foreach (var user in group.Users)
-                    DogStatsd.Timer($"{statsd_prefix}.queue.duration", (DateTimeOffset.Now - user.SearchStartTime).TotalMilliseconds, tags: [$"queue:{bundle.Queue.Pool.name}"]);
+                    DogStatsd.Timer($"{statsd_prefix}.queue.duration", (DateTimeOffset.Now - user.SearchStartTime).TotalMilliseconds, tags: [$"queue:{bundle.Queue.Pool.DisplayName}"]);
 
                 string password = Guid.NewGuid().ToString();
                 long roomId = await sharedInterop.CreateRoomAsync(AppSettings.BanchoBotUserId, new MultiplayerRoom(0)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-server-spectator/issues/384

Because they're all named "1v1" now.