### PR TITLE
Ranked Play: Add base damage and individual multipliers

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.505.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.505.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
@@ -70,7 +70,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(950_000, RoomState.Users[USER_ID_2].Life);
         }
 
         [Fact]
@@ -88,8 +88,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
             Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
-            Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID_2].Life);
         }
 
         [Fact]
@@ -98,11 +98,14 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             // Needs to be 1HP to bypass the last stand mechanic.
             RoomState.Users[USER_ID].Life = 1;
 
+            SetUserContext(ContextUser2);
+            await MarkCurrentUserReadyAndAvailable();
+
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
 
             Assert.Equal(0, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID_2].Life);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
             Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(950_000, RoomState.Users[USER_ID_2].Life);
         }
 
         [Fact]
@@ -82,8 +82,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(4, RoomState.Users[firstActiveUser].Hand.Count);
             Assert.Equal(5, RoomState.Users[secondActiveUser].Hand.Count);
 
-            Assert.Equal(900_000, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID_2].Life);
         }
 
         [Fact]
@@ -92,11 +92,14 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             // Needs to be 1HP to bypass the last stand mechanic.
             RoomState.Users[USER_ID].Life = 1;
 
+            SetUserContext(ContextUser2);
+            await MarkCurrentUserReadyAndAvailable();
+
             await FinishCountdown();
             Assert.Equal(RankedPlayStage.Ended, RoomState.Stage);
 
             Assert.Equal(0, RoomState.Users[USER_ID].Life);
-            Assert.Equal(900_000, RoomState.Users[USER_ID_2].Life);
+            Assert.Equal(1_000_000, RoomState.Users[USER_ID_2].Life);
         }
     }
 }

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -471,6 +471,38 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
+        public async Task RoundsWonIncrementedForWinner()
+        {
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 0 }
+                    ]));
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1, UserState.RoundsWon);
+            Assert.Equal(0, User2State.RoundsWon);
+        }
+
+        [Fact]
+        public async Task RoundsWonNotIncrementedOnTie()
+        {
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 1 }
+                    ]));
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(0, UserState.RoundsWon);
+            Assert.Equal(0, User2State.RoundsWon);
+        }
+
+        [Fact]
         public async Task ContinuesToRoundWarmupAndCardPlayNotInFinalRound()
         {
             await FinishCountdown();

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -465,7 +465,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task TieDamage()
+        public async Task NoDamageOnTie()
         {
             UserState.Life = 1_000_000;
             User2State.Life = 1_000_000;
@@ -477,46 +477,10 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                         new SoloScore { user_id = USER_ID_2, total_score = 500_000 },
                     ]));
 
-            RoomState.DamageMultiplier = 2;
-
             await MatchController.Stage.Enter();
 
-            Assert.Equal(950_000, UserState.Life);
-            Assert.Equal(950_000, User2State.Life);
-
-            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
-            {
-                RawDamage = 50_000,
-                Damage = 50_000,
-                OldLife = 1_000_000,
-                NewLife = 950_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Bonus,
-                        RawValue = 50_000,
-                        Damage = 50_000
-                    }
-                ]
-            });
-
-            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
-            {
-                RawDamage = 50_000,
-                Damage = 50_000,
-                OldLife = 1_000_000,
-                NewLife = 950_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Bonus,
-                        RawValue = 50_000,
-                        Damage = 50_000
-                    }
-                ]
-            });
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(1_000_000, User2State.Life);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -53,15 +53,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 500_000,
-                        Damage = 500_000
-                    }
-                ]
+                DirectDamage = 500_000
             }, User2State.DamageInfo);
         }
 
@@ -109,15 +101,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 250_000,
                 OldLife = 1_000_000,
                 NewLife = 750_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 250_000,
-                        Damage = 250_000
-                    }
-                ]
+                DirectDamage = 250_000
             }, User2State.DamageInfo);
         }
 
@@ -155,15 +139,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 250_000,
                 OldLife = 1_000_000,
                 NewLife = 750_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 250_000,
-                        Damage = 250_000
-                    }
-                ]
+                DirectDamage = 250_000
             }, User2State.DamageInfo);
         }
 
@@ -203,21 +179,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 250_000,
-                        Damage = 250_000
-                    },
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Multiplier,
-                        RawValue = 2,
-                        Damage = 250_000
-                    }
-                ]
+                DirectDamage = 250_000,
+                Multiplier = 2
             });
         }
 
@@ -257,21 +220,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 250_000,
-                        Damage = 250_000
-                    },
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Multiplier,
-                        RawValue = 2,
-                        Damage = 250_000
-                    }
-                ]
+                DirectDamage = 250_000,
+                Multiplier = 2
             });
         }
 
