### PR TITLE
Delay closing tournament rooms for 30min after last user left

### DIFF
--- a/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
+++ b/osu.Server.Spectator.Tests/Multiplayer/RoomParticipationTests.cs
@@ -218,7 +218,7 @@ namespace osu.Server.Spectator.Tests.Multiplayer
         [Fact]
         public async Task UserJoinPreJoinFailureCleansUpRoom()
         {
-            Database.Setup(db => db.MarkRoomActiveAsync(It.IsAny<MultiplayerRoom>()))
+            Database.Setup(db => db.SetRoomEndDateAsync(It.IsAny<MultiplayerRoom>(), It.IsAny<DateTimeOffset?>()))
                     .ThrowsAsync(new Exception("error"));
 
             await Assert.ThrowsAnyAsync<Exception>(() => Hub.JoinRoom(ROOM_ID));

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -134,13 +134,14 @@ namespace osu.Server.Spectator.Database
                 })).ToArray();
         }
 
-        public async Task MarkRoomActiveAsync(MultiplayerRoom room)
+        public async Task SetRoomEndDateAsync(MultiplayerRoom room, DateTimeOffset? endDate)
         {
             var connection = await getConnectionAsync();
 
-            await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = null WHERE id = @RoomID", new
+            await connection.ExecuteAsync("UPDATE multiplayer_rooms SET ends_at = @EndDate WHERE id = @RoomID", new
             {
-                RoomID = room.RoomID
+                RoomID = room.RoomID,
+                EndDate = endDate
             });
         }
 

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -67,9 +67,9 @@ namespace osu.Server.Spectator.Database
         Task<database_beatmap[]> GetBeatmapsAsync(int beatmapSetId);
 
         /// <summary>
-        /// Marks the given <paramref name="room"/> as active and accepting new players.
+        /// Sets the end date of the <paramref name="room"/>.
         /// </summary>
-        Task MarkRoomActiveAsync(MultiplayerRoom room);
+        Task SetRoomEndDateAsync(MultiplayerRoom room, DateTimeOffset? endDate);
 
         /// <summary>
         /// Updates the current settings of <paramref name="room"/> in the database.

--- a/osu.Server.Spectator/Database/Models/multiplayer_room.cs
+++ b/osu.Server.Spectator/Database/Models/multiplayer_room.cs
@@ -28,5 +28,6 @@ namespace osu.Server.Spectator.Database.Models
         public database_queue_mode queue_mode { get; set; }
         public ushort auto_start_duration { get; set; }
         public bool auto_skip { get; set; }
+        public bool tournament_mode { get; set; }
     }
 }

--- a/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
+++ b/osu.Server.Spectator/Extensions/ServiceCollectionExtensions.cs
@@ -40,7 +40,8 @@ namespace osu.Server.Spectator.Extensions
                                     .AddSingleton<MultiplayerEventDispatcher>()
                                     .AddSingleton<IMatchmakingQueueBackgroundService, MatchmakingQueueBackgroundService>()
                                     .AddHostedService<IMatchmakingQueueBackgroundService>(ctx => ctx.GetRequiredService<IMatchmakingQueueBackgroundService>())
-                                    .AddSingleton<IMultiplayerRoomController, MultiplayerRoomController>();
+                                    .AddSingleton<IMultiplayerRoomController, MultiplayerRoomController>()
+                                    .AddHostedService<MultiplayerRoomLifetimeBackgroundService>();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerRoomController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerRoomController.cs
@@ -41,9 +41,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         /// </summary>
         /// <param name="user">The user leaving the room.</param>
         /// <param name="roomUsage">The room being left.</param>
+        /// <param name="forceCloseOnEmpty">
+        /// Whether to force the room to close if it is empty after the user has left.
+        /// Only has an observable effect in rooms with <see cref="ServerMultiplayerRoom.TournamentMode"/> enabled,
+        /// as tournament mode rooms are the only ones which are allowed to remain open while empty for 30 minutes as counted from the time when the last user leaves.
+        /// </param>
         Task LeaveRoom(
             IMultiplayerUserState user,
-            ItemUsage<ServerMultiplayerRoom> roomUsage);
+            ItemUsage<ServerMultiplayerRoom> roomUsage,
+            bool forceCloseOnEmpty = false);
 
         /// <summary>
         /// The given user is kicked from the room.

