### PR TITLE
Lower chance of osu! standard low elo maps that gained a lot of rating in ranked play pool

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -81,8 +81,8 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         {
             MatchmakingBeatmapSelector selector = new MatchmakingBeatmapSelector(new matchmaking_pool(),
             [
-                new matchmaking_pool_beatmap { beatmap_id = 0, rating = 1000 },
-                new matchmaking_pool_beatmap { beatmap_id = 1, rating = 1000 },
+                new matchmaking_pool_beatmap { beatmap_id = 0, rating = 1000, difficultyrating = 10.0 },
+                new matchmaking_pool_beatmap { beatmap_id = 1, rating = 1000, difficultyrating = 10.0 },
             ], new Mock<IDatabaseFactory>().Object);
 
             matchmaking_pool_beatmap[] result = selector.GetAppropriateBeatmaps(50, [new EloRating(1000, 350), new EloRating(1000, 350)]);

--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingBeatmapSelectorTest.cs
@@ -116,5 +116,40 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             Assert.Equal(1234, result.Single().beatmap_id);
             Assert.Equal(1, result.Single().playmode);
         }
+
+        [Fact]
+        public void RatingDiffWeight()
+        {
+            var deflatedRatingBeatmap = new matchmaking_pool_beatmap
+            {
+                rating = 1200,
+                difficultyrating = 10.0,
+                playmode = 0
+            };
+
+            double deflateWeight = MatchmakingBeatmapSelector.RatingDiffWeight(deflatedRatingBeatmap, 1000);
+            Assert.Equal(1.0, deflateWeight);
+
+            var inflatedRatingBeatmap = new matchmaking_pool_beatmap
+            {
+                rating = 1200,
+                difficultyrating = 0.0,
+                playmode = 0
+            };
+
+            double inflateWeight = MatchmakingBeatmapSelector.RatingDiffWeight(inflatedRatingBeatmap, 1000);
+            Assert.InRange(inflateWeight, 0.25, 0.5);
+
+            double highTargetWeight = MatchmakingBeatmapSelector.RatingDiffWeight(inflatedRatingBeatmap, 1700);
+            Assert.InRange(highTargetWeight, 0.99, 1.0);
+
+            var inflatedNonStandardBeatmap = new matchmaking_pool_beatmap(inflatedRatingBeatmap)
+            {
+                playmode = 1
+            };
+
+            double nonStandardWeight = MatchmakingBeatmapSelector.RatingDiffWeight(inflatedNonStandardBeatmap, 1000);
+            Assert.Equal(1.0, nonStandardWeight);
+        }
     }
 }

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
@@ -69,5 +69,10 @@ namespace osu.Server.Spectator.Database.Models
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
         public override int GetHashCode()
             => HashCode.Combine(id, pool_id, beatmap_id, mods);