@@ -312,21 +262,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 50_000,
                 OldLife = 1_000_000,
                 NewLife = 950_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 10_000,
-                        Damage = 10_000
-                    },
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Multiplier,
-                        RawValue = 5,
-                        Damage = 40_000
-                    }
-                ]
+                DirectDamage = 10_000,
+                Multiplier = 5
             });
         }
 
@@ -364,15 +301,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 1_000_000,
                 OldLife = 1_000_000,
                 NewLife = 1,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 1_000_000,
-                        Damage = 1_000_000
-                    }
-                ]
+                DirectDamage = 1_000_000
             });
 
             await MatchController.Stage.Enter();
@@ -394,15 +323,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 1_000_000,
                 OldLife = 1,
                 NewLife = 0,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 1_000_000,
-                        Damage = 1_000_000
-                    }
-                ]
+                DirectDamage = 1_000_000
             });
         }
 
@@ -440,15 +361,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 1_000_000,
                 OldLife = 999_999,
                 NewLife = 0,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 1_000_000,
-                        Damage = 1_000_000
-                    }
-                ]
+                DirectDamage = 1_000_000
             });
         }
 
@@ -486,27 +399,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 550_000,
                 OldLife = 1_000_000,
                 NewLife = 450_000,
-                Sources =
-                [
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Attack,
-                        RawValue = 250_000,
-                        Damage = 250_000
-                    },
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Multiplier,
-                        RawValue = 2,
-                        Damage = 250_000
-                    },
-                    new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Bonus,
-                        RawValue = 50_000,
-                        Damage = 50_000
-                    }
-                ]
+                DirectDamage = 250_000,
+                Multiplier = 2,
+                BonusDamage = 50_000
             });
         }
 

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -182,7 +182,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                         new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
                     ]));
 
-            RoomState.DamageMultiplier = 2;
+            RoomState.DamageMultiplier = 1.5;
 
             await MatchController.Stage.Enter();
 
@@ -236,7 +236,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                         new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
                     ]));
 
-            UserState.DamageMultiplier = 2;
+            UserState.DamageMultiplier = 1.5;
 
             await MatchController.Stage.Enter();
 
@@ -296,7 +296,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             await MatchController.Stage.Enter();
 
             Assert.Equal(1_000_000, UserState.Life);
-            Assert.Equal(940_000, User2State.Life);
+            Assert.Equal(950_000, User2State.Life);
 
             Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
             {
@@ -309,9 +309,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
             {
                 RawDamage = 10_000,
-                Damage = 60_000,
+                Damage = 50_000,
                 OldLife = 1_000_000,
-                NewLife = 940_000,
+                NewLife = 950_000,
                 Sources =
                 [
                     new RankedPlayDamageSource
@@ -323,8 +323,8 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                     new RankedPlayDamageSource
                     {
                         Type = RankedPlayDamageType.Multiplier,
-                        RawValue = 6,
-                        Damage = 50_000
+                        RawValue = 5,
+                        Damage = 40_000
                     }
                 ]
             });
@@ -419,7 +419,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                         new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
                     ]));
 
-            RoomState.DamageMultiplier = 2;
+            RoomState.DamageMultiplier = 1.5;
 
             await MatchController.Stage.Enter();
 
@@ -520,9 +520,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task UserMultiplierIncreasesForWinner()
+        public async Task MultipliersIncrease()
         {
-            // Single winner.
+            // Definite winner.
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [
@@ -533,8 +533,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             await MatchController.Stage.Enter();
             await FinishCountdown();
 
-            Assert.Equal(2, UserState.DamageMultiplier);
-            Assert.Equal(1, User2State.DamageMultiplier);
+            Assert.Equal(1, RoomState.DamageMultiplier);
+            Assert.Equal(1, UserState.DamageMultiplier);
+            Assert.Equal(0.5, User2State.DamageMultiplier);
 
             // Tie.
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
@@ -547,8 +548,9 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             await MatchController.GotoStage(RankedPlayStage.Results);
             await FinishCountdown();
 
-            Assert.Equal(3, UserState.DamageMultiplier);
-            Assert.Equal(2, User2State.DamageMultiplier);
+            Assert.Equal(1.5, RoomState.DamageMultiplier);
+            Assert.Equal(1, UserState.DamageMultiplier);
+            Assert.Equal(0.5, User2State.DamageMultiplier);
         }
 
         [Fact]

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -22,6 +22,10 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task DamageTakenWithMissingScore()
         {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
             ((ResultsStage)MatchController.Stage).ScoreRetrievalWaitTime = TimeSpan.FromSeconds(1);
 
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
@@ -35,26 +39,40 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(1_000_000, UserState.Life);
             Assert.Equal(500_000, User2State.Life);
 
-            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 0,
                 Damage = 0,
                 OldLife = 1_000_000,
                 NewLife = 1_000_000,
-            });
+            }, UserState.DamageInfo);
 
