### PR TITLE
Always use decks of size 50 in ranked play

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -23,15 +23,12 @@ namespace osu.Server.Spectator.Tests.Matchmaking
                 {
                     id = (uint)i,
                     rating = 1000,
-                }).ToArray())
-            {
-                PoolSize = 50
-            };
+                }).ToArray());
 
-            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
         }
 
@@ -43,15 +40,12 @@ namespace osu.Server.Spectator.Tests.Matchmaking
                 {
                     id = (uint)i,
                     rating = 1500,
-                }).ToArray())
-            {
-                PoolSize = 50
-            };
+                }).ToArray());
 
-            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
         }
 
@@ -63,15 +57,12 @@ namespace osu.Server.Spectator.Tests.Matchmaking
                 {
                     id = (uint)i,
                     rating = 2000,
-                }).ToArray())
-            {
-                PoolSize = 50
-            };
+                }).ToArray());
 
-            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
         }
 
@@ -83,12 +74,9 @@ namespace osu.Server.Spectator.Tests.Matchmaking
                 {
                     id = (uint)i,
                     rating = 1000 + i,
-                }).ToArray())
-            {
-                PoolSize = 50
-            };
+                }).ToArray());
 
-            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             int countEasy = result.Count(b => b.rating < 1500);
             int countHard = result.Count(b => b.rating > 1500);
 
@@ -96,7 +84,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.True((double)countEasy / result.Length >= 0.25);
             Assert.True((double)countHard / result.Length >= 0.25);
 
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps([new EloRating(1500, 80)]);
+            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
         }
 
@@ -109,7 +97,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
                 new matchmaking_pool_beatmap { id = 1, rating = 1000 },
             ]);
 
-            matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps([new EloRating(1000, 350), new EloRating(1000, 350)]);
+            matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps(50, [new EloRating(1000, 350), new EloRating(1000, 350)]);
 
             Assert.Equal(2, result.Length);
             Assert.Single(result, t => t.id == 0);
@@ -134,7 +122,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             }));
 
             MatchmakingBeatmapSelector selector = await MatchmakingBeatmapSelector.Initialise(new matchmaking_pool { ruleset_id = 1 }, dbFactory.Object);
-            matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps([]);
+            matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps(50, []);
 
             Assert.Single(result);
             Assert.Equal(1234, result.Single().beatmap_id);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -130,7 +130,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
 
             using (var db = dbFactory.GetInstance())
             {
-                foreach (var beatmap in beatmapSelector.GetAppropriateBeatmaps(users.Select(u => u.Rating).ToArray()))
+                foreach (var beatmap in beatmapSelector.GetAppropriateBeatmaps(AppSettings.MatchmakingPoolSize, users.Select(u => u.Rating).ToArray()))
                 {
                     MultiplayerPlaylistItem item = beatmap.ToPlaylistItem();
                     item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(room.RoomID, item));

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -12,8 +12,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 {
     public class MatchmakingBeatmapSelector
     {
-        public int PoolSize { get; set; } = AppSettings.MatchmakingPoolSize;
-
         private readonly matchmaking_pool_beatmap[] beatmaps;
 
         public MatchmakingBeatmapSelector(matchmaking_pool_beatmap[] beatmaps)
@@ -59,8 +57,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <summary>
         /// Retrieves a set of playlist items from the pool within an appropriate difficulty range for the lobby.
         /// </summary>
+        /// <param name="count">The number of beatmaps to retrieve.</param>
         /// <param name="ratings">The lobby user ratings.</param>
-        public matchmaking_pool_beatmap[] GetAppropriateBeatmaps(EloRating[] ratings)
+        public matchmaking_pool_beatmap[] GetAppropriateBeatmaps(int count, EloRating[] ratings)
         {
             // Pick from maps around the minimum rating.
             double ratingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
@@ -74,7 +73,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                double weight = Math.Clamp(Math.Exp(-Math.Pow(beatmapRating - ratingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
                                return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
                            })
-                           .Take(PoolSize)
+                           .Take(count)
                            .ToArray();
         }
     }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -21,7 +21,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
     public class RankedPlayMatchController : IMatchController, IMatchmakingMatchController
     {
         public const int PLAYER_HAND_SIZE = 5;
-        public const int DECK_SIZE = PLAYER_HAND_SIZE * 2 + 1;
+        public const int DECK_SIZE = 50;
 
         public MultiplayerPlaylistItem CurrentItem => Room.Playlist.Single(item => item.ID == Room.Settings.PlaylistItemId);
 
@@ -87,7 +87,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             PoolId = poolId;
 
             // Build the deck.
-            matchmaking_pool_beatmap[] beatmaps = beatmapSelector.GetAppropriateBeatmaps(50, users.Select(u => u.Rating).ToArray());
+            matchmaking_pool_beatmap[] beatmaps = beatmapSelector.GetAppropriateBeatmaps(DECK_SIZE, users.Select(u => u.Rating).ToArray());
             Random.Shared.Shuffle(beatmaps);
 
             foreach (var beatmap in beatmaps)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -87,11 +87,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             PoolId = poolId;
 
             // Build the deck.
-            matchmaking_pool_beatmap[] beatmaps = beatmapSelector.GetAppropriateBeatmaps(users.Select(u => u.Rating).ToArray());
-
-            if (beatmaps.Length < DECK_SIZE)
-                throw new InvalidOperationException($"There should be at least {DECK_SIZE} beatmaps, but only {beatmaps.Length} were selected.");
-
+            matchmaking_pool_beatmap[] beatmaps = beatmapSelector.GetAppropriateBeatmaps(50, users.Select(u => u.Rating).ToArray());
             Random.Shared.Shuffle(beatmaps);
 
             foreach (var beatmap in beatmaps)


### PR DESCRIPTION
The environment variable was primarily an optimisation for quick play, which required every playlist item to be stored against the room. Ranked play doesn't suffer from this issue.

However, for ranked play, we also don't want infinitely-sized decks because that would reduce map selection to RNGing over the entire map pool, so we still want _some_ limit. 50 is probably a good middle ground here, given that this is a shared deck.

I expect the live environment value of `MATCHMAKING_POOL_SIZE` to be less than 50, causing both players to not receive additional cards and too narrow a map pool.