--- a/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerUserState.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/IMultiplayerUserState.cs
@@ -32,21 +32,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         MultiplayerRoomUser CreateRoomUser();
 
         /// <summary>
-        /// Associates this <see cref="IMultiplayerUserState"/> with the given <paramref name="roomId"/>.
-        /// Performed on room join.
+        /// Ran when this <see cref="IMultiplayerUserState"/> joins the room with the given <paramref name="roomId"/>.
         /// </summary>
-        void AssociateWithRoom(long roomId);
+        void HandleRoomJoined(long roomId);
+
+        /// <summary>
+        /// Ran when this <see cref="IMultiplayerUserState"/> leaves the room with the given <paramref name="roomId"/>.
+        /// </summary>
+        void HandleRoomLeft(long roomId);
 
         /// <summary>
         /// Whether this <see cref="IMultiplayerUserState"/> is currently associated with the given <paramref name="roomId"/>.
         /// </summary>
         bool IsAssociatedWithRoom(long roomId);
-
-        /// <summary>
-        /// Disassociates this <see cref="IMultiplayerUserState"/> from the given <paramref name="roomId"/>.
-        /// Performed on room leave.
-        /// </summary>
-        void DisassociateFromRoom(long roomId);
 
         /// <summary>
         /// Subscribes to relevant event groups for the given <paramref name="roomId"/> via the supplied <paramref name="eventDispatcher"/>.

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerClientState.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerClientState.cs
@@ -28,7 +28,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         public MultiplayerRoomUser CreateRoomUser()
             => new MultiplayerRoomUser(UserId) { Role = MultiplayerRoomUserRole.Player };
 