-            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 500_000,
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
-            });
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 500_000,
+                        Damage = 500_000
+                    }
+                ]
+            }, User2State.DamageInfo);
         }
 
         [Fact]
         public async Task DamageTakenWithLateArrivingScore()
         {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [
@@ -77,26 +95,40 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(1_000_000, UserState.Life);
             Assert.Equal(750_000, User2State.Life);
 
-            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 0,
                 Damage = 0,
                 OldLife = 1_000_000,
                 NewLife = 1_000_000,
-            });
+            }, UserState.DamageInfo);
 
-            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 250_000,
                 Damage = 250_000,
                 OldLife = 1_000_000,
                 NewLife = 750_000,
-            });
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 250_000,
+                        Damage = 250_000
+                    }
+                ]
+            }, User2State.DamageInfo);
         }
 
         [Fact]
         public async Task DamageTakenIsDifferenceBetweenScores()
         {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [
@@ -109,26 +141,40 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
             Assert.Equal(1_000_000, UserState.Life);
             Assert.Equal(750_000, User2State.Life);
 
-            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 0,
                 Damage = 0,
                 OldLife = 1_000_000,
                 NewLife = 1_000_000,
-            });
+            }, UserState.DamageInfo);
 
-            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            Assert.Equal(new RankedPlayDamageInfo
             {
                 RawDamage = 250_000,
                 Damage = 250_000,
                 OldLife = 1_000_000,
                 NewLife = 750_000,
-            });
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 250_000,
+                        Damage = 250_000
+                    }
+                ]
+            }, User2State.DamageInfo);
         }
 
         [Fact]
-        public async Task DamageMultiplierAdded()
+        public async Task RoomDamageMultiplierAdded()
         {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [
@@ -157,12 +203,86 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 500_000,
                 OldLife = 1_000_000,
                 NewLife = 500_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 250_000,
+                        Damage = 250_000
+                    },
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Multiplier,
+                        RawValue = 2,
+                        Damage = 250_000
+                    }
+                ]
+            });
+        }
+
+        [Fact]
+        public async Task RoomUserMultiplierAdded()
+        {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
+                    ]));
+
+            UserState.DamageMultiplier = 2;
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(500_000, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 250_000,
+                Damage = 500_000,
+                OldLife = 1_000_000,
+                NewLife = 500_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 250_000,
+                        Damage = 250_000
+                    },
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Multiplier,
+                        RawValue = 2,
+                        Damage = 250_000
+                    }
+                ]
             });
         }
 
         [Fact]
         public async Task DeathDamageLeadsToLastStand()
         {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
                     [
@@ -189,6 +309,15 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 1_000_000,
                 OldLife = 1_000_000,
                 NewLife = 1,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 1_000_000,
+                        Damage = 1_000_000
+                    }
+                ]
             });
 
             await MatchController.Stage.Enter();
@@ -210,12 +339,135 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 Damage = 1_000_000,
                 OldLife = 1,
                 NewLife = 0,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 1_000_000,
