### PR TITLE
Expire cards when players fail to ready up in time

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
@@ -14,6 +15,13 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         public FinishCardPlayStageTests()
             : base(RankedPlayStage.FinishCardPlay)
         {
+        }
+
+        protected override async Task SetupForEnter()
+        {
+            await base.SetupForEnter();
+
+            await MatchController.ActivateCard(RoomState.ActiveUser!.Hand.First());
         }
 
         [Fact]
@@ -46,11 +54,20 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToNextRoundWhenAnyPlayerFailsToBecomeReady()
         {
+            int firstActiveUser = RoomState.ActiveUserId!.Value;
+
             await Hub.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
             Assert.Equal(RankedPlayStage.FinishCardPlay, RoomState.Stage);
 
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            int secondActiveUser = RoomState.ActiveUserId!.Value;
+
+            Assert.NotEqual(firstActiveUser, secondActiveUser);
+
+            Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
+            Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
             Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
@@ -59,8 +76,17 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToNextRoundWhenAllPlayersFailToBecomeReady()
         {
+            int firstActiveUser = RoomState.ActiveUserId!.Value;
+
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            int secondActiveUser = RoomState.ActiveUserId!.Value;
+
+            Assert.NotEqual(firstActiveUser, secondActiveUser);
+
+            Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
+            Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
             Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         {
             await base.SetupForEnter();
 
-            await MatchController.ActivateCard(UserState.Hand.First());
+            await MatchController.ActivateCard(RoomState.ActiveUser!.Hand.First());
         }
 
         [Fact]
@@ -48,11 +48,20 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToNextRoundWhenAnyPlayerFailsToBecomeReady()
         {
+            int firstActiveUser = RoomState.ActiveUserId!.Value;
+
             await MarkCurrentUserReadyAndAvailable();
             Assert.Equal(RankedPlayStage.GameplayWarmup, RoomState.Stage);
 
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            int secondActiveUser = RoomState.ActiveUserId!.Value;
+
+            Assert.NotEqual(firstActiveUser, secondActiveUser);
+
+            Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
+            Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
             Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
@@ -61,8 +70,17 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToNextRoundWhenAllPlayersFailToBecomeReady()
         {
+            int firstActiveUser = RoomState.ActiveUserId!.Value;
+
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.CardPlay, RoomState.Stage);
+
+            int secondActiveUser = RoomState.ActiveUserId!.Value;
+
+            Assert.NotEqual(firstActiveUser, secondActiveUser);
+
+            Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
+            Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
             Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Game.Online;
@@ -27,10 +28,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
+            Debug.Assert(State.ActiveUserId != null);
+            Debug.Assert(Controller.LastActivatedCard != null);
+
             if (allPlayersReady())
                 await Controller.GotoStage(RankedPlayStage.GameplayWarmup);
             else
             {
+                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
+
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable))

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Game.Online;
@@ -27,12 +28,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
+            Debug.Assert(State.ActiveUserId != null);
+            Debug.Assert(Controller.LastActivatedCard != null);
+
             if (allPlayersReady())
-            {
                 await Controller.GotoStage(RankedPlayStage.Gameplay);
-            }
             else
             {
+                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
+
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable || p.State != MultiplayerUserState.Ready))


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/37488

Really this card removal should be done in `CardPlayStage` but I'm not yet sure what negative effects that may have client-side.