### PR TITLE
Speed up queue time by scaling window with player rating

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -358,17 +358,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
                 double distance = Math.Min(leftDistance, rightDistance);
 
+                // Speedup user pairing by a coefficient based on rating
+                double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
+
                 TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-                /// Speedup of user pairing window expansion by a coefficient based on elo
-                /// 1500: 1
-                /// 1800: 1.17
-                /// 2000: 1.56
-                /// 2200: 2.39
-                /// 2400: 4.22
-                /// 2600: 8.59
-                /// subject to future changes if the elo distribution changes, but it is fine for now I think
-                double searchRadiusEloBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
-                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * searchRadiusEloBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
+                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
 
                 if (distance > searchRadius)
                     break;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -359,7 +359,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 double distance = Math.Min(leftDistance, rightDistance);
 
                 TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
+                /// Speedup of user pairing window expansion by a coefficient based on elo
+                /// 1500: 1
+                /// 1800: 1.17
+                /// 2000: 1.56
+                /// 2200: 2.39
+                /// 2400: 4.22
+                /// 2600: 8.59
+                /// subject to future changes if the elo distribution changes, but it is fine for now I think
+                double searchRadiusEloBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
+                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * searchRadiusEloBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
 
                 if (distance > searchRadius)
                     break;


### PR DESCRIPTION
The gradually increasing window creates unusually long queue times for higher elo players due to the low player volume and huge rating gap between them. This pr aims to remedy this problem with minimal change to the spirit of the system.

The math for this change is the reciprocal of a bell curve (the coefficients are nerfed because a direct reciprocal of the full playerbase elo distribution is way too extreme.)  

https://www.desmos.com/calculator/eouhvb4txz
Graph