+                        Damage = 1_000_000
+                    }
+                ]
+            });
+        }
+
+        [Fact]
+        public async Task BonusDamageSource()
+        {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
+                    ]));
+
+            RoomState.DamageMultiplier = 2;
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(450_000, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 300_000,
+                Damage = 550_000,
+                OldLife = 1_000_000,
+                NewLife = 450_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 250_000,
+                        Damage = 250_000
+                    },
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Multiplier,
+                        RawValue = 2,
+                        Damage = 250_000
+                    },
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Bonus,
+                        RawValue = 50_000,
+                        Damage = 50_000
+                    }
+                ]
+            });
+        }
+
+        [Fact]
+        public async Task TieDamage()
+        {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 500_000 },
+                    ]));
+
+            RoomState.DamageMultiplier = 2;
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(950_000, UserState.Life);
+            Assert.Equal(950_000, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 50_000,
+                Damage = 50_000,
+                OldLife = 1_000_000,
+                NewLife = 950_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Bonus,
+                        RawValue = 50_000,
+                        Damage = 50_000
+                    }
+                ]
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 50_000,
+                Damage = 50_000,
+                OldLife = 1_000_000,
+                NewLife = 950_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Bonus,
+                        RawValue = 50_000,
+                        Damage = 50_000
+                    }
+                ]
             });
         }
 
         [Fact]
         public async Task UserNotKilledIfQuitInFinalRound()
         {
+            User2State.Life = 1_000_000;
             UserState.Life = 0;
 
             SetUserContext(ContextUser2);

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -222,7 +222,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task RoomUserMultiplierAdded()
+        public async Task UserMultiplierAdded()
         {
             UserState.Life = 1_000_000;
             User2State.Life = 1_000_000;
@@ -270,6 +270,61 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                         Type = RankedPlayDamageType.Multiplier,
                         RawValue = 2,
                         Damage = 250_000
+                    }
+                ]
+            });
+        }
+
+        [Fact]
+        public async Task CombinedMultipliers()
+        {
+            UserState.Life = 1_000_000;
+            User2State.Life = 1_000_000;
+
+            ((ResultsStage)MatchController.Stage).BaseDamage = 0;
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 490_000 },
+                    ]));
+
+            RoomState.DamageMultiplier = 2;
+            UserState.DamageMultiplier = 3;
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(940_000, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 10_000,
+                Damage = 60_000,
+                OldLife = 1_000_000,
+                NewLife = 940_000,
+                Sources =
+                [
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Attack,
+                        RawValue = 10_000,
+                        Damage = 10_000
+                    },
+                    new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Multiplier,
+                        RawValue = 6,
+                        Damage = 50_000
                     }
                 ]
             });

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -465,6 +465,38 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
+        public async Task UserMultiplierIncreasesForWinner()
+        {
+            // Single winner.
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 250_000 },
+                    ]));
+
+            await MatchController.Stage.Enter();
+            await FinishCountdown();
+
+            Assert.Equal(2, UserState.DamageMultiplier);
+            Assert.Equal(1, User2State.DamageMultiplier);
+
+            // Tie.
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 500_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 500_000 },
+                    ]));
+
+            await MatchController.GotoStage(RankedPlayStage.Results);
+            await FinishCountdown();
+
+            Assert.Equal(3, UserState.DamageMultiplier);
+            Assert.Equal(2, User2State.DamageMultiplier);
+        }
+
+        [Fact]
         public async Task UserNotKilledIfQuitInFinalRound()
         {
             User2State.Life = 1_000_000;

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/RoundWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/RoundWarmupStageTests.cs
@@ -57,67 +57,13 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task RoundMultiplierAdjustmentOsu()
+        public async Task GlobalMultiplierIncreases()
         {
             RoomState.CurrentRound = 0;
             MatchController.Pool.ruleset_id = 0;
             await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
 
-            double[] expectedMultipliers = [1, 1, 2, 2.5, 3, 3.5, 4, 4.5, 5];
-
-            for (int i = 0; i < expectedMultipliers.Length; i++)
-            {
-                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
-
-                // Go to the next round, for the next iteration.
-                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-            }
-        }
-
-        [Fact]
-        public async Task RoundMultiplierAdjustmentTaiko()
-        {
-            RoomState.CurrentRound = 0;
-            MatchController.Pool.ruleset_id = 1;
-            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-
-            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
-
-            for (int i = 0; i < expectedMultipliers.Length; i++)
-            {
-                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
-
-                // Go to the next round, for the next iteration.
-                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-            }
-        }
-
-        [Fact]
-        public async Task RoundMultiplierAdjustmentCatch()
-        {
-            RoomState.CurrentRound = 0;
-            MatchController.Pool.ruleset_id = 2;
-            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-
-            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
-
-            for (int i = 0; i < expectedMultipliers.Length; i++)
-            {
-                Assert.Equal(expectedMultipliers[i], RoomState.DamageMultiplier);
-
-                // Go to the next round, for the next iteration.
-                await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-            }
-        }
-
-        [Fact]
-        public async Task RoundMultiplierAdjustmentMania()
-        {
-            RoomState.CurrentRound = 0;
-            MatchController.Pool.ruleset_id = 3;
-            await MatchController.GotoStage(RankedPlayStage.RoundWarmup);
-
-            double[] expectedMultipliers = [1, 1, 2.5, 3.5, 4.5, 5.5, 6.5];
+            double[] expectedMultipliers = [0.5, 1, 1.5, 2];
 
             for (int i = 0; i < expectedMultipliers.Length; i++)
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OpenSkillSharp.Models;
 using OpenSkillSharp.Rating;
-using osu.Framework.Utils;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
@@ -335,54 +334,26 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// Causes a player to take damage.
         /// </summary>
         /// <param name="userId">The user ID of the player taking damage.</param>
-        /// <param name="attackDamage">Amount of damage dealt from an attack.</param>
-        /// <param name="attackMultiplier">Scales the <paramref name="attackDamage"/> damage.</param>
-        /// <param name="bonusDamage">Amount of damage dealt from any other source. Does not scale with <paramref name="attackMultiplier"/>.</param>
+        /// <param name="directDamage">Direct amount of damage before any multipliers are added.</param>
+        /// <param name="multiplier">A multiplier of <paramref name="directDamage"/>.</param>
+        /// <param name="bonusDamage">Damage dealt for winning a round. Does not scale with <paramref name="multiplier"/>.</param>
         /// <returns>A descriptor for the damage taken.</returns>
-        public RankedPlayDamageInfo Damage(int userId, int attackDamage = 0, double attackMultiplier = 1, int bonusDamage = 0)
+        public RankedPlayDamageInfo Damage(int userId, int directDamage = 0, double multiplier = 1, int bonusDamage = 0)
         {
             RankedPlayUserInfo userInfo = State.Users[userId];
-            RankedPlayDamageInfo damageInfo = new RankedPlayDamageInfo();
 
-            if (attackDamage != 0)
+            int totalDamage = (int)Math.Ceiling(directDamage * multiplier) + bonusDamage;
+
+            RankedPlayDamageInfo damageInfo = new RankedPlayDamageInfo
             {
-                damageInfo.Sources.Add(new RankedPlayDamageSource
-                {
-                    Type = RankedPlayDamageType.Attack,
-                    RawValue = attackDamage,
-                    Damage = attackDamage
-                });
-
-                if (!Precision.AlmostEquals(1, attackMultiplier))
-                {
-                    damageInfo.Sources.Add(new RankedPlayDamageSource
-                    {
-                        Type = RankedPlayDamageType.Multiplier,
-                        RawValue = attackMultiplier,
-                        Damage = (int)Math.Ceiling(attackDamage * (attackMultiplier - 1))
-                    });
-                }
-            }
-
-            if (bonusDamage != 0)
-            {
-                damageInfo.Sources.Add(new RankedPlayDamageSource
-                {
-                    Type = RankedPlayDamageType.Bonus,
-                    RawValue = bonusDamage,
-                    Damage = bonusDamage
-                });
-            }
-
-            foreach (var source in damageInfo.Sources)
-            {
-                damageInfo.Damage += source.Damage;
-                if (source.Type != RankedPlayDamageType.Multiplier)
-                    damageInfo.RawDamage += source.Damage;
-            }
-
-            damageInfo.OldLife = userInfo.Life;
-            damageInfo.NewLife = Math.Max(damageInfo.OldLife == 1_000_000 ? 1 : 0, damageInfo.OldLife - damageInfo.Damage);
+                RawDamage = directDamage + bonusDamage,
+                Damage = totalDamage,
+                OldLife = userInfo.Life,
+                NewLife = Math.Max(userInfo.Life == 1_000_000 ? 1 : 0, userInfo.Life - totalDamage),
+                DirectDamage = directDamage,
+                Multiplier = multiplier,
+                BonusDamage = bonusDamage,
+            };
 
             userInfo.Life = damageInfo.NewLife;
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OpenSkillSharp.Models;
 using OpenSkillSharp.Rating;
+using osu.Framework.Utils;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
@@ -334,28 +335,58 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// Causes a player to take damage.
         /// </summary>
         /// <param name="userId">The user ID of the player taking damage.</param>
-        /// <param name="amount">The amount of damage (before any multipliers are added) to take.</param>
+        /// <param name="attackDamage">Amount of damage dealt from an attack.</param>
+        /// <param name="attackMultiplier">Scales the <paramref name="attackDamage"/> damage.</param>
+        /// <param name="bonusDamage">Amount of damage dealt from any other source. Does not scale with <paramref name="attackMultiplier"/>.</param>
         /// <returns>A descriptor for the damage taken.</returns>
-        public RankedPlayDamageInfo Damage(int userId, int amount)
+        public RankedPlayDamageInfo Damage(int userId, int attackDamage = 0, double attackMultiplier = 1, int bonusDamage = 0)
         {
             RankedPlayUserInfo userInfo = State.Users[userId];
+            RankedPlayDamageInfo damageInfo = new RankedPlayDamageInfo();
 
-            int rawDamage = amount;
-            int damage = (int)Math.Ceiling(rawDamage * State.DamageMultiplier);
-
-            int oldLife = userInfo.Life;
-            // Last-stand mechanic: fatal attacks bring players 1HP first before killing them.
-            int newLife = Math.Max(oldLife <= 1 ? 0 : 1, oldLife - damage);
-
-            userInfo.Life = newLife;
-
-            return new RankedPlayDamageInfo
+            if (attackDamage != 0)
             {
-                RawDamage = rawDamage,
-                Damage = damage,
-                OldLife = oldLife,
-                NewLife = newLife,
-            };
+                damageInfo.Sources.Add(new RankedPlayDamageSource
+                {
+                    Type = RankedPlayDamageType.Attack,
+                    RawValue = attackDamage,
+                    Damage = attackDamage
+                });
+
+                if (!Precision.AlmostEquals(1, attackMultiplier))
+                {
+                    damageInfo.Sources.Add(new RankedPlayDamageSource
+                    {
+                        Type = RankedPlayDamageType.Multiplier,
+                        RawValue = attackMultiplier,
+                        Damage = (int)Math.Ceiling(attackDamage * (attackMultiplier - 1))
+                    });
+                }
+            }
+
+            if (bonusDamage != 0)
+            {
+                damageInfo.Sources.Add(new RankedPlayDamageSource
+                {
+                    Type = RankedPlayDamageType.Bonus,
+                    RawValue = bonusDamage,
+                    Damage = bonusDamage
+                });
+            }
+
+            foreach (var source in damageInfo.Sources)
+            {
+                damageInfo.Damage += source.Damage;
+                if (source.Type != RankedPlayDamageType.Multiplier)
+                    damageInfo.RawDamage += source.Damage;
+            }
+
+            damageInfo.OldLife = userInfo.Life;
+            damageInfo.NewLife = Math.Max(damageInfo.OldLife <= 1 ? 0 : 1, damageInfo.OldLife - damageInfo.Damage);
+
+            userInfo.Life = damageInfo.NewLife;
+
+            return damageInfo;
         }
 
         public async Task HandleMatchCompleted()

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
@@ -31,16 +31,17 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             Debug.Assert(State.ActiveUserId != null);
             Debug.Assert(Controller.LastActivatedCard != null);
 
-            if (allPlayersReady())
+            if (Room.Users.All(isPlayerReady))
                 await Controller.GotoStage(RankedPlayStage.GameplayWarmup);
             else
             {
-                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
+                if (Room.Users.Any(isPlayerReady))
+                {
+                    foreach (var player in Room.Users.Where(u => !isPlayerReady(u)))
+                        Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
+                }
 
-                // Subtract 100K HP from every player that failed to load the beatmap in time.
-                // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
-                foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable))
-                    Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
+                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);
@@ -56,14 +57,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         private async Task continueWhenAllPlayersReady()
         {
-            if (allPlayersReady())
+            if (Room.Users.All(isPlayerReady))
                 await Finish();
         }
 
         /// <summary>
         /// Only requires players to have the beatmap, but not necessarily have it loaded yet.
         /// </summary>
