### PR TITLE
Reduce results stage duration

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         }
 
         protected override RankedPlayStage Stage => RankedPlayStage.Results;
-        protected override TimeSpan Duration => TimeSpan.FromSeconds(20);
+        protected override TimeSpan Duration => TimeSpan.FromSeconds(15);
 
         protected override async Task Begin()
         {


### PR DESCRIPTION
One complaint (e.g. [reddit](https://www.reddit.com/r/osugame/comments/1sr1trx/constructive_feedback_on_ranked_play_match_format/), [forums](https://osu.ppy.sh/community/forums/topics/2198397?n=118), Koifishu) I'm hearing is that the results screen takes too long. Its animations should be done within around 5 seconds, so 10 seconds total duration may be appropriate here.