### PR TITLE
Implement beatmap rating adjustments

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -21,15 +21,15 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
-                    id = (uint)i,
+                    beatmap_id = i,
                     rating = 1000,
-                }).ToArray());
+                }).ToArray(), new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
             matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
+            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -38,15 +38,15 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
-                    id = (uint)i,
+                    beatmap_id = i,
                     rating = 1500,
-                }).ToArray());
+                }).ToArray(), new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
             matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
+            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -55,15 +55,15 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
-                    id = (uint)i,
+                    beatmap_id = i,
                     rating = 2000,
-                }).ToArray());
+                }).ToArray(), new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
 
             matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
+            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -72,9 +72,9 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
-                    id = (uint)i,
+                    beatmap_id = i,
                     rating = 1000 + i,
-                }).ToArray());
+                }).ToArray(), new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             int countEasy = result.Count(b => b.rating < 1500);
@@ -85,7 +85,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.True((double)countHard / result.Length >= 0.25);
 
             matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.id), result2.OrderBy(b => b.id));
+            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -93,15 +93,15 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         {
             MatchmakingBeatmapSelector selector = new MatchmakingBeatmapSelector(
             [
-                new matchmaking_pool_beatmap { id = 0, rating = 1000 },
-                new matchmaking_pool_beatmap { id = 1, rating = 1000 },
-            ]);
+                new matchmaking_pool_beatmap { beatmap_id = 0, rating = 1000 },
+                new matchmaking_pool_beatmap { beatmap_id = 1, rating = 1000 },
+            ], new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps(50, [new EloRating(1000, 350), new EloRating(1000, 350)]);
 
             Assert.Equal(2, result.Length);
