### PR TITLE
Throw error when attempting to send invite to not-online player as referee

### DIFF
--- a/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
+++ b/osu.Server.Spectator/Hubs/Referee/RefereeHub.cs
@@ -217,6 +217,16 @@ namespace osu.Server.Spectator.Hubs.Referee
                     if (roomUsage.Item.BannedUsers.Contains(userId))
                         ThrowHelper.ThrowUserBanned();
 
+                    // check whether the target user is online.
+                    // this relies on the fact that `MultiplayerHub` eagerly creates empty user states on connect,
+                    // which should be fine to do since https://github.com/ppy/osu-server-spectator/pull/338/changes/3080a14b174f8417cf95b939efd349da762da533.
+                    // note that this is querying a memory store, which means that it can break down if multiple concurrent instances of spectator server are active.
+                    // right now this is only the case during instance handover post-deploys, and https://github.com/ppy/osu/pull/37506 hopefully makes that not painful.
+                    // lock is purposefully not taken as taking it has little practical benefit and only increases contention / deadlock fears.
+                    var targetUser = playerStates.GetEntityUnsafe(userId);
+                    if (targetUser == null)
+                        ThrowHelper.ThrowUserNotConnected();
+
                     await roomUsage.Item.InvitePlayer(userId, invitedBy: userUsage.Item.UserId);
                 }
             }

--- a/osu.Server.Spectator/Hubs/Referee/ThrowHelper.cs
+++ b/osu.Server.Spectator/Hubs/Referee/ThrowHelper.cs
@@ -134,5 +134,12 @@ namespace osu.Server.Spectator.Hubs.Referee
         [DoesNotReturn]
         public static void ThrowUserNotHost()
             => throw new RefereeHubException(18, "You are not the host of the room.");
+
+        /// <summary>
+        /// Error 19: The specified user is not connected to multiplayer.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowUserNotConnected()
+            => throw new RefereeHubException(19, "The specified user is not connected to multiplayer.");
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu-server-spectator/issues/491.

A few months back an implementation this naïve would be too broken to live, but through the combination of
https://github.com/ppy/osu-server-spectator/pull/338/commits/3080a14b174f8417cf95b939efd349da762da533 (which ensures that all users are present in the multiplayer hub immediately after connect) and https://github.com/ppy/osu/pull/37506 (which hopefully minimises split-brains during post-deploy handover) it's probably maybe fine to try it now.