+
+        public static double DifficultyRatingToEloRating(double difficultyRating)
+        {
+            return (int)Math.Round(800 + 500 * (Math.Exp(0.16 * difficultyRating) - 1));
+        }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -146,17 +146,24 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         public matchmaking_pool_beatmap[] GetAppropriateBeatmaps(int count, EloRating[] ratings)
         {
             // Pick from maps around the minimum rating.
-            double userRatingMu = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
+            double targetRating = ratings.Select(r => r.Mu).DefaultIfEmpty(1500).Min();
 
             const double rating_sig = 100;
 
             HashSet<matchmaking_pool_beatmap> maps = [];
 
-            foreach (double rating in randomNumberSamples(count, userRatingMu, rating_sig))
+            foreach (double rating in randomNumberSamples(count, targetRating, rating_sig))
             {
                 // Could optimize with binary search?
                 var map = beatmaps.Values
                                   .Where(b => !maps.Contains(b))
+                                  .Where(b =>
+                                  {
+                                      double p = mapProbability(b);
+                                      if (1 <= p) return true;
+
+                                      return Random.Shared.NextDouble() <= p;
+                                  })
                                   .MinBy(b => Math.Abs(b.rating - rating));
 
                 if (map == null)
@@ -166,6 +173,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             }
 
             return maps.ToArray();
+        }
+
+        private static double mapProbability(matchmaking_pool_beatmap map)
+        {
+            return 1.0;
         }
 
         private static IEnumerable<double> randomNumberSamples(int n, double mu, double sigma)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -159,7 +159,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                   .Where(b => !maps.Contains(b))
                                   .Where(b =>
                                   {
-                                      double p = BeatmapProbability(b, targetRating);
+                                      double p = BeatmapWeight(b, targetRating);
                                       return p switch
                                       {
                                           >= 1 => true,
@@ -184,12 +184,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <param name="beatmap">Map to calculate probability for</param>
         /// <param name="targetRating">Rating to target the pool for</param>
         /// <returns>Number between 0 and 1 representing the probability</returns>
-        public static double BeatmapProbability(matchmaking_pool_beatmap beatmap, double targetRating)
+        public static double BeatmapWeight(matchmaking_pool_beatmap beatmap, double targetRating)
         {
-            return RatingDiffProbability(beatmap, targetRating);
+            return RatingDiffWeight(beatmap, targetRating);
         }
 
-        public static double RatingDiffProbability(matchmaking_pool_beatmap beatmap, double targetRating)
+        public static double RatingDiffWeight(matchmaking_pool_beatmap beatmap, double targetRating)
         {
             // The goal is to improve user perception of standard pools in lower elo.
             // The lower the target elo, the less likely we want to show massive positive rating outliers.
@@ -202,10 +202,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Parameters for logistic curve
             const double target_center = 1300;
             const double target_radius = 75;
-            const double min_probability = 0.25;
+            const double min_weight = 0.25;
 
             // Use logistic curve: targetRating => [min_probability, 1.0]
-            double lowerBound = min_probability + (1 - min_probability) / (1 + Math.Exp(-(targetRating - target_center) / target_radius));
+            double lowerBound = min_weight + (1 - min_weight) / (1 + Math.Exp(-(targetRating - target_center) / target_radius));
 
             const double max_rating_diff = 300;
             double ratingDiff = beatmap.rating - originalRating; // >0 because of early return earlier
@@ -213,9 +213,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             // Map ratingDiff => [lowerBound, 1.0]
             double relativeRatingDiff = Math.Clamp(ratingDiff / max_rating_diff, 0, 1);
             double inverseRatingDiffSquared = Math.Pow(1 - relativeRatingDiff, 2);
-            double probability = lowerBound + (1 - lowerBound) * inverseRatingDiffSquared;
+            double weight = lowerBound + (1 - lowerBound) * inverseRatingDiffSquared;
 
-            return probability;
+            return weight;
         }
 
         private static IEnumerable<double> randomNumberSamples(int n, double mu, double sigma)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -159,10 +159,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                   .Where(b => !maps.Contains(b))
                                   .Where(b =>
                                   {
-                                      double p = mapProbability(b);
-                                      if (1 <= p) return true;
-
-                                      return Random.Shared.NextDouble() <= p;
+                                      double p = beatmapProbability(b, targetRating);
+                                      return p switch
+                                      {
+                                          >= 1 => true,
+                                          <= 0 => false,
+                                          _ => Random.Shared.NextDouble() <= p
+                                      };
                                   })
                                   .MinBy(b => Math.Abs(b.rating - rating));
 
@@ -175,9 +178,41 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             return maps.ToArray();
         }
 
-        private static double mapProbability(matchmaking_pool_beatmap map)
+        /// <summary>
+        /// Calculates the threshold for an extra probability check a map must pass in order to be considered for pooling.
+        /// </summary>
+        /// <param name="beatmap">Map to calculate probability for</param>
+        /// <param name="targetRating">Rating to target the pool for</param>
+        /// <returns>Number between 0 and 1 representing the probability</returns>
+        private static double beatmapProbability(matchmaking_pool_beatmap beatmap, double targetRating)
         {
-            return 1.0;
+            // The goal is to improve user perception of standard pools in lower elo.
+            // The lower the target elo, the less likely we want to show massive positive rating outliers.
+
+            const double min_target = 800;
+            const double max_target = 1500;
+            const double max_map_diff = 300;
+            const double min_probability = 0.25;
+
+            if (beatmap.playmode == 0) return 1;
+            if (targetRating >= max_target) return 1;
+
+            double originalRating = matchmaking_pool_beatmap.DifficultyRatingToEloRating(beatmap.difficultyrating);
+            if (originalRating < beatmap.rating) return 1;
+
+            // Step 1: Determine the size of the probability interval
+            // Scale the target rating: [min_target, max_target] -> [0, 1]
+            double relativeTargetRating = Math.Clamp((max_target - beatmap.rating) / (max_target - min_target), 0, 1);
+            // Scale [0, 1] -> [min_probability, 1] (inverse)
+            double lowerBound = min_probability + (1 - min_probability) * (1 - relativeTargetRating);
+
+            // Step 2: Determine what point to use in the probability interval
+            // Scale rating diff: [0, 300] -> [0, 1]
+            double relativeMapRatingDiff = Math.Clamp((beatmap.rating - originalRating) / max_map_diff, 0, 1);
+            // Scale [0, 1] -> [lowerBound, 1]  (inverse)
+            double probability = lowerBound + (1 - lowerBound) * (1 - relativeMapRatingDiff);
+
+            return probability;
         }
 
         private static IEnumerable<double> randomNumberSamples(int n, double mu, double sigma)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -58,7 +58,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                         playmode = b.playmode,
                         checksum = b.checksum,
                         difficultyrating = b.difficultyrating,
-                        rating = (int)Math.Round(800 + 500 * (Math.Exp(0.16 * b.difficultyrating) - 1)),
+                        rating = matchmaking_pool_beatmap.DifficultyRatingToEloRating(b.difficultyrating),
                     })
                     .ToDictionary(b => b.beatmap_id, b => b);
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -159,7 +159,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                                   .Where(b => !maps.Contains(b))
                                   .Where(b =>
                                   {
-                                      double p = beatmapProbability(b, targetRating);
+                                      double p = BeatmapProbability(b, targetRating);
                                       return p switch
                                       {
                                           >= 1 => true,
@@ -184,33 +184,36 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <param name="beatmap">Map to calculate probability for</param>
         /// <param name="targetRating">Rating to target the pool for</param>
         /// <returns>Number between 0 and 1 representing the probability</returns>
-        private static double beatmapProbability(matchmaking_pool_beatmap beatmap, double targetRating)
+        public static double BeatmapProbability(matchmaking_pool_beatmap beatmap, double targetRating)
+        {
+            return RatingDiffProbability(beatmap, targetRating);
+        }
+
+        public static double RatingDiffProbability(matchmaking_pool_beatmap beatmap, double targetRating)
         {
             // The goal is to improve user perception of standard pools in lower elo.
             // The lower the target elo, the less likely we want to show massive positive rating outliers.
 
-            const double min_target = 800;
-            const double max_target = 1500;
-            const double max_map_diff = 300;
-            const double min_probability = 0.25;
-
-            if (beatmap.playmode == 0) return 1;
-            if (targetRating >= max_target) return 1;
+            if (beatmap.playmode != 0) return 1;
 
             double originalRating = matchmaking_pool_beatmap.DifficultyRatingToEloRating(beatmap.difficultyrating);
-            if (originalRating < beatmap.rating) return 1;
+            if (beatmap.rating <= originalRating) return 1;
 
-            // Step 1: Determine the size of the probability interval
-            // Scale the target rating: [min_target, max_target] -> [0, 1]
-            double relativeTargetRating = Math.Clamp((max_target - beatmap.rating) / (max_target - min_target), 0, 1);
-            // Scale [0, 1] -> [min_probability, 1] (inverse)
-            double lowerBound = min_probability + (1 - min_probability) * (1 - relativeTargetRating);
+            // Parameters for logistic curve
+            const double target_center = 1300;
+            const double target_radius = 75;
+            const double min_probability = 0.25;
 
-            // Step 2: Determine what point to use in the probability interval
-            // Scale rating diff: [0, 300] -> [0, 1]
-            double relativeMapRatingDiff = Math.Clamp((beatmap.rating - originalRating) / max_map_diff, 0, 1);
-            // Scale [0, 1] -> [lowerBound, 1]  (inverse)
-            double probability = lowerBound + (1 - lowerBound) * (1 - relativeMapRatingDiff);
+            // Use logistic curve: targetRating => [min_probability, 1.0]
+            double lowerBound = min_probability + (1 - min_probability) / (1 + Math.Exp(-(targetRating - target_center) / target_radius));
+
+            const double max_rating_diff = 300;
+            double ratingDiff = beatmap.rating - originalRating; // >0 because of early return earlier
+
+            // Map ratingDiff => [lowerBound, 1.0]
+            double relativeRatingDiff = Math.Clamp(ratingDiff / max_rating_diff, 0, 1);
+            double inverseRatingDiffSquared = Math.Pow(1 - relativeRatingDiff, 2);
+            double probability = lowerBound + (1 - lowerBound) * inverseRatingDiffSquared;
 
             return probability;
         }


### PR DESCRIPTION
A stopgap measure to improve player retention by hiding maps that _seem_ too easy (scenario of "5* player getting 3* map"). Most 3* maps tend to be underweighted by 0.5*.

Parameters:
- `min_weight = 0.25` : Minimum pick weight a beatmap can ever reach.
- `target_center = 1300` and `target_radius = 75`: Target rating range over which to modulate the lower bound
- `max_rating_diff = 300`: How large the rating diff needs to be in order to assign the minimum weight

<img width="863" height="449" alt="image" src="https://github.com/user-attachments/assets/d0df617e-ba09-46ce-9274-6474651db138" />

To be honest, this plays double duty in being a change I personally dislike. I don't like changes that only affect a single ruleset, and I don't like changes that alter the appearance rate of maps. But it really feels somewhat necessary to improve the future prospects of the game.