### PR TITLE
Reduce beatmap rating breadth at lower skill levels

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -27,9 +27,6 @@ namespace osu.Server.Spectator.Tests.Matchmaking
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
-
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -44,9 +41,6 @@ namespace osu.Server.Spectator.Tests.Matchmaking
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
-
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -61,9 +55,6 @@ namespace osu.Server.Spectator.Tests.Matchmaking
 
             matchmaking_pool_beatmap[] result = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
             Assert.Equal(50, result.Length);
-
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]
@@ -83,9 +74,6 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.Equal(50, result.Length);
             Assert.True((double)countEasy / result.Length >= 0.25);
             Assert.True((double)countHard / result.Length >= 0.25);
-
-            matchmaking_pool_beatmap[] result2 = beatmapSelector.GetAppropriateBeatmaps(50, [new EloRating(1500, 80)]);
-            Assert.NotEqual(result.OrderBy(b => b.beatmap_id), result2.OrderBy(b => b.beatmap_id));
         }
 
         [Fact]

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -147,7 +147,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Pick from maps around the minimum rating.
             double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
             // Constant standard deviation to give a wide breadth around mu.
-            const double rating_sig = 50;
+            double rating_sig = 50+50/(1+Math.Exp(-0.01*(userRatingMu-1800)));
 
             return beatmaps.Values.OrderByDescending(b =>
                            {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -147,7 +147,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Pick from maps around the minimum rating.
             double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
             // Constant standard deviation to give a wide breadth around mu.
-            const double rating_sig = 100;
+            const double rating_sig = 50;
 
             return beatmaps.Values.OrderByDescending(b =>
                            {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -146,13 +146,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         {
             // Pick from maps around the minimum rating.
             double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
-            // Constant standard deviation to give a wide breadth around mu.
-            double rating_sig = 50+50/(1+Math.Exp(-0.01*(userRatingMu-1800)));
+
+            // Logistic curve that is narrow (50pts) at lower ratings where there are many beatmaps,
+            // and broader (100pts) at higher ratings where there are fewer beatmaps.
+            double ratingSig = 50 + 50 / (1 + Math.Exp(-0.01 * (userRatingMu - 1800)));
 
             return beatmaps.Values.OrderByDescending(b =>
                            {
                                // The clamp attempts to ensure all beatmaps are given some chance of being selected.
-                               double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * rating_sig * rating_sig)), 1e-6, 1);
+                               double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * ratingSig * ratingSig)), 1e-6, 1);
                                return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
                            })
                            .Take(count)


### PR DESCRIPTION
There are widespread complaints from players on repeatedly getting a mixture of maps from a difficulty range that is way too wide. This is simply a value nerf to the issue.