### PR TITLE
Allow top-100 players to always be able to pair

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueTest.cs
@@ -231,6 +231,34 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.Equal(2, bundle.FormedGroups[0].Users.Length);
         }
 
+        [Fact]
+        public void Top100MatchesWithTop1()
+        {
+            CustomSystemClock clock = new CustomSystemClock();
+
+            queue.Pool.lobby_size = 2;
+            queue.Pool.rating_search_radius = 20;
+            queue.Pool.rating_search_radius_max = 200;
+            queue.Clock = clock;
+            queue.Top100Rating = 2000;
+
+            queue.Add(new MatchmakingQueueUser("1")
+            {
+                Rating = new EloRating(2600)
+            });
+
+            queue.Add(new MatchmakingQueueUser("2")
+            {
+                Rating = new EloRating(2000)
+            });
+
+            // Maximise search bonus.
+            clock.UtcNow += TimeSpan.FromMinutes(10);
+
+            var bundle = queue.Update();
+            Assert.Single(bundle.FormedGroups);
+        }
+
         private class CustomSystemClock : ISystemClock
         {
             public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UtcNow;

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -834,6 +834,16 @@ namespace osu.Server.Spectator.Database
             })).ToArray();
         }
 
+        public async Task<int[]> GetMatchmakingPoolTop100RatingsAsync(uint poolId)
+        {
+            var connection = await getConnectionAsync();
+
+            return (await connection.QueryAsync<int>("SELECT rating FROM matchmaking_user_stats WHERE pool_id = @PoolId AND plays > 0 ORDER BY rating DESC LIMIT 100", new
+            {
+                PoolId = poolId
+            })).ToArray();
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -290,5 +290,7 @@ namespace osu.Server.Spectator.Database
         Task InsertUserEloHistoryEntry(ulong roomId, uint poolId, uint userId, uint opponentId, matchmaking_room_result result, int eloBefore, int eloAfter);
 
         Task<int[]> GetMatchmakingPoolRatingsAsync(uint poolId);
+
+        Task<int[]> GetMatchmakingPoolTop100RatingsAsync(uint poolId);
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 using osu.Game.Extensions;
+using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
@@ -67,11 +69,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <summary>
         /// Refreshes this <see cref="MatchmakingQueue"/> with a new pool.
         /// </summary>
-        /// <param name="pool">The new pool.</param>
-        public void Refresh(matchmaking_pool pool)
+        public async Task<MatchmakingQueueUpdateBundle> Refresh(IDatabaseAccess db)
         {
-            lock (queueLock)
-                Pool = pool;
+            matchmaking_pool? newPool = await db.GetMatchmakingPoolAsync(Pool.id);
+
+            if (newPool == null)
+                return Clear();
+
+            Pool = newPool;
+
+            if (!newPool.active)
+                return Clear();
+
+            return new MatchmakingQueueUpdateBundle(this);
         }
 
         /// <summary>

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -45,6 +45,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         private readonly object queueLock = new object();
 
         /// <summary>
+        /// The top-100 player's rating from the pool. This is populated upon the first <see cref="Refresh"/>.
+        /// </summary>
+        private int top100Rating = 99999;
+
+        /// <summary>
         /// A running counter for the next group ID.
         /// </summary>
         private uint nextGroupId = 1;
@@ -80,6 +85,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             if (!newPool.active)
                 return Clear();
+
+            int[] topRatings = await db.GetMatchmakingPoolTop100RatingsAsync(Pool.id);
+            top100Rating = topRatings.LastOrDefault();
 
             return new MatchmakingQueueUpdateBundle(this);
         }
@@ -344,13 +352,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Gradually expand a search from the pivot user until the rating search radius is exhausted.
             MatchmakingQueueUser pivotUser = users[pivotIndex];
 
-            // Speedup user pairing by a coefficient based on rating
+            // Search bonus based on the user's rating to cover gaps in the rating distribution.
             double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
 
+            // Search bonus based on how much time the user spent in the queue.
             TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-            double timeBonus = Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp);
+            double searchTimeBonus = Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp);
 
-            double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * timeBonus);
+            // Distance bonus such that top-100 players can always match against each other.
+            double top100Bonus = Math.Max(1, (pivotUser.Rating.Mu - top100Rating) / Pool.rating_search_radius_max);
+
+            double searchRadius = Math.Min(
+                Pool.rating_search_radius_max * top100Bonus,
+                Pool.rating_search_radius * ratingBonus * searchTimeBonus);
 
             IEnumerable<MatchmakingQueueUser> allMatches = users.Where(u => !u.Equals(pivotUser) && Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius);
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -35,6 +35,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         public ISystemClock Clock { get; set; } = new SystemClock();
 
         /// <summary>
+        /// The top-100 player's rating from the pool. This is populated upon the first <see cref="Refresh"/>.
+        /// </summary>
+        public int Top100Rating { get; set; } = 99999;
+
+        /// <summary>
         /// All users active in the matchmaking queue.
         /// </summary>
         private readonly HashSet<MatchmakingQueueUser> matchmakingUsers = new HashSet<MatchmakingQueueUser>();
@@ -43,11 +48,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// Lock for <see cref="matchmakingUsers"/>.
         /// </summary>
         private readonly object queueLock = new object();
-
-        /// <summary>
-        /// The top-100 player's rating from the pool. This is populated upon the first <see cref="Refresh"/>.
-        /// </summary>
-        private int top100Rating = 99999;
 
         /// <summary>
         /// A running counter for the next group ID.
@@ -87,7 +87,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 return Clear();
 
             int[] topRatings = await db.GetMatchmakingPoolTop100RatingsAsync(Pool.id);
-            top100Rating = topRatings.LastOrDefault();
+            Top100Rating = topRatings.LastOrDefault();
 
             return new MatchmakingQueueUpdateBundle(this);
         }
@@ -360,7 +360,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             double searchTimeBonus = Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp);
 
             // Distance bonus such that top-100 players can always match against each other.
-            double top100Bonus = Math.Max(1, (pivotUser.Rating.Mu - top100Rating) / Pool.rating_search_radius_max);
+            double top100Bonus = Math.Max(1, (pivotUser.Rating.Mu - Top100Rating) / Pool.rating_search_radius_max);
 
             double searchRadius = Math.Min(
                 Pool.rating_search_radius_max * top100Bonus,

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -339,14 +339,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             using (var db = databaseFactory.GetInstance())
             {
                 foreach ((_, MatchmakingQueue queue) in poolQueues)
-                {
-                    matchmaking_pool? newPool = await db.GetMatchmakingPoolAsync(queue.Pool.id);
-
-                    if (newPool?.active != true)
-                        await processBundle(queue.Clear());
-                    else
-                        queue.Refresh(newPool);
-                }
+                    await processBundle(await queue.Refresh(db));
             }
 
             lastQueueRefreshTime = DateTimeOffset.Now;


### PR DESCRIPTION
In a recent mrekk stream, he was stuck in the queue for 2 hours unable to pair with anybody because he's too far ahead in rating. This change is intended to make players within the top-100 be able to eventually pair with each other by increasing the maximum search radius to cover the top-100 window.