### PR TITLE
Adjust beatmap rating for higher difficulties at lower SRs

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -23,7 +23,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             foreach (var b in beatmaps)
             {
                 // Todo: This default rating is only accurate for NoMod beatmaps.
-                b.rating ??= (int)Math.Round(800 + 150 * b.difficultyrating);
+                b.rating ??= (int)Math.Round(800 + 500 * (Math.Exp(0.16 * b.difficultyrating) - 1));
             }
         }
 


### PR DESCRIPTION
Target: week 3

The idea is to compress the lower SR ranges so that there's more difficult maps, and to space out the high ranges so that there's more ELO growth.

Red - old, blue - new.

<img width="800" height="800" alt="desmos-graph" src="https://github.com/user-attachments/assets/9b2b161d-9a32-40f7-83a5-be90b02ea182" />