### PR TITLE
Pool ranked play based on normally distributed difficulty

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -147,18 +147,45 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Pick from maps around the minimum rating.
             double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
 
-            // Logistic curve that is narrow (50pts) at lower ratings where there are many beatmaps,
-            // and broader (100pts) at higher ratings where there are fewer beatmaps.
-            double ratingSig = 50 + 50 / (1 + Math.Exp(-0.01 * (userRatingMu - 1800)));
+            const double rating_sig = 100;
 
-            return beatmaps.Values.OrderByDescending(b =>
-                           {
-                               // The clamp attempts to ensure all beatmaps are given some chance of being selected.
-                               double weight = Math.Clamp(Math.Exp(-Math.Pow(b.rating - userRatingMu, 2) / (2 * ratingSig * ratingSig)), 1e-6, 1);
-                               return Math.Pow(Random.Shared.NextDouble(), 1.0 / weight);
-                           })
-                           .Take(count)
-                           .ToArray();
+            HashSet<matchmaking_pool_beatmap> maps = [];
+
+            foreach (double rating in randomNumberSamples(count, userRatingMu, rating_sig))
+            {
+                // Could optimize with binary search?
+                var map = beatmaps.Values
+                                  .Where(b => !maps.Contains(b))
+                                  .MinBy(b => Math.Abs(b.rating - rating));
+
+                if (map == null)
+                    break; // happens when more maps are requested than are available
+
+                maps.Add(map);
+            }
+
+            return maps.ToArray();
+        }
+
+        private static IEnumerable<double> randomNumberSamples(int n, double mu, double sigma)
+        {
+            return Enumerable.Range(0, (int)Math.Ceiling((double)n / 2))
+                             .SelectMany(_ => boxMuller())
+                             .Take(n) // Box-Muller returns pairs of numbers, only take as many as we need
+                             .Select(x => mu + sigma * x);
+        }
+
+        // The Box–Muller transform [..] is a random number sampling method for generating pairs of
+        // independent, standard, normally distributed (zero expectation, unit variance) random numbers,
+        // given a source of uniformly distributed random numbers.
+        // https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
+        private static double[] boxMuller()
+        {
+            double theta = 2 * Math.PI * Random.Shared.NextDouble();
+            double r = Math.Sqrt(-2 * Math.Log(Random.Shared.NextDouble()));
+            double x = r * Math.Cos(theta);
+            double y = r * Math.Sin(theta);
+            return [x, y];
         }
 
         public readonly record struct BeatmapLookupKey(int BeatmapId, string Mods);


### PR DESCRIPTION
The expectation of the bell curve in the ranked play intro sequence implies that the maps are picked normally distributed based on their difficulty. Current algorithm generates a normally-distributed number for every map based on map rating, then picks the maps with the highest value. This overweights rating ranges that have more maps. 

Example:
- 1300 rating: 50 maps
- 1500 rating: 10 maps

When pooling for 1400 rating, this example would have a 5x higher chance of pooling 1300 rated maps.

This new implementation follows the expected bell curve, by picking a random rating normally distributed, and _then_ picking the map closest to the generated rating.

Parameters:
- `rating_sig = 100`: Variance in context of normal distribution.

Currently set to 100, but could revert back to logistic curve from previous implementation, or simply increase to widen the breadth of ratings generated. Have to do some testing.