### PR TITLE
Adjust quick play ready user check

### DIFF
--- a/osu.Server.Spectator/Extensions/MultiplayerRoomUserExtensions.cs
+++ b/osu.Server.Spectator/Extensions/MultiplayerRoomUserExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online;
+using osu.Game.Online.Multiplayer;
+
+namespace osu.Server.Spectator.Extensions
+{
+    public static class MultiplayerRoomUserExtensions
+    {
+        /// <summary>
+        /// Whether a user is in a state capable of starting gameplay.
+        /// </summary>
+        public static bool IsReadyForGameplay(this MultiplayerRoomUser user)
+            => user.BeatmapAvailability.State == DownloadState.LocallyAvailable && (user.State == MultiplayerUserState.Ready || user.State == MultiplayerUserState.Idle);
+    }
+}

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OpenSkillSharp.Models;
 using OpenSkillSharp.Rating;
+using osu.Game.Online;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer;
@@ -16,6 +17,7 @@ using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Extensions;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
@@ -468,7 +470,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
 
         private bool allUsersReady()
         {
-            return room.Users.All(u => u.State == MultiplayerUserState.Ready);
+            return room.Users.All(u => u.IsReadyForGameplay());
         }
 
         private bool hasEnoughUsersForGameplay()
@@ -477,7 +479,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
                 // Special case for testing in solo play.
                 (room.Users.Count == 1 && allUsersReady())
                 // Otherwise, always require at least two ready users.
-                || room.Users.Count(u => u.State == MultiplayerUserState.Ready) >= 2;
+                || room.Users.Count(u => u.IsReadyForGameplay()) >= 2;
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
@@ -295,10 +295,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             foreach (var user in room.Users)
                 await ChangeUserVoteToSkipIntro(room, user, false);
 
-            var readyUsers = room.Users.Where(u =>
-                u.BeatmapAvailability.State == DownloadState.LocallyAvailable
-                && (u.State == MultiplayerUserState.Ready || u.State == MultiplayerUserState.Idle)
-            ).ToArray();
+            var readyUsers = room.Users.Where(u => u.IsReadyForGameplay()).ToArray();
 
             foreach (var u in readyUsers)
                 await ChangeAndBroadcastUserState(room, u, MultiplayerUserState.WaitingForLoad);


### PR DESCRIPTION
This is part 3 to fixing https://github.com/ppy/osu/issues/36045 and mentioned as bullet point 3 in https://github.com/ppy/osu/pull/36121.

> Quick play sends both a [`Ready`](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L257-L259) state and [beatmap availability](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L268) to the server BUT only [relies](https://github.com/ppy/osu-server-spectator/blob/6c844e6327d9e9f6d7386f6e5e4bb678fb0d27e5/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs#L469-L472) on the ready state to decide when a match can be started.

Now the two conditions are matched.