### PR TITLE
Fill out properties missing in server-side replays if client is sending them

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
     </ItemGroup>
 
 </Project>

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
     </ItemGroup>
 
 </Project>

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Osu.Mods;
@@ -257,61 +256,6 @@ namespace osu.Server.Spectator.Tests
             await uploadsCompleteAsync();
 
             mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.Mods.Any(m => m is OsuModTouchDevice))), Times.Once);
-            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
-        }
-
-        [Fact]
-        public async Task FrameBundlesFromOldClientsWithoutModsHandledCorrectly()
-        {
-            scoreUploader.SaveReplays = true;
-
-            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
-            Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
-            mockClients.Setup(clients => clients.All).Returns(mockReceiver.Object);
-            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockReceiver.Object);
-
-            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
-
-            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
-            hub.Context = mockContext.Object;
-            hub.Clients = mockClients.Object;
-
-            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
-            {
-                id = 456,
-                passed = true
-            }));
-
-            await hub.BeginPlaySession(1234, new SpectatorState
-            {
-                BeatmapID = beatmap_id,
-                RulesetID = 0,
-                State = SpectatedUserState.Playing,
-                Mods = [new APIMod(new OsuModDoubleTime())]
-            });
-
-            var frameHeader = new FrameHeader(new ScoreInfo
-            {
-                Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = 1 }
-            }, new ScoreProcessorStatistics())
-            {
-                Mods = null, // simulate older client that did not send this property over wire
-            };
-
-            await hub.SendFrameData(new FrameDataBundle(
-                frameHeader,
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
-
-            await hub.EndPlaySession(new SpectatorState
-            {
-                BeatmapID = beatmap_id,
-                RulesetID = 0,
-                State = SpectatedUserState.Quit,
-            });
-
-            await uploadsCompleteAsync();
-
-            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.Mods.Any(m => m is OsuModDoubleTime))), Times.Once);
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -259,6 +259,112 @@ namespace osu.Server.Spectator.Tests
             mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
         }
 
+        [Fact]
+        public async Task TotalScoreWithoutModsAndPausesStoredToReplay()
+        {
+            scoreUploader.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.All).Returns(mockReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockReceiver.Object);
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            await hub.SendFrameData(new FrameDataBundle(
+                new FrameHeader(new ScoreInfo
+                {
+                    Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = 1 },
+                    TotalScoreWithoutMods = 123_321,
+                    TotalScore = 246_642,
+                    Pauses = { 1000, 2000 },
+                }, new ScoreProcessorStatistics()),
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Quit,
+            });
+
+            await uploadsCompleteAsync();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item =>
+                item.Score.ScoreInfo.TotalScoreWithoutMods == 123_321 && item.Score.ScoreInfo.Pauses.Count == 2)), Times.Once);
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
+        }
+
+        [Fact]
+        public async Task FrameBundlesFromOldClientsThatDoNotContainTotalScoreWithoutModsOrPausesAreHandled()
+        {
+            scoreUploader.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.All).Returns(mockReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockReceiver.Object);
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            await hub.SendFrameData(new FrameDataBundle(
+                new FrameHeader(new ScoreInfo
+                {
+                    Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = 1 }
+                }, new ScoreProcessorStatistics())
+                {
+                    TotalScoreWithoutMods = null,
+                    Pauses = null,
+                },
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Quit,
+            });
+
+            await uploadsCompleteAsync();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.IsAny<ScoreUploader.UploadItem>()), Times.Once);
+            mockReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Quit)), Times.Once());
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Scoring;
@@ -131,6 +132,17 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 score.ScoreInfo.Combo = data.Header.Combo;
                 score.ScoreInfo.TotalScore = data.Header.TotalScore;
                 score.ScoreInfo.APIMods = data.Header.Mods;
+
+                // handle frame bundles from old clients that don't send both of these properties
+                // null checks can be elided when property is made non-nullable on `FrameDataBundle` 20261126
+                if (data.Header.TotalScoreWithoutMods != null)
+                    score.ScoreInfo.TotalScoreWithoutMods = data.Header.TotalScoreWithoutMods.Value;
+
+                if (data.Header.Pauses != null)
+                {
+                    score.ScoreInfo.Pauses.Clear();
+                    score.ScoreInfo.Pauses.AddRange(data.Header.Pauses);
+                }
 
                 score.Replay.Frames.AddRange(data.Frames);
 

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -130,11 +130,7 @@ namespace osu.Server.Spectator.Hubs.Spectator
                 score.ScoreInfo.MaxCombo = data.Header.MaxCombo;
                 score.ScoreInfo.Combo = data.Header.Combo;
                 score.ScoreInfo.TotalScore = data.Header.TotalScore;
-
-                // null here means the frame bundle is from an old client that can't send mod data
-                // can be removed (along with making property non-nullable on `FrameDataBundle`) 20250407
-                if (data.Header.Mods != null)
-                    score.ScoreInfo.APIMods = data.Header.Mods;
+                score.ScoreInfo.APIMods = data.Header.Mods;
 
                 score.Replay.Frames.AddRange(data.Frames);
 

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -16,11 +16,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
         <PackageReference Include="OpenSkillSharp" Version="1.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.518.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.518.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.518.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.518.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.518.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.527.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.527.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.527.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.527.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2026.317.0" />
         <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
     </ItemGroup>


### PR DESCRIPTION
- Related to https://github.com/ppy/osu/issues/37818
- Server-side counterpart of https://github.com/ppy/osu/pull/37919
- [x] Depends on NuGet package with above change