### PR TITLE
Fix rating update being delayed slightly

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/EndedStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/EndedStageTests.cs
@@ -36,7 +36,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task WinnerIsUserWithMaxLife()
         {
+            MatchController.UserRatingsUpdated = false;
             User2State.Life = 500_000;
+
             await MatchController.Stage.Enter();
 
             Assert.Equal(USER_ID, RoomState.WinningUserId);
@@ -70,6 +72,12 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
 
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
             Assert.Equal(1_000_000, UserState.Life);
+        }
+
+        [Fact]
+        public void UserRatingUpdatedImmediately()
+        {
+            Assert.True(MatchController.UserRatingsUpdated);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayStageTests.cs
@@ -69,5 +69,14 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(RankedPlayStage.Gameplay, RoomState.Stage);
             Assert.Equal(0, UserState.Life);
         }
+
+        [Fact]
+        public async Task UserRatingUpdatedImmediatelyOnPlayerLeave()
+        {
+            await Hub.LeaveRoom();
+
+            Assert.Equal(RankedPlayStage.Gameplay, RoomState.Stage);
+            Assert.True(MatchController.UserRatingsUpdated);
+        }
     }
 }

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayStageTests.cs
@@ -62,12 +62,15 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task ContinuesToEndedWhenAnyPlayerLeaves()
+        public async Task ContinuesToResultsWhenAnyPlayerLeaves()
         {
             await Hub.LeaveRoom();
 
             Assert.Equal(RankedPlayStage.Gameplay, RoomState.Stage);
             Assert.Equal(0, UserState.Life);
+
+            await LoadAndFinishGameplay(ContextUser2);
+            Assert.Equal(RankedPlayStage.Results, RoomState.Stage);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -199,5 +199,29 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(RankedPlayStage.Results, RoomState.Stage);
             Assert.Equal(0, UserState.Life);
         }