-        private bool allPlayersReady()
-            => Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable);
+        private bool isPlayerReady(MultiplayerRoomUser user)
+            => user.BeatmapAvailability.State == DownloadState.LocallyAvailable;
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
@@ -40,7 +40,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable))
-                    Controller.Damage(player.UserID, bonusDamage: 100_000);
+                    Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/FinishCardPlayStage.cs
@@ -40,7 +40,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable))
-                    Controller.Damage(player.UserID, 100_000);
+                    Controller.Damage(player.UserID, bonusDamage: 100_000);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
@@ -40,7 +40,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable || p.State != MultiplayerUserState.Ready))
-                    Controller.Damage(player.UserID, 100_000);
+                    Controller.Damage(player.UserID, bonusDamage: 100_000);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
@@ -40,7 +40,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 // Subtract 100K HP from every player that failed to load the beatmap in time.
                 // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
                 foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable || p.State != MultiplayerUserState.Ready))
-                    Controller.Damage(player.UserID, bonusDamage: 100_000);
+                    Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayWarmupStage.cs
@@ -31,16 +31,17 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             Debug.Assert(State.ActiveUserId != null);
             Debug.Assert(Controller.LastActivatedCard != null);
 
-            if (allPlayersReady())
+            if (Room.Users.All(isPlayerReady))
                 await Controller.GotoStage(RankedPlayStage.Gameplay);
             else
             {
-                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
+                if (Room.Users.Any(isPlayerReady))
+                {
+                    foreach (var player in Room.Users.Where(u => !isPlayerReady(u)))
+                        Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
+                }
 
-                // Subtract 100K HP from every player that failed to load the beatmap in time.
-                // Although this seems unfair, it means that players are not able to purposefully block the others' picks.
-                foreach (var player in Room.Users.Where(p => p.BeatmapAvailability.State != DownloadState.LocallyAvailable || p.State != MultiplayerUserState.Ready))
-                    Controller.Damage(player.UserID, 100_000, State.DamageMultiplier);
+                await Controller.RemoveCards(State.ActiveUserId.Value, [Controller.LastActivatedCard]);
 
                 if (HasGameplayRoundsRemaining())
                     await Controller.GotoStage(RankedPlayStage.RoundWarmup);
@@ -56,14 +57,14 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         private async Task continueWhenAllPlayersReady()
         {
-            if (allPlayersReady())
+            if (Room.Users.All(isPlayerReady))
                 await FinishWithCountdown(TimeSpan.FromSeconds(10));
         }
 
         /// <summary>
         /// Requires all players to be in the ready state, signaling they have finished viewing the beatmap details/etc.
         /// </summary>
-        private bool allPlayersReady()
-            => Room.Users.All(u => u.BeatmapAvailability.State == DownloadState.LocallyAvailable && u.State == MultiplayerUserState.Ready);
+        private bool isPlayerReady(MultiplayerRoomUser user)
+            => user.BeatmapAvailability.State == DownloadState.LocallyAvailable && user.State == MultiplayerUserState.Ready;
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -84,12 +84,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
                 State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
             }
