### PR TITLE
Limit maximum matchmaking search radius

### DIFF
--- a/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
@@ -28,6 +28,11 @@ namespace osu.Server.Spectator.Database.Models
         public int rating_search_radius { get; set; }
 
         /// <summary>
+        /// The maximum search radius.
+        /// </summary>
+        public int rating_search_radius_max { get; set; } = 9999;
+
+        /// <summary>
         /// The amount of time (in seconds) before each doubling of the <see cref="rating_search_radius">rating search radius</see>.
         /// </summary>
         public int rating_search_radius_exp { get; set; }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -349,7 +349,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 double distance = Math.Min(leftDistance, rightDistance);
 
                 TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-                double searchRadius = Pool.rating_search_radius * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp);
+                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
 
                 if (distance > searchRadius)
                     break;


### PR DESCRIPTION
Will eventually be used to limit the search radius to a sane value like 200.

Soft dependency on https://github.com/ppy/osu-web/pull/12607