-        public void AssociateWithRoom(long roomId)
+        public void HandleRoomJoined(long roomId)
         {
             if (CurrentRoomID != null)
                 throw new InvalidOperationException("User is already in a room.");
@@ -39,7 +39,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         public bool IsAssociatedWithRoom(long roomId) => CurrentRoomID == roomId;
 
-        public void DisassociateFromRoom(long roomId)
+        public void HandleRoomLeft(long roomId)
         {
             if (CurrentRoomID == null)
                 return;

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerEventDispatcher.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerEventDispatcher.cs
@@ -112,7 +112,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         /// </summary>
         /// <param name="roomId">The ID of the disbanded room.</param>
         /// <param name="userId">The ID of the user that disbanded the room.</param>
-        public async Task PostRoomDisbandedAsync(long roomId, int userId)
+        public async Task PostRoomDisbandedAsync(long roomId, int? userId)
         {
             await logToDatabase(new multiplayer_realtime_room_event
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomController.cs
@@ -85,7 +85,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                         if (isNewRoom && !room.Settings.MatchType.IsMatchmakingType())
                             room.Host = roomUser;
 
-                        userState.AssociateWithRoom(roomId);
+                        userState.HandleRoomJoined(roomId);
 
                         var existingUser = room.Users.FirstOrDefault(u => u.UserID == roomUser.UserID);
 
@@ -95,6 +95,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                             throw new InvalidOperationException($"User {roomUser.UserID} attempted to join room {room.RoomID} they are already present in.");
 
                         await userState.SubscribeToEvents(eventDispatcher, roomId);
+
+                        if (room.EndDate != null)
+                        {
+                            room.Log("Clearing pending end date.");
+                            await room.SetEndDateAsync(null);
+                        }
 
                         room.Log(roomUser, "User joined");
                     }
@@ -114,7 +120,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                                 {
                                     // the room was retrieved and associated to the usage, but something failed before the user (host) could join.
                                     // for now, let's mark the room as ended if this happens.
-                                    await endMatch(room, roomUser.UserID);
+                                    await room.Disband(roomUser.UserID);
                                 }
 
                                 roomUsage.Destroy();
@@ -123,7 +129,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                         finally
                         {
                             // no matter how we end up cleaning up the room, ensure the user's state is cleared.
-                            userState.DisassociateFromRoom(roomId);
+                            userState.HandleRoomLeft(roomId);
                         }
 
                         throw;
@@ -151,8 +157,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             return roomSnapshot;
         }
 
-        public async Task LeaveRoom(IMultiplayerUserState user, ItemUsage<ServerMultiplayerRoom> roomUsage)
-            => await removeUserFromRoom(user, roomUsage, user.UserId);
+        public async Task LeaveRoom(IMultiplayerUserState user, ItemUsage<ServerMultiplayerRoom> roomUsage, bool forceCloseOnEmpty = false)
+            => await removeUserFromRoom(user, roomUsage, user.UserId, forceCloseOnEmpty);
 
         public async Task KickUserFromRoom(IMultiplayerUserState kickedUser, ItemUsage<ServerMultiplayerRoom> roomUsage, int kickedBy)
             => await removeUserFromRoom(kickedUser, roomUsage, kickedBy);
@@ -195,7 +201,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             room.BanUser(bannedUserId);
         }
 
-        private async Task removeUserFromRoom(IMultiplayerUserState state, ItemUsage<ServerMultiplayerRoom> roomUsage, int removingUserId)
+        private async Task removeUserFromRoom(IMultiplayerUserState state, ItemUsage<ServerMultiplayerRoom> roomUsage, int removingUserId, bool forceCloseOnEmpty = false)
         {
             long? roomId = null;
 
@@ -234,19 +240,29 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     // Errors are logged internally by SharedInterop.
                 }
 
-                // handle closing the room if the only participant is the user which is leaving.
+                // special handling if the only participant is the user which is leaving.
                 if (room.Users.Count == 0)
                 {
-                    await endMatch(room, removingUserId);
+                    if (!room.TournamentMode || forceCloseOnEmpty)
+                    {
+                        await room.Disband(removingUserId);
 
-                    // only destroy the usage after the database operation succeeds.
-                    room.Log("Stopping tracking of room (all users left).");
-                    roomUsage.Destroy();
-                    return;
+                        // only destroy the usage after the database operation succeeds.
+                        room.Log("Stopping tracking of room (all users left).");
+                        roomUsage.Destroy();
+                        return;
+                    }
+                    else
+                    {
+                        var endDate = DateTimeOffset.Now.AddMinutes(30);
+                        room.Log($"All users left tournament room; setting room to close on {endDate}");
+                        await room.SetEndDateAsync(endDate);
+                    }
                 }
 
                 // if this user was the host, we need to arbitrarily transfer host so the room can continue to exist.
-                if (room.Host?.Equals(user) == true)
+                // this only applies to non-tournament rooms; in tournament rooms host is not transferable.
+                if (room.Host?.Equals(user) == true && !room.TournamentMode)
                 {
                     // there *has* to still be at least one user in the room (see user check above).
                     var newHost = room.Users.First();
@@ -262,7 +278,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             finally
             {
                 if (roomId != null)
-                    state.DisassociateFromRoom(roomId.Value);
+                    state.HandleRoomLeft(roomId.Value);
             }
         }
 
@@ -273,14 +289,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         /// </remarks>
         private static bool isRefereeSpectatingOwnMatch(IMultiplayerUserState state, MultiplayerRoomUser user)
             => user.Role == MultiplayerRoomUserRole.Referee && state is MultiplayerClientState;
-
-        private async Task endMatch(MultiplayerRoom room, int disbandingUserId)
-        {
-            using (var db = databaseFactory.GetInstance())
-                await db.EndMatchAsync(room);
-
-            await eventDispatcher.PostRoomDisbandedAsync(room.RoomID, disbandingUserId);
-        }
 
         public Task<ItemUsage<ServerMultiplayerRoom>> GetRoom(long roomId)
             => rooms.GetForUse(roomId);

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomLifetimeBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomLifetimeBackgroundService.cs
@@ -49,7 +49,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                         // double-check inside the lock to be safe.
                         if (roomUsage?.Item?.EndDate == null || DateTimeOffset.Now <= roomUsage.Item.EndDate)
                         {
-                            logger.LogDebug("Skipping attempt to destroy usage of room ID:{RoomId} due as its end date has changed to {EndDate}", roomId, roomUsage.Item?.EndDate);
+                            logger.LogDebug("Skipping attempt to destroy usage of room ID:{RoomId} due as its end date has changed to {EndDate}", roomId, roomUsage?.Item?.EndDate);
                             continue;
                         }
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomLifetimeBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomLifetimeBackgroundService.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using osu.Server.Spectator.Entities;
+using osu.Server.Spectator.Hubs.Referee;
+
+namespace osu.Server.Spectator.Hubs.Multiplayer
+{
+    public class MultiplayerRoomLifetimeBackgroundService : BackgroundService
+    {
+        private readonly EntityStore<ServerMultiplayerRoom> rooms;
+        private readonly EntityStore<RefereeClientState> referees;
+        private readonly ILogger<MultiplayerRoomLifetimeBackgroundService> logger;
+
+        public MultiplayerRoomLifetimeBackgroundService(
+            EntityStore<ServerMultiplayerRoom> rooms,
+            EntityStore<RefereeClientState> referees,
+            ILoggerFactory loggerFactory)
+        {
+            this.rooms = rooms;
+            this.referees = referees;
+            logger = loggerFactory.CreateLogger<MultiplayerRoomLifetimeBackgroundService>();
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                logger.LogDebug("Running clean-up of rooms with set end dates.");
+
+                long[] endedRoomIds = rooms.GetAllEntities()
+                                           .Where(kv => kv.Value.EndDate != null && DateTimeOffset.Now > kv.Value.EndDate)
+                                           .Select(kv => kv.Key)
+                                           .ToArray();
+                var actualCleanedUpRoomIds = new HashSet<long>();
+
+                foreach (long roomId in endedRoomIds)
+                {
+                    using (var roomUsage = await rooms.TryGetForUse(roomId))
+                    {
+                        // since `GetAllEntities()` above, someone else could have touched the room and caused the end date to change again.
+                        // double-check inside the lock to be safe.
+                        if (roomUsage?.Item?.EndDate == null || DateTimeOffset.Now <= roomUsage.Item.EndDate)
+                        {
+                            logger.LogDebug("Skipping attempt to destroy usage of room ID:{RoomId} due as its end date has changed to {EndDate}", roomId, roomUsage.Item?.EndDate);
+                            continue;
+                        }
+
+                        await roomUsage.Item.Disband(disbandingUserId: null);
+
+                        logger.LogDebug("Destroying usage of room ID:{RoomId} as its end date of {EndDate} has passed", roomId, roomUsage.Item.EndDate);
+                        roomUsage.Destroy();
+                        actualCleanedUpRoomIds.Add(roomId);
+                    }
+                }
+
+                long[] allRefereeIds = referees.GetAllEntities().Select(kv => kv.Key).ToArray();
+
+                foreach (long refereeId in allRefereeIds)
+                {
+                    using (var refereeUsage = await referees.TryGetForUse(refereeId))
+                    {
+                        if (refereeUsage?.Item is RefereeClientState refereeClientState)
+                            refereeClientState.DisassociateFromRooms(actualCleanedUpRoomIds);
+                    }
+                }
+
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+    }
+}

--- a/osu.Server.Spectator/Hubs/Multiplayer/ServerMultiplayerRoom.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/ServerMultiplayerRoom.cs
@@ -38,6 +38,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         public IReadOnlySet<int> BannedUsers => bannedUsers;
         private readonly HashSet<int> bannedUsers = [];
 
+        public bool TournamentMode { get; private set; }
+        public DateTimeOffset? EndDate { get; private set; }
+
         private ServerMultiplayerRoom(
             long roomId,
             IMultiplayerRoomController roomController,
@@ -102,10 +105,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 foreach (var item in await db.GetAllPlaylistItemsAsync(roomId))
                     room.Playlist.Add(item.ToMultiplayerPlaylistItem());
 
+                room.TournamentMode = databaseRoom.tournament_mode;
+
                 await room.ChangeMatchType(room.Settings.MatchType);
 
                 room.Log("Marking room active");
-                await db.MarkRoomActiveAsync(room);
+                await room.setEndDateAsync(db, null);
             }
 
             return room;
@@ -165,6 +170,26 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
         #endregion
 
         #region Room state management
+
+        public async Task SetEndDateAsync(DateTimeOffset? endDate)
+        {
+            using (var db = dbFactory.GetInstance())
+                await setEndDateAsync(db, endDate);
+        }
+
+        private async Task setEndDateAsync(IDatabaseAccess db, DateTimeOffset? endDate)
+        {
+            await db.SetRoomEndDateAsync(this, endDate);
+            EndDate = endDate;
+        }
+
+        public async Task Disband(int? disbandingUserId)
+        {
+            using (var db = dbFactory.GetInstance())
+                await db.EndMatchAsync(this);
+
+            await eventDispatcher.PostRoomDisbandedAsync(RoomID, disbandingUserId);
+        }
 
         private async Task changeRoomState(MultiplayerRoomState newState)
         {
@@ -1242,7 +1267,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 
         #endregion
 
-        public async Task<bool> UserCanJoin(int userId) => !bannedUsers.Contains(userId) && await MatchController.UserCanJoin(userId);
+        public async Task<bool> UserCanJoin(int userId)
+        {
+            if (bannedUsers.Contains(userId))
+                return false;
+
+            if (EndDate != null && DateTimeOffset.Now >= EndDate)
+                return false;
+
+            return await MatchController.UserCanJoin(userId);
+        }
 
         #region IMatchController encapsulation
 

--- a/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
+++ b/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
@@ -87,6 +87,11 @@ namespace osu.Server.Spectator.Hubs.Referee
         Task RemoveReferee(long roomId, int targetUserId);
 
         /// <summary>
+        /// Lists all rooms that the caller is a referee in.
+        /// </summary>
+        Task<ListRoomsResponse> ListRooms();
+
+        /// <summary>
         /// Changes the settings of the room with the given <paramref name="roomId"/>.
         /// Encompasses the <c>!mp name</c>, <c>!mp password</c>, and <c>!mp set</c> commands on bancho.
         /// </summary>

--- a/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
+++ b/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
@@ -75,13 +75,14 @@ namespace osu.Server.Spectator.Hubs.Referee
         /// <summary>
         /// Adds the user with the given <paramref name="targetUserId"/> as a referee of the room with the given <paramref name="roomId"/>.
         /// The user has to call <see cref="JoinRoom"/> to start performing referee actions.
+        /// Only the room host can call this method, and they cannot call it on themselves.
         /// </summary>
         Task AddReferee(long roomId, int targetUserId);
 
         /// <summary>
         /// Removes the user with the given <paramref name="targetUserId"/> from the set of referees of the room with the given <paramref name="roomId"/>.
         /// If the user was joined to the room at the time of this call, they will be kicked from the room.
-        /// A user cannot call this method on themselves; for that purpose <see cref="LeaveRoom"/> should be used instead.
+        /// Only the room host can call this method, and they cannot call it on themselves.
         /// </summary>
         Task RemoveReferee(long roomId, int targetUserId);
 

--- a/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
+++ b/osu.Server.Spectator/Hubs/Referee/IRefereeHubServer.cs
@@ -48,13 +48,6 @@ namespace osu.Server.Spectator.Hubs.Referee
         Task<RoomJoinedResponse> JoinRoom(long roomId);
 
         /// <summary>
-        /// Leaves the multiplayer room with the given <paramref name="roomId"/>.
-        /// This operation removes the caller's referee privileges;
-        /// they will not be able to <see cref="JoinRoom"/> again unless granted referee privileges again by another referee in the room.
-        /// </summary>
-        Task LeaveRoom(long roomId);
-
-        /// <summary>
         /// Closes the room with the given <paramref name="roomId"/>.
         /// Corresponds to the <c>!mp close</c> command on bancho.
         /// </summary>

--- a/osu.Server.Spectator/Hubs/Referee/Models/Responses/ListRoomsResponse.cs
+++ b/osu.Server.Spectator/Hubs/Referee/Models/Responses/ListRoomsResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace osu.Server.Spectator.Hubs.Referee.Models.Responses
+{
+    /// <summary>
+    /// Contains the list of all rooms that the caller is a referee in.
+    /// </summary>
+    public class ListRoomsResponse
+    {
+        /// <summary>
+        /// The list of IDs of rooms in which the caller is a referee.
+        /// </summary>
+        [JsonPropertyName("room_ids")]
+        public IEnumerable<long> RoomIDs { get; set; } = [];
+    }
+}

--- a/osu.Server.Spectator/Hubs/Referee/RefereeClientState.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeClientState.cs
@@ -36,6 +36,22 @@ namespace osu.Server.Spectator.Hubs.Referee
         public void DisassociateFromRoom(long roomId)
             => refereedRoomIds.Remove(roomId);
 
+        public void DisassociateFromRooms(IEnumerable<long> roomIds)
+            => refereedRoomIds.ExceptWith(roomIds);
+
+        public void HandleRoomJoined(long roomId)
+            => AssociateWithRoom(roomId);
+
+        public void HandleRoomLeft(long roomId)
+        {
+            // intentionally a no-op.
+            // a referee leaving a room intentionally has no real consequences.
+            // the expectation is that it should NOT disassociate the referee from the room since they may want to return later for whatever reason.
+            // the only way in which a referee CAN be disassociated from the room are as follows:
+            // - getting removed as referee by another referee,
+            // - closing the room entirely.
+        }
+
         public Task SubscribeToEvents(MultiplayerEventDispatcher eventDispatcher, long roomId)
             => eventDispatcher.SubscribeRefereeAsync(roomId, ConnectionId);
 

--- a/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
@@ -151,26 +151,6 @@ namespace osu.Server.Spectator.Hubs.Referee
             }
         }
 
-        public async Task LeaveRoom(long roomId)
-        {
-            using (var userUsage = await refereeStates.GetForUse(Context.GetUserId()))
-            {
-                Debug.Assert(userUsage.Item != null);
-
-                ensureIsReferee(roomId, userUsage);
-
-                using (var roomUsage = await roomController.GetRoom(roomId))
-                {
-                    Debug.Assert(roomUsage.Item != null);
-
-                    await tryKickRefereeFromMultiplayerHub(roomUsage, userUsage.Item.UserId, userUsage.Item.UserId);
-                    await kickRefereeFromRefereeHub(roomUsage, userUsage, userUsage.Item.UserId);
-
-                    await eventDispatcher.PostRefereeRemovedAsync(roomId, userUsage.Item.UserId);
-                }
-            }
-        }
-
         public async Task CloseRoom(long roomId)
         {
             using (var closingUserUsage = await refereeStates.GetForUse(Context.GetUserId()))

--- a/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
@@ -277,8 +277,6 @@ namespace osu.Server.Spectator.Hubs.Referee
             {
                 Debug.Assert(userUsage.Item != null);
 
-                ensureIsReferee(roomId, userUsage);
-
                 using (var roomUsage = await roomController.GetRoom(roomId))
                 {
                     if (roomUsage.Item == null)
@@ -286,6 +284,11 @@ namespace osu.Server.Spectator.Hubs.Referee
 
                     if (targetUserId == userUsage.Item.UserId)
                         ThrowHelper.ThrowCannotPerformOperationOnSelf();
+
+                    // referee addition is unique in that it can only be performed by the room host
+                    // this mirrors bancho
+                    if (userUsage.Item.UserId != roomUsage.Item.Host?.UserID)
+                        ThrowHelper.ThrowUserNotHost();
 
                     if (roomUsage.Item.BannedUsers.Contains(targetUserId))
                         ThrowHelper.ThrowUserBanned();
@@ -313,12 +316,15 @@ namespace osu.Server.Spectator.Hubs.Referee
             {
                 Debug.Assert(userUsage.Item != null);
 
-                ensureIsReferee(roomId, userUsage);
-
                 using (var roomUsage = await roomController.GetRoom(roomId))
                 {
                     if (roomUsage.Item == null)
                         ThrowHelper.ThrowRoomDoesNotExist();
+
+                    // referee removal is unique in that it can only be performed by the room host
+                    // this mirrors bancho
+                    if (userUsage.Item.UserId != roomUsage.Item.Host?.UserID)
+                        ThrowHelper.ThrowUserNotHost();
 
                     if (targetUserId == userUsage.Item.UserId)
                         ThrowHelper.ThrowCannotPerformOperationOnSelf();

--- a/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
@@ -215,7 +215,8 @@ namespace osu.Server.Spectator.Hubs.Referee
                         }
                     }
 
-                    await roomController.LeaveRoom(closingUserUsage.Item, roomUsage);
+                    await roomController.LeaveRoom(closingUserUsage.Item, roomUsage, forceCloseOnEmpty: true);
+                    closingUserUsage.Item.DisassociateFromRoom(roomId);
                 }
             }
         }
@@ -402,11 +403,9 @@ namespace osu.Server.Spectator.Hubs.Referee
                 // user is joined to the room. proceed with a full kick to flush them out.
                 await roomController.KickUserFromRoom(refereeUsage.Item, roomUsage, kickingUserId);
             }