-            else
-            {
-                // Tie: both players take the base amount of damage.
-                foreach ((int userId, RankedPlayUserInfo info) in State.Users)
-                    info.DamageInfo = Controller.Damage(userId, bonusDamage: BaseDamage);
-            }
 
             if (Controller.Ranked)
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -107,9 +107,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            // Increase room tension by increasing the global multiplier.
-            State.DamageMultiplier += 0.5;
-
             // Award the winning player with their own multiplier boost.
             if (winningUserId != null)
                 State.Users[winningUserId.Value].DamageMultiplier += 0.5;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -83,6 +83,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 double attackMultiplier = State.DamageMultiplier + State.Users[winningUserId.Value].DamageMultiplier;
 
                 State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
+                State.Users[(int)winningUserId].RoundsWon += 1;
             }
 
             if (Controller.Ranked)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -19,6 +19,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         /// </summary>
         public TimeSpan ScoreRetrievalWaitTime { get; set; } = TimeSpan.FromSeconds(10);
 
+        /// <summary>
+        /// Base amount of damage taken per round.
+        /// </summary>
+        public int BaseDamage { get; set; } = 50_000;
+
         public ResultsStage(RankedPlayMatchController controller)
             : base(controller)
         {
@@ -53,24 +58,36 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 }
             }
 