-            Assert.Single(result, t => t.id == 0);
-            Assert.Single(result, t => t.id == 1);
+            Assert.Single(result, t => t.beatmap_id == 0);
+            Assert.Single(result, t => t.beatmap_id == 1);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public void OnlyEasyBeatmaps()
         {
-            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
+            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
                     beatmap_id = i,
@@ -35,7 +35,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public void OnlyAverageBeatmaps()
         {
-            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
+            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
                     beatmap_id = i,
@@ -52,7 +52,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public void OnlyHardBeatmaps()
         {
-            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
+            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
                     beatmap_id = i,
@@ -69,7 +69,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public void WideSelection()
         {
-            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(
+            MatchmakingBeatmapSelector beatmapSelector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
                 Enumerable.Range(1, 1000).Select(i => new matchmaking_pool_beatmap
                 {
                     beatmap_id = i,
@@ -91,7 +91,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public void NoDuplicates()
         {
-            MatchmakingBeatmapSelector selector = new MatchmakingBeatmapSelector(
+            MatchmakingBeatmapSelector selector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
             [
                 new matchmaking_pool_beatmap { beatmap_id = 0, rating = 1000 },
                 new matchmaking_pool_beatmap { beatmap_id = 1, rating = 1000 },

--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
@@ -52,7 +52,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0, [USER_ID, USER_ID_2],
-                    new MatchmakingBeatmapSelector([]));
+                    new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
         }
 
@@ -211,7 +211,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -305,7 +305,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -342,7 +342,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -660,7 +660,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var roomUsage = await Rooms.GetForUse(ROOM_ID, true))
             {
                 roomUsage.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);

--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
@@ -52,7 +52,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0, [USER_ID, USER_ID_2],
-                    new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
+                    new MatchmakingBeatmapSelector(new matchmaking_pool(), Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
         }
 
@@ -211,7 +211,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(new matchmaking_pool(), Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -305,7 +305,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(new matchmaking_pool(), Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -342,7 +342,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
             {
                 room.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(new matchmaking_pool(), Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);
@@ -660,7 +660,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             using (var roomUsage = await Rooms.GetForUse(ROOM_ID, true))
             {
                 roomUsage.Item = await initialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
-                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
+                    [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector(new matchmaking_pool(), Array.Empty<matchmaking_pool_beatmap>(), DatabaseFactory.Object));
             }
 
             await Hub.JoinRoom(ROOM_ID);

--- a/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
@@ -70,7 +70,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay
             {
                 room.Item = await ServerMultiplayerRoom.InitialiseMatchmakingRoomAsync(ROOM_ID, RoomController, DatabaseFactory.Object, EventDispatcher, LoggerFactory.Object, 0,
                     new[] { USER_ID, USER_ID_2 }.Select(u => new MatchmakingQueueUser(u.ToString()) { UserId = u }).ToArray(),
-                    new MatchmakingBeatmapSelector(Enumerable.Range(1, 50).Select(i => new matchmaking_pool_beatmap
+                    new MatchmakingBeatmapSelector(new matchmaking_pool(), Enumerable.Range(1, 50).Select(i => new matchmaking_pool_beatmap
                     {
                         id = (uint)i,
                         beatmap_id = i

--- a/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/RankedPlayStageImplementationTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
+using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs.Multiplayer;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue;
@@ -73,7 +74,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay
                     {
                         id = (uint)i,
                         beatmap_id = i
-                    }).ToArray()), new Mock<IMatchmakingQueueBackgroundService>().Object);
+                    }).ToArray(), new Mock<IDatabaseFactory>().Object), new Mock<IMatchmakingQueueBackgroundService>().Object);
 
                 Room = room.Item;
             }

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -714,6 +714,22 @@ namespace osu.Server.Spectator.Database
             })).ToArray();
         }
 
+        public async Task UpdateMatchmakingPoolBeatmapRatingAsync(matchmaking_pool_beatmap beatmap)
+        {
+            var conn = await getConnectionAsync();
+
+            await conn.ExecuteAsync("INSERT INTO `matchmaking_pool_beatmaps` (pool_id, beatmap_id, mods, rating, rating_sig) "
+                                    + "VALUES (@PoolId, @BeatmapId, @Mods, @Rating, @RatingSig) "
+                                    + "ON DUPLICATE KEY UPDATE rating = @Rating, rating_sig = @RatingSig", new
+            {
+                PoolId = beatmap.pool_id,
+                BeatmapId = beatmap.beatmap_id,
+                Mods = beatmap.mods,
+                Rating = beatmap.rating,
+                RatingSig = beatmap.rating_sig
+            });
+        }
+
         public async Task<database_beatmap[]> GetMatchmakingGlobalPoolBeatmapsAsync(int rulesetId, int variant)
         {
             var connection = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -277,6 +277,8 @@ namespace osu.Server.Spectator.Database
 
         Task<matchmaking_pool_beatmap[]> GetMatchmakingPoolBeatmapsAsync(uint poolId);
 
+        Task UpdateMatchmakingPoolBeatmapRatingAsync(matchmaking_pool_beatmap beatmap);
+
         Task<database_beatmap[]> GetMatchmakingGlobalPoolBeatmapsAsync(int rulesetId, int variant);
 
         Task<matchmaking_user_stats?> GetMatchmakingUserStatsAsync(int userId, uint poolId);

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
@@ -18,8 +18,9 @@ namespace osu.Server.Spectator.Database.Models
         public uint id { get; set; }
         public uint pool_id { get; set; }
         public int beatmap_id { get; set; }
-        public string? mods { get; set; }
-        public int? rating { get; set; }
+        public string mods { get; set; } = string.Empty;
+        public double rating { get; set; } = 1500;
+        public double rating_sig = 150;
         public int selection_count { get; set; }
 
         // osu_beatmaps

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
@@ -22,9 +22,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <param name="poolId">The pool on which the beatmap was played.</param>
         /// <param name="beatmapId">The beatmap that was played.</param>
         /// <param name="mods">Any mods the beatmap was played with.</param>
-        /// <param name="score">The resultant score.</param>
-        /// <param name="rating">The resultant rating.</param>
-        Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int score, EloRating rating);
+        /// <param name="scores">The achieved scores.</param>
+        /// <param name="ratings">The ratings corresponding to each of the scores.</param>
+        Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int[] scores, EloRating[] ratings);
 
         /// <summary>
         /// Whether a user is in the matchmaking queue.

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
@@ -3,7 +3,9 @@
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 {
@@ -13,6 +15,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// Records the current state of a match.
         /// </summary>
         Task RecordMatch(int poolId, MatchRoomState state);
+
+        /// <summary>
+        /// Records the result of a beatmap, adjusting the beatmap's rating as appropriate.
+        /// </summary>
+        /// <param name="poolId">The pool on which the beatmap was played.</param>
+        /// <param name="beatmapId">The beatmap that was played.</param>
+        /// <param name="mods">Any mods the beatmap was played with.</param>
+        /// <param name="score">The resultant score.</param>
+        /// <param name="rating">The resultant rating.</param>
+        Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int score, EloRating rating);
 
         /// <summary>
         /// Whether a user is in the matchmaking queue.

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -2,8 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using OpenSkillSharp.Models;
+using OpenSkillSharp.Rating;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
@@ -12,17 +15,20 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 {
     public class MatchmakingBeatmapSelector
     {
-        private readonly matchmaking_pool_beatmap[] beatmaps;
+        private readonly Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps;
+        private readonly IDatabaseFactory dbFactory;
 
-        public MatchmakingBeatmapSelector(matchmaking_pool_beatmap[] beatmaps)
+        private readonly HashSet<BeatmapLookupKey> pendingBeatmapUpdates = [];
+
+        public MatchmakingBeatmapSelector(Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps, IDatabaseFactory dbFactory)
         {
             this.beatmaps = beatmaps;
+            this.dbFactory = dbFactory;
+        }
 
-            foreach (var b in beatmaps)
-            {
-                // Todo: This default rating is only accurate for NoMod beatmaps.
-                b.rating ??= (int)Math.Round(800 + 500 * (Math.Exp(0.16 * b.difficultyrating) - 1));
-            }
+        public MatchmakingBeatmapSelector(matchmaking_pool_beatmap[] beatmaps, IDatabaseFactory dbFactory)
+            : this(beatmaps.ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b), dbFactory)
+        {
         }
 
         /// <summary>
@@ -34,23 +40,82 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         {
             using (var db = dbFactory.GetInstance())
             {
-                matchmaking_pool_beatmap[] beatmaps = await db.GetMatchmakingPoolBeatmapsAsync(pool.id);
-
-                // If there are no beatmaps specified in the pool, use all global ranked beatmaps.
-                if (beatmaps.Length == 0)
-                {
-                    database_beatmap[] globalBeatmaps = await db.GetMatchmakingGlobalPoolBeatmapsAsync(pool.ruleset_id, pool.variant_id);
-                    beatmaps = globalBeatmaps.Select(b => new matchmaking_pool_beatmap
+                // Get all ranked beatmaps.
+                Dictionary<int, matchmaking_pool_beatmap> rankedBeatmaps =
+                    (await db.GetMatchmakingGlobalPoolBeatmapsAsync(pool.ruleset_id, pool.variant_id))
+                    .Select(b => new matchmaking_pool_beatmap
                     {
                         pool_id = pool.id,
                         beatmap_id = b.beatmap_id,
                         playmode = b.playmode,
                         checksum = b.checksum,
-                        difficultyrating = b.difficultyrating
-                    }).ToArray();
-                }
+                        difficultyrating = b.difficultyrating,
+                        rating = (int)Math.Round(800 + 500 * (Math.Exp(0.16 * b.difficultyrating) - 1)),
+                    })
+                    .ToDictionary(b => b.beatmap_id, b => b);
 
-                return new MatchmakingBeatmapSelector(beatmaps);
+                // Get all beatmaps from the pool.
+                Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> poolBeatmaps =
+                    (await db.GetMatchmakingPoolBeatmapsAsync(pool.id))
+                    .ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b);
+
+                // The pool may not contain all ranked beatmaps, so back-fill it.
+                foreach ((int beatmapId, matchmaking_pool_beatmap beatmap) in rankedBeatmaps)
+                    poolBeatmaps.TryAdd(new BeatmapLookupKey(beatmapId, string.Empty), beatmap);
+
+                return new MatchmakingBeatmapSelector(poolBeatmaps, dbFactory);
+            }
+        }
+
+        public async Task Update()
+        {
+            matchmaking_pool_beatmap[] toUpdate;
+
+            lock (beatmaps)
+            {
+                toUpdate = pendingBeatmapUpdates.Select(id => beatmaps[id]).ToArray();
+                pendingBeatmapUpdates.Clear();
+            }
+
+            using (var db = dbFactory.GetInstance())
+            {
+                foreach (var beatmap in toUpdate)
+                    await db.UpdateMatchmakingPoolBeatmapRatingAsync(beatmap);
+            }
+        }
+
+        public void AdjustRating(BeatmapLookupKey key, int playerScore, EloRating playerRating)
+        {
+            lock (beatmaps)
+            {
+                if (!beatmaps.TryGetValue(key, out matchmaking_pool_beatmap? beatmap))
+                    return;
+
+                PlackettLuce model = new PlackettLuce
+                {
+                    Mu = 1500,
+                    Sigma = 150,
+                    Beta = 75,
+                    Tau = 1.5
+                };
+
+                IRating[] ratings = model.Rate(
+                                             [
+                                                 new Team { Players = [model.Rating(playerRating.Mu, playerRating.Sig)] },
+                                                 new Team { Players = [model.Rating(beatmap.rating, beatmap.rating_sig)] }
+                                             ],
+                                             scores:
+                                             [
+                                                 playerScore,
+                                                 700_000
+                                             ])
+                                         .Select(t => t.Players.Single())
+                                         .ToArray();
+
+                beatmap.rating = ratings[1].Mu;
+                beatmap.rating_sig = ratings[1].Sigma;
+
+                pendingBeatmapUpdates.Add(key);
             }
         }
 
@@ -61,20 +126,24 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <param name="ratings">The lobby user ratings.</param>
         public matchmaking_pool_beatmap[] GetAppropriateBeatmaps(int count, EloRating[] ratings)
         {
-            // Pick from maps around the minimum rating.
-            double ratingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
-            // Constant standard deviation to give a wide breadth around mu.
-            const double rating_sig = 100;
+            lock (beatmaps)
+            {
+                // Pick from maps around the minimum rating.
+                double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
+                // Constant standard deviation to give a wide breadth around mu.
+                const double rating_sig = 100;
 
-            return beatmaps.OrderByDescending(b =>
-                           {
-                               double beatmapRating = b.rating ?? 1500;
-                               // The clamp attempts to ensure all beatmaps are given some chance of being selected.
-                               double weight = Math.Clamp(Math.Exp(-Math.Pow(beatmapRating - ratingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
-                               return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
-                           })
-                           .Take(count)
-                           .ToArray();
+                return beatmaps.Values.OrderByDescending(b =>
+                               {
+                                   // The clamp attempts to ensure all beatmaps are given some chance of being selected.
+                                   double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
+                                   return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
+                               })
+                               .Take(count)
+                               .ToArray();
+            }
         }
+
+        public readonly record struct BeatmapLookupKey(int BeatmapId, string Mods);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -15,19 +15,21 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 {
     public class MatchmakingBeatmapSelector
     {
+        private readonly matchmaking_pool pool;
         private readonly Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps;
         private readonly IDatabaseFactory dbFactory;
 
         private readonly HashSet<BeatmapLookupKey> pendingBeatmapUpdates = [];
 
-        public MatchmakingBeatmapSelector(Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps, IDatabaseFactory dbFactory)
+        public MatchmakingBeatmapSelector(matchmaking_pool pool, Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps, IDatabaseFactory dbFactory)
         {
+            this.pool = pool;
             this.beatmaps = beatmaps;
             this.dbFactory = dbFactory;
         }
 
-        public MatchmakingBeatmapSelector(matchmaking_pool_beatmap[] beatmaps, IDatabaseFactory dbFactory)
-            : this(beatmaps.ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b), dbFactory)
+        public MatchmakingBeatmapSelector(matchmaking_pool pool, matchmaking_pool_beatmap[] beatmaps, IDatabaseFactory dbFactory)
+            : this(pool, beatmaps.ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b), dbFactory)
         {
         }
 
@@ -63,7 +65,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 foreach ((int beatmapId, matchmaking_pool_beatmap beatmap) in rankedBeatmaps)
                     poolBeatmaps.TryAdd(new BeatmapLookupKey(beatmapId, string.Empty), beatmap);
 
-                return new MatchmakingBeatmapSelector(poolBeatmaps, dbFactory);
+                return new MatchmakingBeatmapSelector(pool, poolBeatmaps, dbFactory);
             }
         }
 
@@ -99,6 +101,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     Tau = 1.5
                 };
 
+                double scoreToWin = pool.ruleset_id switch
+                {
+                    0 => 600_000,
+                    1 => 700_000,
+                    2 => 600_000,
+                    3 => 800_000,
+                    _ => throw new ArgumentException("Unknown ruleset ID.")
+                };
+
                 IRating[] ratings = model.Rate(
                                              [
                                                  new Team { Players = [model.Rating(playerRating.Mu, playerRating.Sig)] },
@@ -107,7 +118,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                              scores:
                                              [
                                                  playerScore,
-                                                 700_000
+                                                 scoreToWin
                                              ])
                                          .Select(t => t.Players.Single())
                                          .ToArray();

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -101,12 +101,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     Tau = 1.5
                 };
 
-                double scoreToWin = pool.ruleset_id switch
+                double clearThreshold = pool.ruleset_id switch
                 {
-                    0 => 600_000,
-                    1 => 700_000,
-                    2 => 600_000,
-                    3 => 800_000,
+                    0 => 550_000,
+                    1 => 850_000,
+                    2 => 850_000,
+                    3 => 850_000,
                     _ => throw new ArgumentException("Unknown ruleset ID.")
                 };
 
@@ -117,7 +117,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                              ],
                                              scores:
                                              [
-                                                 scoreToWin,
+                                                 clearThreshold,
                                                  .. playerScores
                                              ])
                                          .Select(t => t.Players.Single())

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -86,7 +86,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             }
         }
 
