### PR TITLE
Fix inconsistent team serialisation in match start broadcasting

### DIFF
--- a/osu.Server.Spectator/Database/Models/MatchStartedEventDetail.cs
+++ b/osu.Server.Spectator/Database/Models/MatchStartedEventDetail.cs
@@ -21,10 +21,18 @@ namespace osu.Server.Spectator.Database.Models
         public Dictionary<int, room_team>? teams { get; set; }
     }
 
+    /// <remarks>
+    /// Note that the numerical values of this enum DO NOT match stable / legacy convention as defined in
+    /// <see href="https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!common/SharedEnums.cs#L48-L53">stable</see>
+    /// and <see href="https://github.com/ppy/osu-web/blob/master/app/Models/LegacyMatch/Score.php#L36-L40">osu-web</see>.
+    /// This is fine, however, as the raw numerical value is only used as a way to convert from the new lazer convention as defined
+    /// <see href="https://github.com/ppy/osu/blob/ed905b761dbba26156dbd089286b5e77cba389dd/osu.Game/Online/Multiplayer/MatchTypes/TeamVersus/TeamVersusRoomState.cs#L23-L24">here</see>;
+    /// the actual value that gets written out to database is the stringified representation of the enum due to the attached <see cref="StringEnumConverter"/>.
+    /// </remarks>
     [JsonConverter(typeof(StringEnumConverter))]
     public enum room_team
     {
+        red = 0,
         blue = 1,
-        red = 2,
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Standard/TeamVersusMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Standard/TeamVersusMatchController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -111,8 +112,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Standard
 
             foreach (var user in room.Users)
             {
-                if (user.MatchState is TeamVersusUserState userState)
-                    teams[user.UserID] = userState.TeamID == 0 ? room_team.red : room_team.blue;
+                if (user.MatchState is TeamVersusUserState userState && Enum.IsDefined(typeof(room_team), userState.TeamID))
+                    teams[user.UserID] = (room_team)userState.TeamID;
             }
 
             return new MatchStartedEventDetail


### PR DESCRIPTION
Closes https://github.com/ppy/osu-server-spectator/issues/490.

After some hemming and hawing, I decided that the best way to fix this was by fixing the odd stone out, which is the *legacy* enum values in `room_team` not matching the new lazer convention. This way, casting between team-like types all across spectator is just not a problem anymore.

As per inline commentary added in the change, this makes sense because the raw numerical value was just not used for anything until now. Even when writing things out to the database, the enum was stringified. So the numerical value desync was really just making things more complicated for basically no gain at all - the best argument I can swing for the old values is that they documented that stable did things differently. Which an inline comment can do just as well.