-            // Add dummy scores for all users that did not play the map.
-            foreach ((int userId, _) in State.Users)
+            foreach ((int userId, RankedPlayUserInfo info) in State.Users)
             {
+                // Add dummy scores for all users that did not play the map.
                 if (scores.All(s => s.user_id != userId))
                     scores.Add(new SoloScore { user_id = (uint)userId });
+
+                // Populate the models with a default damage info.
+                info.DamageInfo = Controller.Damage(userId);
             }
 
-            int maxTotalScore = (int)scores.Select(s => s.total_score).Max();
+            int winningTotalScore = (int)scores.Select(s => s.total_score).Max();
+            SoloScore[] winningScores = scores.Where(u => u.total_score == winningTotalScore).ToArray();
 
-            foreach (var score in scores)
-            {
-                var userInfo = State.Users[(int)score.user_id];
-                userInfo.DamageInfo = Controller.Damage((int)score.user_id, maxTotalScore - (int)score.total_score);
-            }
-
-            SoloScore[] winningScores = scores.Where(u => u.total_score == maxTotalScore).ToArray();
             if (winningScores.Length == 1)
-                State.Users[(int)winningScores.Single().user_id].RoundsWon += 1;
+            {
+                // Single winner: losing player takes damage.
+                int winningUserId = (int)winningScores.Single().user_id;
+                SoloScore losingScore = scores.Single(u => u.user_id != winningUserId);
+
+                int attackDamage = winningTotalScore - (int)losingScore.total_score;
+                double attackMultiplier = State.DamageMultiplier;
+
+                State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
+            }
+            else
+            {
+                // Tie: both players take the base amount of damage.
+                foreach ((int userId, RankedPlayUserInfo info) in State.Users)
+                    info.DamageInfo = Controller.Damage(userId, bonusDamage: BaseDamage);
+            }
 
             if (Controller.Ranked)
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -80,7 +80,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 SoloScore losingScore = scores.Single(u => u.user_id != winningUserId);
 
                 int attackDamage = winningTotalScore - (int)losingScore.total_score;
-                double attackMultiplier = State.DamageMultiplier * State.Users[winningUserId.Value].DamageMultiplier;
+                double attackMultiplier = State.DamageMultiplier + State.Users[winningUserId.Value].DamageMultiplier;
 
                 State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
             }
@@ -107,17 +107,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
+            // Increase room tension by increasing the global multiplier.
+            State.DamageMultiplier += 0.5;
+
+            // Award the winning player with their own multiplier boost.
             if (winningUserId != null)