-        public void AdjustRating(BeatmapLookupKey key, int playerScore, EloRating playerRating)
+        public void AdjustRating(BeatmapLookupKey key, int[] playerScores, EloRating[] playerRatings)
         {
             lock (beatmaps)
             {
@@ -112,13 +112,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
                 IRating[] ratings = model.Rate(
                                              [
-                                                 new Team { Players = [model.Rating(playerRating.Mu, playerRating.Sig)] },
-                                                 new Team { Players = [model.Rating(beatmap.rating, beatmap.rating_sig)] }
+                                                 new Team { Players = [model.Rating(beatmap.rating, beatmap.rating_sig)] },
+                                                 .. playerRatings.Select(p => new Team { Players = [model.Rating(p.Mu, p.Sig)] }).ToArray()
                                              ],
                                              scores:
                                              [
-                                                 playerScore,
-                                                 scoreToWin
+                                                 scoreToWin,
+                                                 .. playerScores
                                              ])
                                          .Select(t => t.Players.Single())
                                          .ToArray();

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using osu.Game.Online.API;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Server.Spectator.Database;
@@ -52,6 +54,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
         private DateTimeOffset lastLobbyUpdateTime = DateTimeOffset.UnixEpoch;
         private DateTimeOffset lastQueueRefreshTime = DateTimeOffset.UnixEpoch;
+        private DateTimeOffset lastPoolUpdateTime = DateTimeOffset.UnixEpoch;
         private DateTimeOffset lastPoolRefreshTime = DateTimeOffset.UnixEpoch;
 
         public MatchmakingQueueBackgroundService(IHubContext<MultiplayerHub> hub, ISharedInterop sharedInterop, IDatabaseFactory databaseFactory, ILoggerFactory loggerFactory,
@@ -77,6 +80,20 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             lobby.RecordMatch(status);
             return Task.CompletedTask;
+        }
+
+        public async Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int score, EloRating rating)
+        {
+            if (!poolQueues.TryGetValue((int)poolId, out MatchmakingQueue? queue))
+                return;
+
+            if (!poolSelectors.TryGetValue(poolId, out MatchmakingBeatmapSelector? selector))
+                poolSelectors[poolId] = selector = await MatchmakingBeatmapSelector.Initialise(queue.Pool, databaseFactory);
+
+            selector.AdjustRating(
+                new MatchmakingBeatmapSelector.BeatmapLookupKey(beatmapId, mods.Length == 0 ? string.Empty : JsonConvert.SerializeObject(mods)),
+                score,
+                rating);
         }
 
         public bool IsInQueue(MultiplayerClientState state)
@@ -262,15 +279,25 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             lastQueueRefreshTime = DateTimeOffset.Now;
         }
 
