### PR TITLE
Fix ranked play matches getting stuck if players fail to load beatmaps

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
@@ -24,16 +24,6 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task DoesNotContinueToGameplayWarmupWithoutBeatmapAvailable()
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                await FinishCountdown();
-                Assert.Equal(RankedPlayStage.FinishCardPlay, RoomState.Stage);
-            }
-        }
-
-        [Fact]
         public async Task ContinuesToGameplayWarmupWhenAllPlayersReady()
         {
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
@@ -51,6 +41,41 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
 
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
             Assert.Equal(0, UserState.Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToNextRoundWhenAnyPlayerFailsToBecomeReady()
+        {
+            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
+            Assert.Equal(RankedPlayStage.FinishCardPlay, RoomState.Stage);
+
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToNextRoundWhenAllPlayersFailToBecomeReady()
+        {
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
+        {
+            RoomState.Users[USER_ID].Life = 50_000;
+
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
+
+            Assert.Equal(0, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
@@ -3,9 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
-using osu.Game.Online.Rooms;
 using Xunit;
 
 namespace osu.Server.Spectator.Tests.RankedPlay.Stages
@@ -22,33 +20,6 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             await base.SetupForEnter();
 
             await MatchController.ActivateCard(UserState.Hand.First());
-        }
-
-        [Fact]
-        public async Task DoesNotContinueToGameplayWithoutReady()
-        {
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
-            SetUserContext(ContextUser2);
-            await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
-            SetUserContext(ContextUser);
-
-            for (int i = 0; i < 5; i++)
-            {
-                await FinishCountdown();
-                Assert.Equal(RankedPlayStage.GameplayWarmup, RoomState.Stage);
-            }
-        }
-
-        [Fact]
-        public async Task DoesNotContinueToGameplayWithoutBeatmapAvailable()
-        {
-            await Hub.ChangeState(MultiplayerUserState.Ready);
-            SetUserContext(ContextUser2);
-            await Hub.ChangeState(MultiplayerUserState.Ready);
-            SetUserContext(ContextUser);
-
-            await FinishCountdown();
-            Assert.Equal(RankedPlayStage.GameplayWarmup, RoomState.Stage);
         }
 
         [Fact]
@@ -72,6 +43,41 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
 
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
             Assert.Equal(0, UserState.Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToNextRoundWhenAnyPlayerFailsToBecomeReady()
+        {
+            await MarkCurrentUserReadyAndAvailable();
+            Assert.Equal(RankedPlayStage.GameplayWarmup, RoomState.Stage);
+
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToNextRoundWhenAllPlayersFailToBecomeReady()
+        {
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+        }
+
+        [Fact]
+        public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
+        {
+            RoomState.Users[USER_ID].Life = 50_000;
+
+            await FinishCountdown();
+            Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
+
+            Assert.Equal(0, RoomState.Users[USER_ID].Life);
+            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayStageImplementation.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayStageImplementation.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
@@ -132,6 +133,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         protected async Task CloseMatch()
         {
             await Controller.GotoStage(RankedPlayStage.Ended);
+        }
+
+        /// <summary>
+        /// Whether there are any more gameplay rounds that can be played.
+        /// </summary>
+        protected bool HasGameplayRoundsRemaining()
+        {
+            int countPlayersAlive = State.Users.Count(u => u.Value.Life > 0);
+            int countCardsRemaining = Controller.DeckCount + State.Users.Sum(u => u.Value.Hand.Count);
+            return countPlayersAlive > 1 && countCardsRemaining > 0;
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         }
 
         protected override RankedPlayStage Stage => RankedPlayStage.FinishCardPlay;
-        protected override TimeSpan Duration => TimeSpan.MaxValue;
+        protected override TimeSpan Duration => TimeSpan.FromMinutes(2);
 
         protected override async Task Begin()
         {
@@ -27,7 +27,20 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            await Controller.GotoStage(RankedPlayStage.GameplayWarmup);
+            if (allPlayersReady())
+                await Controller.GotoStage(RankedPlayStage.GameplayWarmup);
+            else
+            {
+                // Subtract 100K HP from every player that failed to load the beatmap in time.
+                // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
+                foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable))
+                    State.Users[player.UserID].Life = Math.Max(0, State.Users[player.UserID].Life - 100_000);
+
+                if (HasGameplayRoundsRemaining())
+                    await Controller.GotoStage(RankedPlayStage.RoundWarmup);
+                else
+                    await Controller.GotoStage(RankedPlayStage.Ended);
+            }
         }
 
         public override async Task HandleUserStateChanged(MultiplayerRoomUser user)
@@ -37,9 +50,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         private async Task continueWhenAllPlayersReady()
         {
-            // Only require players to have the beatmap, but not necessarily have it loaded yet.
-            if (Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable))
+            if (allPlayersReady())
                 await Finish();
         }
+
+        /// <summary>
+        /// Only requires players to have the beatmap, but not necessarily have it loaded yet.
+        /// </summary>
+        private bool allPlayersReady()
+            => Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         }
 
         protected override RankedPlayStage Stage => RankedPlayStage.GameplayWarmup;
-        protected override TimeSpan Duration => TimeSpan.MaxValue;
+        protected override TimeSpan Duration => TimeSpan.FromMinutes(2);
 
         protected override async Task Begin()
         {
@@ -27,7 +27,22 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            await Controller.GotoStage(RankedPlayStage.Gameplay);
+            if (allPlayersReady())
+            {
+                await Controller.GotoStage(RankedPlayStage.Gameplay);
+            }
+            else
+            {
+                // Subtract 100K HP from every player that failed to load the beatmap in time.
+                // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
+                foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable || p.State != MultiplayerUserState.Ready))
+                    State.Users[player.UserID].Life = Math.Max(0, State.Users[player.UserID].Life - 100_000);
+
+                if (HasGameplayRoundsRemaining())
+                    await Controller.GotoStage(RankedPlayStage.RoundWarmup);
+                else
+                    await Controller.GotoStage(RankedPlayStage.Ended);
+            }
         }
 
         public override async Task HandleUserStateChanged(MultiplayerRoomUser user)
@@ -37,9 +52,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         private async Task continueWhenAllPlayersReady()
         {
-            // Require players to be in the ready state, signaling they have finished viewing the beatmap details/etc.
-            if (Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable && u.State == MultiplayerUserState.Ready))
+            if (allPlayersReady())
                 await FinishWithCountdown(TimeSpan.FromSeconds(10));
         }
+
+        /// <summary>
+        /// Requires all players to be in the ready state, signaling they have finished viewing the beatmap details/etc.
+        /// </summary>
+        private bool allPlayersReady()
+            => Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable && u.State == MultiplayerUserState.Ready);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -92,7 +92,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             foreach ((_, RankedPlayUserInfo userInfo) in State.Users)
                 userInfo.DamageInfo = null;
 
-            if (hasGameplayRoundsRemaining())
+            if (HasGameplayRoundsRemaining())
                 await Controller.GotoStage(RankedPlayStage.RoundWarmup);
             else
                 await Controller.GotoStage(RankedPlayStage.Ended);
@@ -101,17 +101,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         public override async Task HandleUserLeft(MultiplayerRoomUser user)
         {
             // Allow players to leave early without incurring a loss if they know gameplay won't continue.
-            if (hasGameplayRoundsRemaining())
+            if (HasGameplayRoundsRemaining())
                 await KillUser(user);
 
             // Remain in the results stage, which will naturally transition to the ended stage once the countdown expires.
-        }
-
-        private bool hasGameplayRoundsRemaining()
-        {
-            int countPlayersAlive = State.Users.Count(u => u.Value.Life > 0);
-            int countCardsRemaining = Controller.DeckCount + State.Users.Sum(u => u.Value.Hand.Count);
-            return countPlayersAlive > 1 && countCardsRemaining > 0;
         }
     }
 }


### PR DESCRIPTION
When the beatmap fails to load for 2 minutes, the player(s) are given a 100K score penalty and the next round is started. No results screen.