-            {
-                // Winner: only increase their multiplier.
                 State.Users[winningUserId.Value].DamageMultiplier += 0.5;
-            }
-            else
-            {
-                // Tie: increase multiplier of both players - this is a very edge-case scenario.
-                foreach ((_, RankedPlayUserInfo info) in State.Users)
-                    info.DamageMultiplier += 0.5;
-            }
 
             foreach ((_, RankedPlayUserInfo userInfo) in State.Users)
                 userInfo.DamageInfo = null;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -110,13 +110,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             if (winningUserId != null)
             {
                 // Winner: only increase their multiplier.
-                State.Users[winningUserId.Value].DamageMultiplier++;
+                State.Users[winningUserId.Value].DamageMultiplier += 0.5;
             }
             else
             {
                 // Tie: increase multiplier of both players - this is a very edge-case scenario.
                 foreach ((_, RankedPlayUserInfo info) in State.Users)
-                    info.DamageMultiplier++;
+                    info.DamageMultiplier += 0.5;
             }
 
             foreach ((_, RankedPlayUserInfo userInfo) in State.Users)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -32,6 +32,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
         protected override RankedPlayStage Stage => RankedPlayStage.Results;
         protected override TimeSpan Duration => TimeSpan.FromSeconds(15);
 
+        private int? winningUserId;
+
         protected override async Task Begin()
         {
             // Collect all scores from the database.
@@ -70,15 +72,15 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
             int winningTotalScore = (int)scores.Select(s => s.total_score).Max();
             SoloScore[] winningScores = scores.Where(u => u.total_score == winningTotalScore).ToArray();
+            winningUserId = winningScores.Length == 1 ? (int)winningScores.Single().user_id : null;
 
-            if (winningScores.Length == 1)
+            if (winningUserId != null)
             {
-                // Single winner: losing player takes damage.
-                int winningUserId = (int)winningScores.Single().user_id;
+                // Winner: losing player takes damage.
                 SoloScore losingScore = scores.Single(u => u.user_id != winningUserId);
 
                 int attackDamage = winningTotalScore - (int)losingScore.total_score;
-                double attackMultiplier = State.DamageMultiplier;
+                double attackMultiplier = State.DamageMultiplier * State.Users[winningUserId.Value].DamageMultiplier;
 
                 State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
             }
@@ -105,6 +107,18 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
+            if (winningUserId != null)
+            {
+                // Winner: only increase their multiplier.
+                State.Users[winningUserId.Value].DamageMultiplier++;
+            }
+            else
+            {
+                // Tie: increase multiplier of both players - this is a very edge-case scenario.
+                foreach ((_, RankedPlayUserInfo info) in State.Users)
+                    info.DamageMultiplier++;
+            }
+
             foreach ((_, RankedPlayUserInfo userInfo) in State.Users)
                 userInfo.DamageInfo = null;
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
@@ -30,6 +30,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
             State.CurrentRound++;
 
+            // Increase tension by increasing the global multiplier.
+            if (State.CurrentRound > 1)
+                State.DamageMultiplier += 0.5;
+
             // Activate the next player.
             // For the first round, this is set during room initialisation.
             if (State.CurrentRound >= 2)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/RoundWarmupStage.cs
@@ -29,7 +29,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
             }
 
             State.CurrentRound++;
-            State.DamageMultiplier = computeDamageMultiplier(State.CurrentRound);
 
             // Activate the next player.
             // For the first round, this is set during room initialisation.
@@ -47,30 +46,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 await Controller.GotoStage(RankedPlayStage.CardDiscard);
             else
                 await Controller.GotoStage(RankedPlayStage.CardPlay);
-        }
-
-        /// <summary>
-        /// Retrieves the damage multiplier for a given round.
-        /// </summary>
-        /// <param name="round">The round.</param>
-        private double computeDamageMultiplier(int round)
-        {
-            switch (Controller.Pool.ruleset_id)
-            {
-                // [ 1, 1, 2, 2.5, 3, 3.5, ... ]
-                case 0:
-                    if (round <= 2)
-                        return 1;
-
-                    return 2 + (round - 3) * 0.5;
-
-                // [ 1, 1, 2.5, 3.5, 4.5, 5.5, ... ]
-                default:
-                    if (round <= 2)
-                        return 1;
-
-                    return 2.5 + (round - 3) * 1.0;
-            }
         }
     }
 }

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -16,11 +16,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
         <PackageReference Include="OpenSkillSharp" Version="1.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.505.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.505.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.505.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.505.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.505.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.518.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2026.317.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
     </ItemGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/37740

This is a pretty drastic change to the scoring system:

- Global multiplier reduced to `0.5` and increases by `0.5` every round.
- Individual multiplier starts at `0.5` and increases by `0.5` for the winning player.
- The global and individual multipliers are added together when dealing damage.
- Bonus damage is set to a conservative `50000` per win. This is non-multiplied and applies on top of the attack damage.
- Failing to download the beatmap now causes `100000` damage multiplied by the global multiplier.

Because this is all frankensteined into the `RankedPlayDamageInfo` model, this change _is_ backwards compatible with existing clients, except that:
- They don't display the individual multipliers.
- The damage may be a bit confusing, because if there's only a 1000 score difference the client will count up to 51000.