### PR TITLE
Floor ratings when counting players in each division

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingLobby.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingLobby.cs
@@ -114,7 +114,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
                     foreach (int rating in await db.GetMatchmakingPoolRatingsAsync((uint)poolId))
                     {
-                        int ratingRounded = (int)Math.Round((float)rating / 25) * 25;
+                        int ratingRounded = (int)Math.Floor((float)rating / 25) * 25;
                         ratingCounts[ratingRounded] = ratingCounts.GetValueOrDefault(ratingRounded) + 1;
                     }
 


### PR DESCRIPTION
As brought up in https://github.com/ppy/osu/pull/37534, I agree that it makes more sense to think of a 1575 player as 1500 rating than 1600.