-        private Task refreshPools()
+        private async Task refreshPools()
         {
-            if (DateTimeOffset.Now - lastPoolRefreshTime < TimeSpan.FromHours(1))
-                return Task.CompletedTask;
+            if (DateTimeOffset.Now - lastPoolUpdateTime >= TimeSpan.FromSeconds(5))
+            {
+                foreach (var selector in poolSelectors.Values)
+                    await selector.Update();
 
-            poolSelectors.Clear();
+                lastPoolUpdateTime = DateTimeOffset.Now;
+            }
 
-            lastPoolRefreshTime = DateTimeOffset.Now;
-            return Task.CompletedTask;
+            if (DateTimeOffset.Now - lastPoolRefreshTime >= TimeSpan.FromHours(1))
+            {
+                foreach (var selector in poolSelectors.Values)
+                    await selector.Update();
+
+                poolSelectors.Clear();
+
+                lastPoolRefreshTime = DateTimeOffset.Now;
+            }
         }
 
         private async Task processBundle(MatchmakingQueueUpdateBundle bundle)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -82,7 +82,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             return Task.CompletedTask;
         }
 
-        public async Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int score, EloRating rating)
+        public async Task RecordBeatmapResult(uint poolId, int beatmapId, APIMod[] mods, int[] scores, EloRating[] ratings)
         {
             if (!poolQueues.TryGetValue((int)poolId, out MatchmakingQueue? queue))
                 return;
@@ -90,10 +90,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             if (!poolSelectors.TryGetValue(poolId, out MatchmakingBeatmapSelector? selector))
                 poolSelectors[poolId] = selector = await MatchmakingBeatmapSelector.Initialise(queue.Pool, databaseFactory);
 
-            selector.AdjustRating(
-                new MatchmakingBeatmapSelector.BeatmapLookupKey(beatmapId, mods.Length == 0 ? string.Empty : JsonConvert.SerializeObject(mods)),
-                score,
-                rating);
+            selector.AdjustRating(new MatchmakingBeatmapSelector.BeatmapLookupKey(beatmapId, mods.Length == 0 ? string.Empty : JsonConvert.SerializeObject(mods)), scores, ratings);
         }
 
         public bool IsInQueue(MultiplayerClientState state)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -12,6 +12,7 @@ using osu.Game.Online.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages;
 
