### PR TITLE
Simplify ranked play queue matchmaking

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueTest.cs
@@ -217,6 +217,20 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.Empty(bundle.DeclinedUsers);
         }
 
+        [Fact]
+        public void CorrectNumberOfUsersMatched()
+        {
+            queue.Pool.lobby_size = 2;
+
+            queue.Add(new MatchmakingQueueUser("1"));
+            queue.Add(new MatchmakingQueueUser("2"));
+            queue.Add(new MatchmakingQueueUser("3"));
+
+            var bundle = queue.Update();
+            Assert.Single(bundle.FormedGroups);
+            Assert.Equal(2, bundle.FormedGroups[0].Users.Length);
+        }
+
         private class CustomSystemClock : ISystemClock
         {
             public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UtcNow;

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Spectator.Database.Models
         /// <summary>
         /// The amount of time (in seconds) before each doubling of the <see cref="rating_search_radius">rating search radius</see>.
         /// </summary>
-        public int rating_search_radius_exp { get; set; }
+        public int rating_search_radius_exp { get; set; } = 300;
 
         public MatchmakingPool ToMatchmakingPool() => new MatchmakingPool
         {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -337,6 +337,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             MatchmakingQueueUser pivotUser = users[pivotIndex];
             HashSet<MatchmakingQueueUser> result = [pivotUser];
 
+            // Speedup user pairing by a coefficient based on rating
+            double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
+            TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
+            double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
+
             int leftIndex = pivotIndex - 1;
             int rightIndex = pivotIndex + 1;
 
@@ -357,12 +362,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     : double.MaxValue;
 
                 double distance = Math.Min(leftDistance, rightDistance);
-
-                // Speedup user pairing by a coefficient based on rating
-                double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
-
-                TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-                double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
 
                 if (distance > searchRadius)
                     break;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -336,8 +336,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             // Speedup user pairing by a coefficient based on rating
             double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
+
             TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
-            double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
+            double timeBonus = Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp);
+
+            double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * timeBonus);
 
             HashSet<MatchmakingQueueUser> result = [];
             result.AddRange(users.Where(u => Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius));

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Internal;
+using osu.Game.Extensions;
 using osu.Server.Spectator.Database.Models;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
@@ -330,44 +331,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <returns></returns>
         private HashSet<MatchmakingQueueUser> findMatchesForUser(IReadOnlyList<MatchmakingQueueUser> users, int pivotIndex)
         {
-            const double uncertainty = 0;
-
             // Gradually expand a search from the pivot user until the rating search radius is exhausted.
-
             MatchmakingQueueUser pivotUser = users[pivotIndex];
-            HashSet<MatchmakingQueueUser> result = [pivotUser];
 
             // Speedup user pairing by a coefficient based on rating
             double ratingBonus = Math.Exp(Math.Pow((pivotUser.Rating.Mu - 1500) / 750, 2));
             TimeSpan searchTime = Clock.UtcNow - pivotUser.SearchStartTime;
             double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * Math.Pow(2, searchTime.TotalSeconds / Pool.rating_search_radius_exp));
 
-            int leftIndex = pivotIndex - 1;
-            int rightIndex = pivotIndex + 1;
-
-            while (result.Count < Pool.lobby_size)
-            {
-                MatchmakingQueueUser? leftUser = leftIndex < 0 ? null : users[leftIndex];
-                MatchmakingQueueUser? rightUser = rightIndex >= users.Count ? null : users[rightIndex];
-
-                if (leftUser == null && rightUser == null)
-                    break;
-
-                double leftDistance = leftUser != null
-                    ? Math.Abs(Math.Abs(pivotUser.Rating.Mu - leftUser.Rating.Mu) - (pivotUser.Rating.Sig - leftUser.Rating.Sig) * uncertainty)
-                    : double.MaxValue;
-
-                double rightDistance = rightUser != null
-                    ? Math.Abs(Math.Abs(pivotUser.Rating.Mu - rightUser.Rating.Mu) - (pivotUser.Rating.Sig - rightUser.Rating.Sig) * uncertainty)
-                    : double.MaxValue;
-
-                double distance = Math.Min(leftDistance, rightDistance);
-
-                if (distance > searchRadius)
-                    break;
-
-                result.Add(leftDistance < rightDistance ? users[leftIndex--] : users[rightIndex++]);
-            }
+            HashSet<MatchmakingQueueUser> result = [];
+            result.AddRange(users.Where(u => Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius));
 
             return result;
         }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -348,7 +348,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             result.AddRange(
                 allMatches
                     .OrderBy(_ => Random.Shared.Next())
-                    .Take(Pool.lobby_size)
+                    .Take(Pool.lobby_size - 1) // pivotUser is already in collection, so we need the number of opponents
             );
 
             return result;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -342,8 +342,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
             double searchRadius = Math.Min(Pool.rating_search_radius_max, Pool.rating_search_radius * ratingBonus * timeBonus);
 
-            HashSet<MatchmakingQueueUser> result = [];
-            result.AddRange(users.Where(u => Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius));
+            IEnumerable<MatchmakingQueueUser> allMatches = users.Where(u => !u.Equals(pivotUser) && Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius);
+
+            HashSet<MatchmakingQueueUser> result = [pivotUser];
+            result.AddRange(
+                allMatches
+                    .OrderBy(_ => Random.Shared.Next())
+                    .Take(Pool.lobby_size)
+            );
 
             return result;
         }


### PR DESCRIPTION
Slightly less performant than the code on master, but way more readable and easier to reason changes for.

If performance does become a bottleneck, can implement following change
```cs

IEnumerable<MatchmakingQueueUser> leftSideMatches = users
                                                    .Take(pivotIndex) // Excludes the pivot user
                                                    .Reverse() // Iterate starting from the pivot to the beginning of list
                                                    .TakeWhile(u => Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius);

IEnumerable<MatchmakingQueueUser> rightSideMatches = users
                                                     .Skip(pivotIndex + 1) // Excludes the pivot user. If pivot user is the highest rated player, sequence is empty
                                                     .TakeWhile(u => Math.Abs(pivotUser.Rating.Mu - u.Rating.Mu) <= searchRadius);

IEnumerable<MatchmakingQueueUser> allMatches = leftSideMatches.Concat(rightSideMatches);
```