### PR TITLE
Adjust parameters for rating model

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -98,8 +98,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             {
                 Mu = 1500,
                 Sigma = 150,
-                Beta = 75,
-                Tau = 1.5
+                Beta = 0,
+                Tau = 15.0,
+                Gamma = (_, _, _, _, _, _, _) => 1.0
             };
 
             double clearThreshold = pool.ruleset_id switch

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -386,8 +386,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                     {
                         Mu = 1500,
                         Sigma = 150,
-                        Beta = 75,
-                        Tau = 1.5
+                        Beta = 0,
+                        Tau = 15.0,
+                        Gamma = (_, _, _, _, _, _, _) => 1.0
                     };
 
                     List<matchmaking_user_stats> stats = [];


### PR DESCRIPTION
We've come up with some parameters that should better align the user rating system according to expectations, as well as to serve the system for future development of leagues.

- On average it should take 5 matches for user ratings to converge. Commonly referred to as "placement matches".
- On average it should take 4-5 wins for a user to move between divisions in a league.
- It should take around 1 month for a user's rating to decay into "unranked" territory.

These changes will be applied retroactively, during which we will also be removing restricted users from the system.

---

after studying [the paper that openskillsharp is based on](https://www.csie.ntu.edu.tw/~cjlin/papers/online_ranking/online_journal.pdf), i am proposing new parameters for the rating model.

## explanation of the rating model

short version
- _mu_ is player rating (higher is better) and _sigma_ is how confident we are in the player's rating (lower is more confident)
- _beta_ is player variance based on team environment
- _tau_ is minimum player variance (=> controls sigma floor)
- _gamma_ is sigma change multiplier

<details>
<summary>detailed changes and explanation</summary>

**player skill is defined as a normal distribution** with mean `mu` and variance `sigma`
- prior to any adjustments, the player sigma is corrected with tau `sqrt(sigma^2 + tau^2)` to prevent it from going too low. **this explains the function of tau acting as a "sigma floor" device.**

team skill is defined as a normal distribution with mean `sum(mu)` and variance `sqrt(sum(sigma^2 + beta^2))` 
- you can see beta is a fixed factor that increases the players variances by a flat amount because of factors in a team game. things like player synergy or other factors
- **because we are using this model in a 1v1 scenario, i am now 99% sure we should be using beta=0**
- even if osu became a team game, beta would be really low, because realistically the performance of one player does not affect the performance of another. beta would technically be non-zero, because of the scenario where two players are put in a team that absolutely hate their guts, which would increase variance in their individual performance based on emotional factors outside of their gameplay skill(?)

**gamma is effectively a direct multiplier to the change on sigma.** in this case, it will determine how fast a player's rating will converge. gamma=0.5 means the sigma would change half as much. the default gamma used in the model is `sigma/c`, where c is a number that represents the total team variance of all teams as `sqrt(team_sigma_1^2 + team_sigma_2^2)`
- because beta is a factor in team variance, higher beta means c would be larger and gamma would be smaller. so beta=0 will maximize gamma.
- players with lower sigma have lower gamma, so their ratings change less
- when both players have equal sigma, _this number simplifies to `gamma = 1/sqrt(2) ≈ 0.7`_

</details>

## goals the parameter changes are optimized for

on average, it should take ~5 matches for sigma to fall below 100, at which point we consider their rating accurate enough for ranking purposes. ("placement matches")
- gamma controls how fast sigma should converge. we choose the maximum gamma of 1.0

on average, we want the average user to take 4-5 wins to rank up by 100 rating points
- tau controls the sigma floor, which determines the minimum amount of rating a player can win/lose after playing actively (outside of rating imbalance obviously)

proposal
- beta 75.0 => 0.0 (remove team variance factor)
- tau 1.5 => 15.0 (compensate for team variance by increasing player variance)
- gamma ~0.7 => 1.0 (increase convergence speed of unrated players)

## simulation data

newly ranked player with mu=1500.0 sigma=150.0 wins and loses matches alternatingly against another (fixed) user with mu=1500.0 sigma=80.0

```
#1      mu 1566.3       (+66)   ± sigma 135.4   (-15)
#5      mu 1537.0       (+43)   ± sigma 97.0    (-8)
#10     mu 1493.7       (-30)   ± sigma 73.4    (-3)
#15     mu 1515.0       (+21)   ± sigma 62.5    (-2)
#20     mu 1493.5       (-19)   ± sigma 57.2    (-1)
#25     mu 1510.2       (+17)   ± sigma 54.6    (-+)
#30     mu 1493.0       (-16)   ± sigma 53.3    (-+)
```

- it takes 5 games to drop below 100 sigma
- it takes ~35 games to reach the rating floor (sigma decrease <0.01)
- rating changes are roughly between 20-30, assuming most somewhat active users are around 60-80 sigma. this gives us roughly 3-5 games to rank up 100 rating points
  - however, this depends on how strong the sigma decay is and how much we want users to play on average (see next section)

## missing mechanics not present in this pr

rating/league/division should be hidden before sigma is <100 or 5 games have been played
- early ratings are practically meaningless
- rating number should not be hidden (community doesnt like hidden numbers), but definitely be suffixed with `*` or `?`
- done on website, but needs to be consistent in-game as well
- should also remove their leaderboard spot / number rank
- incentive for new players to play with a goal (finish 5 placement games) where every game has a higher chance of a better matchup, rather than players trying the mode once and then dipping out directly

sigma decay, simply increment sigma by some number per day
- the idea is that every day we grow less confident about a player's rating the more days pass by without any matches recorded
- incentive to play more actively
- needs to be implemented as a cron-kinda thing? i have no clue about how exactly you want this implemented
- should take roughly 30 days of inactivity for player to become unranked. ballpark value of +1 sigma/day. a 70 sigma player would become unranked after 1 month. a player who plays 1 match/day will stabilize at roughly 60 sigma.