### PR TITLE
Adjust beatmap clear thresholds

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -104,7 +104,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             double clearThreshold = pool.ruleset_id switch
             {
-                0 => 550_000,
+                0 => 420_000,
                 1 => 850_000,
                 2 => 850_000,
                 3 => 850_000,


### PR DESCRIPTION
Latest data:

| ruleset\_id | avg | stddev | p\_25 | p\_50 | p\_75 | count |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 0 | 545327 | 176869 | 422937 | 543338 | 662210 | 1090997 |
| 1 | 833371 | 126548 | 752539 | 853898 | 934855 | 13662 |
| 2 | 808340 | 143042 | 718767 | 833948 | 919046 | 6486 |
| 3 | 813899 | 129695 | 737681 | 843075 | 916008 | 105404 |

Previously used p50 levels, but it's probably a little too harsh and ratings are probably fluctuating too much. This adjusts to use p25 levels instead.