### PR TITLE
Wait for score submission before processing quick play scores

### DIFF
--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -209,6 +209,12 @@ namespace osu.Server.Spectator.Database
         Task<(long roomID, long playlistItemID)?> GetMultiplayerRoomIdForScoreAsync(long scoreId);
 
         /// <summary>
+        /// Waits for all score submissions on a given playlist item to complete, up to a maximum of 10 seconds.
+        /// </summary>
+        /// <param name="playlistItemId">The playlist item.</param>
+        Task WaitForRoomScoreSubmissionComplete(long playlistItemId);
+
+        /// <summary>
         /// Retrieve all scores for a specified playlist item.
         /// </summary>
         /// <param name="playlistItemId">The playlist item.</param>


### PR DESCRIPTION
Fixes https://osu.ppy.sh/community/forums/topics/2160029?n=1

RFC. I'm not sure of a better way to handle this...

Normally, the server knows score submission completed by way of users [getting into the `FinishedPlay state`](https://github.com/ppy/osu/blob/59a27dad3d4b4e2e735ac4a7f4e44ca4efa4a0e9/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs#L213-L222), but this is not the case in the failing scenario.

The failing scenario is, that when a user quits gameplay score submission runs [asynchronously](https://github.com/ppy/osu/blob/59a27dad3d4b4e2e735ac4a7f4e44ca4efa4a0e9/osu.Game/Screens/Play/SubmittingPlayer.cs#L263-L276) in the background while the server thinks that it's complete by way of the user no longer being in the `Gameplay` state.

This diff accurately reproduces the fixed issue:

```diff
diff --git a/osu.Game/Screens/Play/SubmittingPlayer.cs b/osu.Game/Screens/Play/SubmittingPlayer.cs
index 06f1a9c530..9b611bc29e 100644
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -269,6 +269,7 @@ private void submitFromFailOrQuit(Score score)
 
                 Task.Run(async () =>
                 {
+                    await Task.Delay(3000);
                     await submitScore(scoreCopy).ConfigureAwait(false);
                     spectatorClient.EndPlaying(GameplayState);
                 }).FireAndForget();

```

Which now behaves like this:

https://github.com/user-attachments/assets/dc683972-7db0-4394-a85e-945c58695f98