-            else
-            {
-                // user has not joined the room yet or is temporarily disconnected. disassociate them from room so they can't join again.
-                refereeUsage.Item.DisassociateFromRoom(roomUsage.Item.RoomID);
-            }
+
+            // finally, disassociate the referee from the room so they can't join or perform referee actions again.
+            refereeUsage.Item.DisassociateFromRoom(roomUsage.Item.RoomID);
         }
 
         public async Task ChangeRoomSettings(long roomId, ChangeRoomSettingsRequest request)
@@ -779,23 +778,9 @@ namespace osu.Server.Spectator.Hubs.Referee
                     return;
                 }
 
-                if (exception != null)
-                {
-                    // if the disconnection isn't clean (due to a networking issue or similar), keep the user's set of refereed rooms intact
-                    // so that they remain referees on all rooms when they reconnect.
-                    // obviously, this is memory state, which is not preserved anywhere else, so it will drop out on server restart.
-                    // additionally, we still unsubscribe the connection from events,
-                    // primarily because only one connection per user ID is supported as written, so the user will need to re-subscribe with a new connection ID when they rejoin anyway.
-                    foreach (long roomId in userUsage.Item.RefereedRoomIds)
-                        await userUsage.Item.UnsubscribeFromEvents(eventDispatcher, roomId);
-
-                    await base.OnDisconnectedAsync(exception);
-                    return;
-                }
-
-                // if the disconnection is clean, it is treated as if the referee wishes to cease being a referee on all their rooms.
-                // in line, perform a full leave.
-                // this will remove the user from the set of referees on all their refereed rooms. the user will not get the referee status back on rejoin.
+                // perform a full leave of all joined rooms.
+                // this will NOT remove the user from the set of referees on all their refereed rooms; they will be permitted to rejoin.
+                // additionally, purposefully leave the user state intact so the referee-room associations are not dropped.
                 foreach (long roomId in userUsage.Item.RefereedRoomIds.ToArray())
                 {
                     using (var roomUsage = await roomController.GetRoom(roomId))
@@ -806,8 +791,6 @@ namespace osu.Server.Spectator.Hubs.Referee
 
                     await eventDispatcher.PostRefereeRemovedAsync(roomId, userUsage.Item.UserId);
                 }
