### PR TITLE
Attempt to increase beatmap variety at high user rating

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -17,6 +17,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
     public class MatchmakingBeatmapSelector
     {
         /// <summary>
+        /// The approximate number of osu! ruleset beatmaps that should be filtered down to for relevancy purposes.
+        /// </summary>
+        private const double osu_beatmap_proportion = 1 / 12.0;
+
+        /// <summary>
         /// Contains all ranked beatmaps.
         /// </summary>
         public Dictionary<int, matchmaking_pool_beatmap> GlobalBeatmaps { get; init; } = [];
@@ -157,9 +162,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * ratingSig * ratingSig)), 1e-6, 1);
                                return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
                            })
-                           // First wide-range filter - at high star ratings there are fewer maps closer to the mean so we'll pick from a larger subset.
-                           .Take(1000)
-                           // Second filter down to the required count while giving some variety (randomness) to the pool.
+                           // Relevancy filter: at high star ratings there are fewer maps closer to the mean so we'll filter to a larger set.
+                           .Take(Math.Max(count, (int)Math.Round(beatmaps.Count * osu_beatmap_proportion)))
+                           // Variety filter: down to the required count.
                            .OrderBy(_ => Random.Shared.NextDouble()).Take(count)
                            .ToArray();
         }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -157,7 +157,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * ratingSig * ratingSig)), 1e-6, 1);
                                return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
                            })
-                           .Take(count)
+                           // First wide-range filter - at high star ratings there are fewer maps closer to the mean so we'll pick from a larger subset.
+                           .Take(1000)
+                           // Second filter down to the required count while giving some variety (randomness) to the pool.
+                           .OrderBy(_ => Random.Shared.NextDouble()).Take(count)
                            .ToArray();
         }
 


### PR DESCRIPTION
This uses a 2-pass filtering method.

The entire FA pool looks something like this:
<img width="640" height="396" alt="image" src="https://github.com/user-attachments/assets/f4e5dbac-fecf-4277-9e69-e59ee3cd102f" />

Use a normal distribution to filter to 1000 beatmaps (providing relevancy) and then apply a uniform distribution on top (providing variety).