### PR TITLE
Implement "last stand" mechanic for ranked play

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
@@ -95,7 +95,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
         {
-            RoomState.Users[USER_ID].Life = 50_000;
+            // Needs to be 1HP to bypass the last stand mechanic.
+            RoomState.Users[USER_ID].Life = 1;
 
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
@@ -89,7 +89,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
         {
-            RoomState.Users[USER_ID].Life = 50_000;
+            // Needs to be 1HP to bypass the last stand mechanic.
+            RoomState.Users[USER_ID].Life = 1;
 
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -161,6 +161,59 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
+        public async Task DeathDamageLeadsToLastStand()
+        {
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1_000_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 0 },
+                    ]));
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(1, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 1_000_000,
+                Damage = 1_000_000,
+                OldLife = 1_000_000,
+                NewLife = 1,
+            });
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(0, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 1_000_000,
+                Damage = 1_000_000,
+                OldLife = 1,
+                NewLife = 0,
+            });
+        }
+
+        [Fact]
         public async Task UserNotKilledIfQuitInFinalRound()
         {
             UserState.Life = 0;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -345,7 +345,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             int damage = (int)Math.Ceiling(rawDamage * State.DamageMultiplier);
 
             int oldLife = userInfo.Life;
-            int newLife = Math.Max(0, oldLife - damage);
+            // Last-stand mechanic: fatal attacks bring players 1HP first before killing them.
+            int newLife = Math.Max(oldLife <= 1 ? 0 : 1, oldLife - damage);
 
             userInfo.Life = newLife;
 


### PR DESCRIPTION
This implements a last-stand mechanic so that matches don't end with one card at high multipliers. When a fatal attack lands, it will first take players to 1HP. Another attack is required to finally defeat them.

One consideration is the results screen - with the way this PR is written it will still display the full damage value even though only up to `HP - 1` damage can be dealt in the first strike. I believe this is fine, because the alternative where the second strike can only deal 1 damage max, is even more awkward.