@@ -52,6 +53,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// All users participating in this match ordered by their turn order.
         /// </summary>
         public int[] UserIdsByTurnOrder { get; private set; } = [];
+
+        public EloRating AverageRating { get; private set; } = new EloRating();
 
         /// <summary>
         /// Mapping of cards to their associated effect.
@@ -123,6 +126,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                                  .ThenBy(_ => Random.Shared.NextSingle())
                                  .Select(u => u.UserId)
                                  .ToArray();
+
+            AverageRating = new EloRating
+            (
+                users.Select(u => u.Rating.Mu).Average(),
+                Math.Sqrt(users.Average(u => Math.Pow(u.Rating.Sig, 2)))
+            );
 
             // Populate the initial active user, for use by the client to display the first turn's user.
             State.ActiveUserId = UserIdsByTurnOrder[0];

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -54,7 +54,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// </summary>
         public int[] UserIdsByTurnOrder { get; private set; } = [];
 
-        public EloRating AverageRating { get; private set; } = new EloRating();
+        public Dictionary<int, EloRating> RatingByUser { get; private set; } = [];
 
         /// <summary>
         /// Mapping of cards to their associated effect.
@@ -115,6 +115,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             // Create the user states.
             foreach (var user in users)
             {
+                RatingByUser[user.UserId] = user.Rating;
                 State.Users[user.UserId] = new RankedPlayUserInfo
                 {
                     Rating = (int)Math.Round(user.Rating.Mu)
@@ -126,12 +127,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                                  .ThenBy(_ => Random.Shared.NextSingle())
                                  .Select(u => u.UserId)
                                  .ToArray();
-
-            AverageRating = new EloRating
-            (
-                users.Select(u => u.Rating.Mu).Average(),
-                Math.Sqrt(users.Average(u => Math.Pow(u.Rating.Sig, 2)))
-            );
 
             // Populate the initial active user, for use by the client to display the first turn's user.
             State.ActiveUserId = UserIdsByTurnOrder[0];

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -80,18 +80,18 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                     OldLife = oldLife,
                     NewLife = newLife,
                 };
+
+                await Controller.MatchmakingService.RecordBeatmapResult(
+                    Controller.PoolId,
+                    Room.CurrentPlaylistItem.BeatmapID,
+                    Room.CurrentPlaylistItem.RequiredMods.ToArray(),
+                    (int)score.total_score,
+                    Controller.RatingByUser[(int)score.user_id]);
             }
 
             SoloScore[] winningScores = scores.Where(u => u.total_score == maxTotalScore).ToArray();
             if (winningScores.Length == 1)
                 State.Users[(int)winningScores.Single().user_id].RoundsWon += 1;
