### PR TITLE
Fix updating beatmap ratings using the wrong values

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -714,6 +714,22 @@ namespace osu.Server.Spectator.Database
             })).ToArray();
         }
 
+        public async Task<matchmaking_pool_beatmap?> GetMatchmakingPoolBeatmapAsync(uint poolId, int beatmapId, string mods)
+        {
+            var connection = await getConnectionAsync();
+
+            return await connection.QuerySingleOrDefaultAsync<matchmaking_pool_beatmap>("SELECT p.*, b.playmode, b.checksum, b.difficultyrating FROM `matchmaking_pool_beatmaps` p "
+                                                                                        + "JOIN `osu_beatmaps` b ON p.beatmap_id = b.beatmap_id "
+                                                                                        + "WHERE p.pool_id = @PoolId "
+                                                                                        + "AND p.beatmap_id = @BeatmapId "
+                                                                                        + "AND p.mods = @Mods", new
+            {
+                PoolId = poolId,
+                BeatmapId = beatmapId,
+                Mods = mods
+            });
+        }
+
         public async Task UpdateMatchmakingPoolBeatmapRatingAsync(matchmaking_pool_beatmap beatmap)
         {
             var conn = await getConnectionAsync();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -277,6 +277,8 @@ namespace osu.Server.Spectator.Database
 
         Task<matchmaking_pool_beatmap[]> GetMatchmakingPoolBeatmapsAsync(uint poolId);
 
+        Task<matchmaking_pool_beatmap?> GetMatchmakingPoolBeatmapAsync(uint poolId, int beatmapId, string mods);
+
         Task UpdateMatchmakingPoolBeatmapRatingAsync(matchmaking_pool_beatmap beatmap);
 
         Task<database_beatmap[]> GetMatchmakingGlobalPoolBeatmapsAsync(int rulesetId, int variant);

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
@@ -28,6 +28,24 @@ namespace osu.Server.Spectator.Database.Models
         public string? checksum { get; set; }
         public double difficultyrating { get; set; }
 
+        public matchmaking_pool_beatmap()
+        {
+        }
+
+        public matchmaking_pool_beatmap(matchmaking_pool_beatmap other)
+        {
+            id = other.id;
+            pool_id = other.pool_id;
+            beatmap_id = other.beatmap_id;
+            mods = other.mods;
+            rating = other.rating;
+            rating_sig = other.rating_sig;
+            selection_count = other.selection_count;
+            playmode = other.playmode;
+            checksum = other.checksum;
+            difficultyrating = other.difficultyrating;
+        }
+
         public MultiplayerPlaylistItem ToPlaylistItem() => new MultiplayerPlaylistItem
         {
             BeatmapID = beatmap_id,

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,16 +16,21 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 {
     public class MatchmakingBeatmapSelector
     {
+        /// <summary>
+        /// Contains all ranked beatmaps.
+        /// </summary>
+        public Dictionary<int, matchmaking_pool_beatmap> GlobalBeatmaps { get; init; } = [];
+
         private readonly matchmaking_pool pool;
-        private readonly Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps;
+        private readonly ConcurrentDictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps;
         private readonly IDatabaseFactory dbFactory;
 
-        private readonly HashSet<BeatmapLookupKey> pendingBeatmapUpdates = [];
+        private readonly ConcurrentQueue<matchmaking_pool_beatmap> pendingUpdates = [];
 
         public MatchmakingBeatmapSelector(matchmaking_pool pool, Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> beatmaps, IDatabaseFactory dbFactory)
         {
             this.pool = pool;
-            this.beatmaps = beatmaps;
+            this.beatmaps = new ConcurrentDictionary<BeatmapLookupKey, matchmaking_pool_beatmap>(beatmaps);
             this.dbFactory = dbFactory;
         }
 
@@ -43,7 +49,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             using (var db = dbFactory.GetInstance())
             {
                 // Get all ranked beatmaps.
-                Dictionary<int, matchmaking_pool_beatmap> rankedBeatmaps =
+                Dictionary<int, matchmaking_pool_beatmap> globalBeatmaps =
                     (await db.GetMatchmakingGlobalPoolBeatmapsAsync(pool.ruleset_id, pool.variant_id))
                     .Select(b => new matchmaking_pool_beatmap
                     {
@@ -62,72 +68,73 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     .ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b);
 
                 // The pool may not contain all ranked beatmaps, so back-fill it.
-                foreach ((int beatmapId, matchmaking_pool_beatmap beatmap) in rankedBeatmaps)
+                foreach ((int beatmapId, matchmaking_pool_beatmap beatmap) in globalBeatmaps)
                     poolBeatmaps.TryAdd(new BeatmapLookupKey(beatmapId, string.Empty), beatmap);
 
-                return new MatchmakingBeatmapSelector(pool, poolBeatmaps, dbFactory);
+                return new MatchmakingBeatmapSelector(pool, poolBeatmaps, dbFactory)
+                {
+                    GlobalBeatmaps = globalBeatmaps
+                };
             }
         }
 
         public async Task Update()
         {
-            matchmaking_pool_beatmap[] toUpdate;
-
-            lock (beatmaps)
-            {
-                toUpdate = pendingBeatmapUpdates.Select(id => beatmaps[id]).ToArray();
-                pendingBeatmapUpdates.Clear();
-            }
-
             using (var db = dbFactory.GetInstance())
             {
-                foreach (var beatmap in toUpdate)
+                while (pendingUpdates.TryDequeue(out matchmaking_pool_beatmap? beatmap))
                     await db.UpdateMatchmakingPoolBeatmapRatingAsync(beatmap);
             }
         }
 
-        public void AdjustRating(BeatmapLookupKey key, int[] playerScores, EloRating[] playerRatings)
+        public async Task AdjustRating(BeatmapLookupKey key, int[] playerScores, EloRating[] playerRatings)
         {
-            lock (beatmaps)
+            // Always use the most-recent databased rating values.
+            matchmaking_pool_beatmap? beatmap;
+            using (var db = dbFactory.GetInstance())
+                beatmap = await db.GetMatchmakingPoolBeatmapAsync(pool.id, key.BeatmapId, key.Mods) ?? GlobalBeatmaps[key.BeatmapId];
+
+            PlackettLuce model = new PlackettLuce
             {
-                if (!beatmaps.TryGetValue(key, out matchmaking_pool_beatmap? beatmap))
-                    return;
+                Mu = 1500,
+                Sigma = 150,
+                Beta = 75,
+                Tau = 1.5
+            };
 
-                PlackettLuce model = new PlackettLuce
-                {
-                    Mu = 1500,
-                    Sigma = 150,
-                    Beta = 75,
-                    Tau = 1.5
-                };
+            double clearThreshold = pool.ruleset_id switch
+            {
+                0 => 550_000,
+                1 => 850_000,
+                2 => 850_000,
+                3 => 850_000,
+                _ => throw new ArgumentException("Unknown ruleset ID.")
+            };
 
-                double clearThreshold = pool.ruleset_id switch
-                {
-                    0 => 550_000,
-                    1 => 850_000,
-                    2 => 850_000,
-                    3 => 850_000,
-                    _ => throw new ArgumentException("Unknown ruleset ID.")
-                };
+            IRating[] ratings = model.Rate(
+                                         [
+                                             new Team { Players = [model.Rating(beatmap.rating, beatmap.rating_sig)] },
+                                             .. playerRatings.Select(p => new Team { Players = [model.Rating(p.Mu, p.Sig)] }).ToArray()
+                                         ],
+                                         scores:
+                                         [
+                                             clearThreshold,
+                                             .. playerScores
+                                         ])
+                                     .Select(t => t.Players.Single())
+                                     .ToArray();
 
-                IRating[] ratings = model.Rate(
-                                             [
-                                                 new Team { Players = [model.Rating(beatmap.rating, beatmap.rating_sig)] },
-                                                 .. playerRatings.Select(p => new Team { Players = [model.Rating(p.Mu, p.Sig)] }).ToArray()
-                                             ],
-                                             scores:
-                                             [
-                                                 clearThreshold,
-                                                 .. playerScores
-                                             ])
-                                         .Select(t => t.Players.Single())
-                                         .ToArray();
+            matchmaking_pool_beatmap newBeatmap = new matchmaking_pool_beatmap(beatmap)
+            {
+                rating = ratings[0].Mu,
+                rating_sig = ratings[0].Sigma
+            };
 
-                beatmap.rating = ratings[0].Mu;
-                beatmap.rating_sig = ratings[0].Sigma;
+            // Store the beatmap back so that it can be used for subsequent lookups.
+            beatmaps[key] = beatmap;
 
-                pendingBeatmapUpdates.Add(key);
-            }
+            // Write the beatmap to the database in the next update cycle.
+            pendingUpdates.Enqueue(newBeatmap);
         }
 
         /// <summary>
@@ -137,22 +144,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <param name="ratings">The lobby user ratings.</param>
         public matchmaking_pool_beatmap[] GetAppropriateBeatmaps(int count, EloRating[] ratings)
         {
-            lock (beatmaps)
-            {
-                // Pick from maps around the minimum rating.
-                double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
-                // Constant standard deviation to give a wide breadth around mu.
-                const double rating_sig = 100;
+            // Pick from maps around the minimum rating.
+            double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
+            // Constant standard deviation to give a wide breadth around mu.
+            const double rating_sig = 100;
 
-                return beatmaps.Values.OrderByDescending(b =>
-                               {
-                                   // The clamp attempts to ensure all beatmaps are given some chance of being selected.
-                                   double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
-                                   return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
-                               })
-                               .Take(count)
-                               .ToArray();
-            }
+            return beatmaps.Values.OrderByDescending(b =>
+                           {
+                               // The clamp attempts to ensure all beatmaps are given some chance of being selected.
+                               double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
+                               return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
+                           })
+                           .Take(count)
+                           .ToArray();
         }
 
         public readonly record struct BeatmapLookupKey(int BeatmapId, string Mods);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -123,8 +123,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                          .Select(t => t.Players.Single())
                                          .ToArray();
 
-                beatmap.rating = ratings[1].Mu;
-                beatmap.rating_sig = ratings[1].Sigma;
+                beatmap.rating = ratings[0].Mu;
+                beatmap.rating_sig = ratings[0].Sigma;
 
                 pendingBeatmapUpdates.Add(key);
             }


### PR DESCRIPTION
The fix here is the first commit. I changed around the way the contest was populated, and forgot to adjust the indices.

The second commit is an attempt to remedy the situation without requiring two server startups by always re-querying the `matchmaking_pool_beatmaps` table. The intentional deploy process here is:
- Deploy this version of server spectator.
- Wait 6 hours for the previous instance to die.
- Clear the `matchmaking_pool_beatmaps` table.

For about 1 hour, the server will then temporarily use the wrong rating to match with players, but I think that's acceptable.