-
-                userUsage.Destroy();
             }
 
             await base.OnDisconnectedAsync(exception);

--- a/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
@@ -394,6 +394,19 @@ namespace osu.Server.Spectator.Hubs.Referee
             refereeUsage.Item.DisassociateFromRoom(roomUsage.Item.RoomID);
         }
 
+        public async Task<ListRoomsResponse> ListRooms()
+        {
+            using (var userUsage = await refereeStates.GetForUse(Context.GetUserId()))
+            {
+                Debug.Assert(userUsage.Item != null);
+
+                return new ListRoomsResponse
+                {
+                    RoomIDs = userUsage.Item.RefereedRoomIds.ToArray()
+                };
+            }
+        }
+
         public async Task ChangeRoomSettings(long roomId, ChangeRoomSettingsRequest request)
         {
             using (var userUsage = await refereeStates.GetForUse(Context.GetUserId()))

--- a/osu.Server.Spectator/Hubs/Referee/ThrowHelper.cs
+++ b/osu.Server.Spectator/Hubs/Referee/ThrowHelper.cs
@@ -126,6 +126,13 @@ namespace osu.Server.Spectator.Hubs.Referee
         /// </summary>
         [DoesNotReturn]
         public static void ThrowInvalidRoll()
-            => throw new RefereeHubException(19, "Invalid roll. Max must be in [1, 100] range inclusive.");
+            => throw new RefereeHubException(17, "Invalid roll. Max must be in [1, 100] range inclusive.");
+
+        /// <summary>
+        /// Error 18: You are not the host of the room.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowUserNotHost()
+            => throw new RefereeHubException(18, "You are not the host of the room.");
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu-server-spectator/issues/460

## [Add support for delayed closing of tournament mode multiplayer rooms](https://github.com/ppy/osu-server-spectator/commit/09898c7f2641cd3ad854c8f4e74bc22a74dcdc46)

The way this works is:

1. When the last user leaves a tournament mode room, the room controller will set an end date for the room in the database to 30 minutes in the future. This is persisted to the database, which makes the rooms disappear on their own in the client-side room listing because that's handled by osu-web which will respect the new end date.
2. If any user joins the room before its end date elapses, the end date is cleared to `null` again.
3. If point (2) never occurs before the end date elapses, `ServerMultiplayerRoom.CanJoinRoom()` now checks the end date, which ensures that after that date passes, no user can join the room anymore.
4. A new job, `MultiplayerRoomLifetimeBackgroundService`, is called into existence. Every minute, it looks for tournament rooms with end dates in the past. If it finds any, it destroys their server-side memory state, and also dissociates any referees from said rooms to complete the cleanup.

Of particular note, this took some non-minor reshuffling of how referee user state is managed because of the expectations here.

- Referees join refereeing rights:
  - On creation and subsequent joining of a tournament room.
  - On being added as a referee by another tournament room's host.
- Referees lose refereeing rights:
  - On being removed as a referee by the tournament room's host.
  - On the room being force-closed by themselves or another referee.
  - On the room being cleaned up by the background job.

The above lists are exhaustive, e.g. those are the *only* conditions that cause granting / losing referee rights. No other interaction causes either.

Obviously, the referee privileges are still server-side memory state and will get lost on a redeploy / restart.

Additionally note that the referee hub does not provide a host change operation and I'm kind of fine with that until someone really needs it for whatever reason - adding it *is* possible, but would require further safeties in terms of per-user open room quotas and similar that I'd rather not get into if I don't need to.

## [Remove `LeaveRoom()` referee hub operation](https://github.com/ppy/osu-server-spectator/commit/36bf482955c7cf7cc723f179798214931537c844)

Now that it doesn't shed referee permissions, it's kind of no real use anymore. It was being very awkward in terms of behaviours given the revised concept of referee permission management so I just removed it.

## [Require being room host for adding / removing referees](https://github.com/ppy/osu-server-spectator/commit/2acf6a659d56002c0eb43cfaabe6f4d30f8aced9)

This is partly to match bancho, partly to reduce undesirable scenarios that could cause weird breakage. For instance, imagine this sequence of steps:

1. User A creates room
2. User A adds user B as referee
3. User B removes user A as referee from room

Now A is in a sticky state as the room is chalked up to them, goes on their open tournament room quota, but they're locked out of it (they can't join the room, as removal of a referee revokes rights). So just disallow this to begin with. With this change only A can add or remove referees.

## [Add primitive for listing all refereed rooms](https://github.com/ppy/osu-server-spectator/commit/ce4d87e5e63c3130eb5cc0dc0f3d70dc33056f83)

Provided for convenience / information as to which rooms can be recovered on a reconnection.

---

@ilw8 @ThePooN would appreciate if you read through the above description of the changes and see if there's anything you'd find objectionable.