### PR TITLE
Ranked Play: Fix late-arriving scores not being considered

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
@@ -53,6 +54,13 @@ namespace osu.Server.Spectator.Tests.RankedPlay
                         user_id = (uint)userId,
                         pool_id = poolId
                     }));
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1_000_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 1_000_000 },
+                    ]));
         }
 
         public async Task InitializeAsync()

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moq;
@@ -45,6 +46,48 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
+            });
+        }
+
+        [Fact]
+        public async Task DamageTakenWithLateArrivingScore()
+        {
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 }
+                    ]));
+
+            Task enterTask = MatchController.Stage.Enter();
+
+            await Task.Delay(1000);
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
+                    ]));
+
+            await enterTask;
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(750_000, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 250_000,
+                Damage = 250_000,
+                OldLife = 1_000_000,
+                NewLife = 750_000,
             });
         }
 

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests.RankedPlay.Stages
@@ -21,6 +22,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task DamageTakenWithMissingScore()
         {
+            ((ResultsStage)MatchController.Stage).ScoreRetrievalWaitTime = TimeSpan.FromSeconds(1);
+
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
@@ -13,6 +14,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 {
     public class ResultsStage : RankedPlayStageImplementation
     {
+        /// <summary>
+        /// Amount of time to wait for scores to arrive in the database before continuing.
+        /// </summary>
+        public TimeSpan ScoreRetrievalWaitTime { get; set; } = TimeSpan.FromSeconds(10);
+
         public ResultsStage(RankedPlayMatchController controller)
             : base(controller)
         {
@@ -25,8 +31,27 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         {
             // Collect all scores from the database.
             List<SoloScore> scores = [];
+
             using (var db = DbFactory.GetInstance())
-                scores.AddRange(await db.GetAllScoresForPlaylistItem(Room.Settings.PlaylistItemId));
+            {
+                // Wait up to 10 seconds to retrieve scores for all players, before continuing and giving them 0 score.
+                using (var cts = new CancellationTokenSource(ScoreRetrievalWaitTime))
+                {
+                    SoloScore[] retrievedScores = [];
+
+                    while (!cts.IsCancellationRequested)
+                    {
+                        retrievedScores = (await db.GetAllScoresForPlaylistItem(Room.Settings.PlaylistItemId)).ToArray();
+
+                        if (retrievedScores.Length == State.Users.Count)
+                            break;
+
+                        await Task.Delay(1000, CancellationToken.None);
+                    }
+
+                    scores.AddRange(retrievedScores);
+                }
+            }
 
             // Add dummy scores for all users that did not play the map.
             foreach ((int userId, _) in State.Users)


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/37296

Waits up to 10 seconds for scores to arrive at osu!web/in the database (can be reduced upon request).

Don't know of a better way to do this...