-
-            await Controller.MatchmakingService.RecordBeatmapResult(
-                Controller.PoolId,
-                Room.CurrentPlaylistItem.BeatmapID,
-                Room.CurrentPlaylistItem.RequiredMods.ToArray(),
-                (int)Math.Round(scores.Select(s => (double)s.total_score).Average()),
-                Controller.AverageRating);
         }
 
         protected override async Task Finish()

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -80,18 +80,18 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                     OldLife = oldLife,
                     NewLife = newLife,
                 };
-
-                await Controller.MatchmakingService.RecordBeatmapResult(
-                    Controller.PoolId,
-                    Room.CurrentPlaylistItem.BeatmapID,
-                    Room.CurrentPlaylistItem.RequiredMods.ToArray(),
-                    (int)score.total_score,
-                    Controller.RatingByUser[(int)score.user_id]);
             }
 
             SoloScore[] winningScores = scores.Where(u => u.total_score == maxTotalScore).ToArray();
             if (winningScores.Length == 1)
                 State.Users[(int)winningScores.Single().user_id].RoundsWon += 1;
+
+            await Controller.MatchmakingService.RecordBeatmapResult(
+                Controller.PoolId,
+                Room.CurrentPlaylistItem.BeatmapID,
+                Room.CurrentPlaylistItem.RequiredMods.ToArray(),
+                scores.Select(s => (int)s.total_score).ToArray(),
+                scores.Select(s => Controller.RatingByUser[(int)s.user_id]).ToArray());
         }
 
         protected override async Task Finish()

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -85,6 +85,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             SoloScore[] winningScores = scores.Where(u => u.total_score == maxTotalScore).ToArray();
             if (winningScores.Length == 1)
                 State.Users[(int)winningScores.Single().user_id].RoundsWon += 1;
+
+            await Controller.MatchmakingService.RecordBeatmapResult(
+                Controller.PoolId,
+                Room.CurrentPlaylistItem.BeatmapID,
+                Room.CurrentPlaylistItem.RequiredMods.ToArray(),
+                (int)Math.Round(scores.Select(s => (double)s.total_score).Average()),
+                Controller.AverageRating);
         }
 
         protected override async Task Finish()


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-web/pull/12930

This changes the meaning of the `matchmaking_pool_beatmaps` table.
- Currently, it represents the full set of beatmaps available for a given pool, with the global beatmaps as a fallback path if the table is empty.
- With this PR, it is used _in addition_ to provide ratings for the global beatmaps.

For this to work, there is an update path that now _inserts_ into the `matchmaking_pool_beatmaps` table whenever beatmap rating is updated.

The way rating adjustments work is: we run the average player against the beatmap such that players are considered to have "won" against the beatmap if the average score is more than 700K.