### PR TITLE
Ranked Play: Only activate last stand at 100% HP

### DIFF
--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/FinishCardPlayStageTests.cs
@@ -95,7 +95,6 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
         {
-            // Needs to be 1HP to bypass the last stand mechanic.
             RoomState.Users[USER_ID].Life = 1;
 
             await FinishCountdown();

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/GameplayWarmupStageTests.cs
@@ -89,7 +89,6 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         [Fact]
         public async Task ContinuesToEndedWhenPlayerDiesFromFailingToBecomeReady()
         {
-            // Needs to be 1HP to bypass the last stand mechanic.
             RoomState.Users[USER_ID].Life = 1;
 
             await FinishCountdown();

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -161,7 +161,7 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
-        public async Task DeathDamageLeadsToLastStand()
+        public async Task FatalHitFromMaxHpActivatesLastStand()
         {
             Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
                     .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
@@ -209,6 +209,40 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
                 RawDamage = 1_000_000,
                 Damage = 1_000_000,
                 OldLife = 1,
+                NewLife = 0,
+            });
+        }
+
+        [Fact]
+        public async Task FatalHitFromBelowMaxHpDoesNotActivateLastStand()
+        {
+            User2State.Life = 999_999;
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1_000_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 0 },
+                    ]));
+
+            await MatchController.Stage.Enter();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(0, User2State.Life);
+
+            Assert.Equal(UserState.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 0,
+                Damage = 0,
+                OldLife = 1_000_000,
+                NewLife = 1_000_000,
+            });
+
+            Assert.Equal(User2State.DamageInfo, new RankedPlayDamageInfo
+            {
+                RawDamage = 1_000_000,
+                Damage = 1_000_000,
+                OldLife = 999_999,
                 NewLife = 0,
             });
         }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -344,8 +344,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             int damage = (int)Math.Ceiling(rawDamage * State.DamageMultiplier);
 
             int oldLife = userInfo.Life;
-            // Last-stand mechanic: fatal attacks bring players 1HP first before killing them.
-            int newLife = Math.Max(oldLife <= 1 ? 0 : 1, oldLife - damage);
+            // Last-stand mechanic: fatal attacks at 100% HP bring players 1HP.
+            int newLife = Math.Max(oldLife == 1_000_000 ? 1 : 0, oldLife - damage);
 
             userInfo.Life = newLife;
 


### PR DESCRIPTION
This will conflict with https://github.com/ppy/osu-server-spectator/pull/504, but is arguably more important.

There's been a lot of confusion about this mechanic, here's a small sampling:
- https://www.reddit.com/r/osugame/comments/1tcke0l/what_is_the_point_of_this_mechanic/
- https://www.reddit.com/r/osugame/comments/1tc19b6/the_craziest_thing_ive_seen_in_ranked_play/
- https://www.reddit.com/r/osugame/comments/1tc0tt4/my_friend_just_hit_1_hp_in_ranked/
- https://osu.ppy.sh/community/forums/topics/2198397?n=241

This is... not how I expected it to behave. It shouldn't activate every time, rather it should be for rare situations. The choice of 1M is because any other value would take explaining as to how it works as well as probably a more complex design. Maybe we don't have to explain things if they only occur in the rarest of situations.