### PR TITLE
Fix duels not appearing in recent history

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -84,10 +84,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             if (!poolLobbies.TryGetValue(poolId, out MatchmakingLobby? lobby))
                 return Task.CompletedTask;
 
+            lobby.RecordMatch(status);
+
             if (!poolQueues.TryGetValue(poolId, out MatchmakingQueue? queue))
                 return Task.CompletedTask;
-
-            lobby.RecordMatch(status);
 
             if (status is RankedPlayRoomState rpState)
             {


### PR DESCRIPTION
The case where a lobby _does_ exist but a queue _does not_ exist is possible in exactly one scenario: duels. For duels, the queues are ephemeral for the duration of the queue.