+
+        [Fact]
+        public void UserRatingNotUpdatedWithRoundsRemaining()
+        {
+            Assert.False(MatchController.UserRatingsUpdated);
+        }
+
+        [Fact]
+        public async Task UserRatingUpdatedImmediatelyInFinalRound()
+        {
+            UserState.Life = 0;
+            await MatchController.Stage.Enter();
+
+            Assert.True(MatchController.UserRatingsUpdated);
+        }
+
+        [Fact]
+        public async Task UserRatingUpdatedImmediatelyOnPlayerLeave()
+        {
+            await Hub.LeaveRoom();
+
+            Assert.Equal(RankedPlayStage.Results, RoomState.Stage);
+            Assert.True(MatchController.UserRatingsUpdated);
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using OpenSkillSharp.Models;
+using OpenSkillSharp.Rating;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
@@ -66,6 +68,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// </summary>
         private readonly List<RankedPlayCardItem> deck = [];
 
+        /// <summary>
+        /// Indicates whether the final user ratings have been updated.
+        /// Todo: This is public for testing purposes, but should not be.
+        /// </summary>
+        public bool UserRatingsUpdated { get; set; }
+
         public RankedPlayMatchController(ServerMultiplayerRoom room, IDatabaseFactory dbFactory, MultiplayerEventDispatcher eventDispatcher)
         {
             Room = room;
@@ -118,7 +126,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                 RatingByUser[user.UserId] = user.Rating;
                 State.Users[user.UserId] = new RankedPlayUserInfo
                 {
-                    Rating = (int)Math.Round(user.Rating.Mu)
+                    Rating = (int)Math.Round(user.Rating.Mu),
+                    RatingAfter = (int)Math.Round(user.Rating.Mu)
                 };
             }
 
@@ -316,6 +325,89 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             await Room.HandleSettingsChanged(true);
 
             LastActivatedCard = card;
+        }
+
+        public async Task HandleMatchCompleted()
+        {
+            if (UserRatingsUpdated)
+                return;
+
+            UserRatingsUpdated = true;
+
+            // Forego any rating calculations if the match hasn't started yet.
+            // Naturally, this also means we don't have a winner to crown.
+            if (State.CurrentRound == 0)
+            {
+                await MatchmakingService.RecordMatch((int)PoolId, State);
+                return;
+            }
+
+            int maxLife = State.Users.Max(u => u.Value.Life);
+            int[] winningUsers = State.Users.Where(u => u.Value.Life == maxLife).Select(u => u.Key).ToArray();
+            if (winningUsers.Length == 1)
+                State.WinningUserId = winningUsers.Single();
+
+            using (var db = DbFactory.GetInstance())
+            {
+                PlackettLuce model = new PlackettLuce
+                {
+                    Mu = 1500,
+                    Sigma = 150,
+                    Beta = 75,
+                    Tau = 1.5
+                };
+
+                List<matchmaking_user_stats> stats = [];
+                List<ITeam> teams = [];
+                List<double> scores = [];
+
+                foreach ((int userId, RankedPlayUserInfo user) in State.Users)
+                {
+                    matchmaking_user_stats userStats = await db.GetMatchmakingUserStatsAsync(userId, PoolId) ?? new matchmaking_user_stats
+                    {
+                        user_id = (uint)userId,
+                        pool_id = PoolId
+                    };
+
+                    stats.Add(userStats);
+                    teams.Add(new Team { Players = [model.Rating(userStats.EloData.Rating.Mu, userStats.EloData.Rating.Sig)] });
+                    scores.Add(user.Life);
+                }
+
+                IRating[] newRatings = model.Rate(teams, scores: scores).Select(t => t.Players.Single()).ToArray();
+
+                for (int i = 0; i < stats.Count; i++)
+                {
+                    matchmaking_room_result result;
+
+                    if (State.WinningUserId == null)
+                        result = matchmaking_room_result.draw;
+                    else if (State.WinningUserId == stats[i].user_id)
+                    {
+                        stats[i].first_placements++;
+                        result = matchmaking_room_result.win;
+                    }
+                    else
+                        result = matchmaking_room_result.loss;
+
+                    await db.InsertUserEloHistoryEntry(
+                        (ulong)Room.RoomID,
+                        PoolId,
+                        stats[i].user_id,
+                        stats.First(u => u.user_id != stats[i].user_id).user_id,
+                        result,
+                        (int)Math.Round(stats[i].EloData.Rating.Mu),
+                        (int)Math.Round(newRatings[i].Mu));
+
+                    stats[i].EloData.ContestCount++;
+                    stats[i].EloData.Rating = new EloRating(newRatings[i].Mu, newRatings[i].Sigma);
+                    await db.UpdateMatchmakingUserStatsAsync(stats[i]);
+
+                    State.Users[(int)stats[i].user_id].RatingAfter = (int)Math.Round(newRatings[i].Mu);
+                }
+            }
+
+            await MatchmakingService.RecordMatch((int)PoolId, State);
         }
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayStageImplementation.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayStageImplementation.cs
@@ -125,6 +125,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         {
             State.Users[user.UserID].Life = 0;
             await EventDispatcher.PostMatchRoomStateChangedAsync(Room);
+
+            if (!HasGameplayRoundsRemaining())
+                await Controller.HandleMatchCompleted();
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
@@ -2,15 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using OpenSkillSharp.Models;
-using OpenSkillSharp.Rating;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
-using osu.Server.Spectator.Database.Models;
-using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 {
@@ -26,83 +20,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Begin()
         {
-            foreach ((_, RankedPlayUserInfo user) in State.Users)
-                user.RatingAfter = user.Rating;
-
-            // Forego any rating calculations if the match hasn't started yet.
-            // Naturally, this also means we don't have a winner to crown.
-            if (State.CurrentRound == 0)
-            {
-                await Controller.MatchmakingService.RecordMatch((int)Controller.PoolId, State);
-                return;
-            }
-
-            int maxLife = State.Users.Max(u => u.Value.Life);
-            int[] winningUsers = State.Users.Where(u => u.Value.Life == maxLife).Select(u => u.Key).ToArray();
-            if (winningUsers.Length == 1)
-                State.WinningUserId = winningUsers.Single();
-
-            using (var db = DbFactory.GetInstance())
-            {
-                PlackettLuce model = new PlackettLuce
-                {
-                    Mu = 1500,
-                    Sigma = 150,
-                    Beta = 75,
-                    Tau = 1.5
-                };
-
-                List<matchmaking_user_stats> stats = [];
-                List<ITeam> teams = [];
-                List<double> scores = [];
-
-                foreach ((int userId, RankedPlayUserInfo user) in State.Users)
-                {
-                    matchmaking_user_stats userStats = await db.GetMatchmakingUserStatsAsync(userId, Controller.PoolId) ?? new matchmaking_user_stats
-                    {
-                        user_id = (uint)userId,
-                        pool_id = Controller.PoolId
-                    };
-
-                    stats.Add(userStats);
-                    teams.Add(new Team { Players = [model.Rating(userStats.EloData.Rating.Mu, userStats.EloData.Rating.Sig)] });
-                    scores.Add(user.Life);
-                }
-
-                IRating[] newRatings = model.Rate(teams, scores: scores).Select(t => t.Players.Single()).ToArray();
-
-                for (int i = 0; i < stats.Count; i++)
-                {
-                    matchmaking_room_result result;
-
-                    if (State.WinningUserId == null)
-                        result = matchmaking_room_result.draw;
-                    else if (State.WinningUserId == stats[i].user_id)
-                    {
-                        stats[i].first_placements++;
-                        result = matchmaking_room_result.win;
-                    }
-                    else
-                        result = matchmaking_room_result.loss;
-
-                    await db.InsertUserEloHistoryEntry(
-                        (ulong)Room.RoomID,
-                        Controller.PoolId,
-                        stats[i].user_id,
-                        stats.First(u => u.user_id != stats[i].user_id).user_id,
-                        result,
-                        (int)Math.Round(stats[i].EloData.Rating.Mu),
-                        (int)Math.Round(newRatings[i].Mu));
-
-                    stats[i].EloData.ContestCount++;
-                    stats[i].EloData.Rating = new EloRating(newRatings[i].Mu, newRatings[i].Sigma);
-                    await db.UpdateMatchmakingUserStatsAsync(stats[i]);
-
-                    State.Users[(int)stats[i].user_id].RatingAfter = (int)Math.Round(newRatings[i].Mu);
-                }
-            }
-
-            await Controller.MatchmakingService.RecordMatch((int)Controller.PoolId, State);
+            await Controller.HandleMatchCompleted();
         }
 
         protected override Task Finish()

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -92,6 +92,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 Room.CurrentPlaylistItem.RequiredMods.ToArray(),
                 scores.Select(s => (int)s.total_score).ToArray(),
                 scores.Select(s => Controller.RatingByUser[(int)s.user_id]).ToArray());
+
+            if (!HasGameplayRoundsRemaining())
+                await Controller.HandleMatchCompleted();
         }
 
         protected override async Task Finish()


### PR DESCRIPTION
Here's two common cases where rating wouldn't be updated immediately. In both of these, it would wait until a delayed transition to the ended stage:
- If a player leaves during gameplay.
- If a player leaves during the results stage, even if in the final round.

The resulting effect is that the player would receive the wrong rating if they re-queued immediately. No data has been lost and live ratings are still accurate.