### PR TITLE
Adjust damage multipliers for taiko/catch/mania

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/RoundWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/RoundWarmupStageTests.cs
@@ -57,9 +57,67 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task RoundMultiplierAdjustment()
+        public async Task RoundMultiplierAdjustmentOsu()
         {
+            RoomState.CurrentRound = 0;
+            MatchController.Pool.ruleset_id = 0;
+            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+
             double[] expectedMultipliers = [1, 1, 2, 2.5, 3, 3.5, 4, 4.5, 5];
+
+            for (int i = 0; i < expectedMultipliers.Length; i++)
+            {
+                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
+
+                // Go to the next round, for the next iteration.
+                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+            }
+        }
+
+        [Fact]
+        public async Task RoundMultiplierAdjustmentTaiko()
+        {
+            RoomState.CurrentRound = 0;
+            MatchController.Pool.ruleset_id = 1;
+            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+
+            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
+
+            for (int i = 0; i < expectedMultipliers.Length; i++)
+            {
+                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
+
+                // Go to the next round, for the next iteration.
+                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+            }
+        }
+
+        [Fact]
+        public async Task RoundMultiplierAdjustmentCatch()
+        {
+            RoomState.CurrentRound = 0;
+            MatchController.Pool.ruleset_id = 2;
+            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+
+            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
+
+            for (int i = 0; i < expectedMultipliers.Length; i++)
+            {
+                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
+
+                // Go to the next round, for the next iteration.
+                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+            }
+        }
+
+        [Fact]
+        public async Task RoundMultiplierAdjustmentMania()
+        {
+            RoomState.CurrentRound = 0;
+            MatchController.Pool.ruleset_id = 3;
+            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
+
+            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
 
             for (int i = 0; i < expectedMultipliers.Length; i++)
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -28,10 +28,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
         public MultiplayerPlaylistItem CurrentItem => Room.Playlist.Single(item => item.ID == Room.Settings.PlaylistItemId);
 
-        public uint PoolId { get; private set; }
-        public bool Ranked { get; private set; }
-
         public IMatchmakingQueueBackgroundService MatchmakingService { get; private set; } = null!;
+        public matchmaking_pool Pool { get; private set; } = null!;
+        public bool Ranked { get; private set; }
 
         public readonly ServerMultiplayerRoom Room;
         public readonly IDatabaseFactory DbFactory;
@@ -98,7 +97,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                                                           IMatchmakingQueueBackgroundService matchmakingService)
         {
             MatchmakingService = matchmakingService;
-            PoolId = pool.id;
+            Pool = pool;
             Ranked = pool.ranked;
 
             // Build the deck.
@@ -369,7 +368,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             // Naturally, this also means we don't have a winner to crown.
             if (State.CurrentRound == 0)
             {
-                await MatchmakingService.RecordMatch((int)PoolId, State);
+                await MatchmakingService.RecordMatch((int)Pool.id, State);
                 return;
             }
 
@@ -396,10 +395,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
                     foreach ((int userId, RankedPlayUserInfo user) in State.Users)
                     {
-                        matchmaking_user_stats userStats = await db.GetMatchmakingUserStatsAsync(userId, PoolId) ?? new matchmaking_user_stats
+                        matchmaking_user_stats userStats = await db.GetMatchmakingUserStatsAsync(userId, Pool.id) ?? new matchmaking_user_stats
                         {
                             user_id = (uint)userId,
-                            pool_id = PoolId
+                            pool_id = Pool.id
                         };
 
                         stats.Add(userStats);
@@ -425,7 +424,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
                         await db.InsertUserEloHistoryEntry(
                             (ulong)Room.RoomID,
-                            PoolId,
+                            Pool.id,
                             stats[i].user_id,
                             stats.First(u => u.user_id != stats[i].user_id).user_id,
                             result,
@@ -441,7 +440,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                 }
             }
 
-            await MatchmakingService.RecordMatch((int)PoolId, State);
+            await MatchmakingService.RecordMatch((int)Pool.id, State);
         }
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -75,7 +75,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             if (Controller.Ranked)
             {
                 await Controller.MatchmakingService.RecordBeatmapResult(
-                    Controller.PoolId,
+                    Controller.Pool.id,
                     Room.CurrentPlaylistItem.BeatmapID,
                     Room.CurrentPlaylistItem.RequiredMods.ToArray(),
                     scores.Select(s => (int)s.total_score).ToArray(),

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
@@ -53,12 +53,24 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         /// Retrieves the damage multiplier for a given round.
         /// </summary>
         /// <param name="round">The round.</param>
-        private static double computeDamageMultiplier(int round)
+        private double computeDamageMultiplier(int round)
         {
-            if (round <= 2)
-                return 1;
+            switch (Controller.Pool.ruleset_id)
+            {
+                // [ 1, 1, 2, 2.5, 3, 3.5, ... ]
+                case 0:
+                    if (round <= 2)
+                        return 1;
 
-            return 2 + (round - 3) * 0.5;
+                    return 2 + (round - 3) * 0.5;
+
+                // [ 1, 1, 2.5, 3.5, 4.5, 5.5, ... ]
+                default:
+                    if (round <= 2)
+                        return 1;
+
+                    return 2.5 + (round - 3) * 1.0;
+            }
         }
     }
 }


### PR DESCRIPTION
The goal here is to keep the osu! damage multiplier the same, and increasing it slightly for the other rulesets which tend to have very equal scores.

osu: `[ 1, 1, 2, 2.5, 3, 3.5, 4, ... ]` (starts at 1, initially increases by 1, and then in 0.5 steppings)
others: `[ 1, 1, 2.5, 3.5, 4.5, 5.5, ... ]` (starts at 1, initially increases by 1.5, then in 1.0 steppings).