### PR TITLE
Disable requeueing users when cancelling duels 

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Moq;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Requests;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Tests.Multiplayer;
 using Xunit;
@@ -166,6 +167,42 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             User2Receiver.Verify(u => u.MatchmakingRoomReady(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
             User2Receiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
             User2Receiver.Verify(u => u.MatchmakingQueueLeft(), Times.Once);
+        }
+
+        [Fact]
+        public async Task CancelledDuelDoesNotRequeue()
+        {
+            Guid duelId = Guid.NewGuid();
+
+            User2Receiver.Setup(u => u.MatchmakingDuelIssued(It.IsAny<MatchmakingDuelIssuedParams>()))
+                         .Callback<MatchmakingDuelIssuedParams>(p => duelId = p.Id);
+
+            await MatchmakingBackgroundService.IssueDuelAsync(UserStates.GetEntityUnsafe(USER_ID)!, new MatchmakingIssueDuelRequest
+            {
+                PoolId = 1,
+                UserId = USER_ID_2
+            });
+
+            User2Receiver.Verify(u => u.MatchmakingDuelIssued(It.IsAny<MatchmakingDuelIssuedParams>()), Times.Once);
+
+            SetUserContext(ContextUser2);
+
+            await MatchmakingBackgroundService.AcceptDuelAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, new MatchmakingAcceptDuelRequest
+            {
+                Id = duelId
+            });
+
+            await MatchmakingBackgroundService.ExecuteOnceAsync();
+
+            UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
+            User2Receiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
+
+            SetUserContext(ContextUser);
+            User2Receiver.Invocations.Clear();
+
+            await MatchmakingBackgroundService.DeclineInvitationAsync(UserStates.GetEntityUnsafe(USER_ID)!);
+
+            User2Receiver.Verify(u => u.MatchmakingQueueStatusChanged(It.IsAny<MatchmakingQueueStatus.Searching>()), Times.Never);
         }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -43,6 +43,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         public int Top100Rating { get; set; } = 99999;
 
         /// <summary>
+        /// Whether to requeue users when a player declines the queue invitation.
+        /// </summary>
+        public bool RequeueOnDecline { get; set; } = true;
+
+        /// <summary>
         /// All users active in the matchmaking queue.
         /// </summary>
         private readonly HashSet<MatchmakingQueueUser> matchmakingUsers = new HashSet<MatchmakingQueueUser>();
@@ -341,15 +346,28 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 {
                     bundle.RecycledGroups.Add(group.Key!);
 
-                    foreach (var user in group.Key!.Users)
+                    if (RequeueOnDecline)
                     {
-                        if (!matchmakingUsers.Contains(user))
-                            continue;
+                        foreach (var user in group.Key!.Users)
+                        {
+                            if (!matchmakingUsers.Contains(user))
+                                continue;
 
-                        user.Group = null;
-                        user.InviteAccepted = false;
+                            user.Group = null;
+                            user.InviteAccepted = false;
 
-                        bundle.AddedUsers.Add(user);
+                            bundle.AddedUsers.Add(user);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var user in group.Key!.Users)
+                        {
+                            if (!matchmakingUsers.Remove(user))
+                                continue;
+
+                            bundle.RemovedUsers.Add(user);
+                        }
                     }
                 }
             }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -404,8 +404,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
         private async Task processBundle(MatchmakingQueueUpdateBundle bundle)
         {
-            foreach (var user in bundle.DeclinedUsers)
-                BanUser(user.UserId, TimeSpan.FromMinutes(1));
+            if (bundle.Queue.Pool.ranked)
+            {
+                foreach (var user in bundle.DeclinedUsers)
+                    BanUser(user.UserId, TimeSpan.FromMinutes(1));
+            }
 
             foreach (var user in bundle.RemovedUsers)
                 await hub.Clients.Client(user.Identifier).SendAsync(nameof(IMatchmakingClient.MatchmakingQueueLeft));

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -205,11 +205,17 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 if (!pool.active)
                     throw new InvalidStateException("The selected matchmaking pool is no longer active.");
 
-                // The user is added to the queue before the queue is added to the dictionary
-                // so that the periodic update doesn't discard the queue due to a lack of users.
-                MatchmakingQueue queue = new MatchmakingQueue(pool) { SearchTimeout = TimeSpan.FromMinutes(5) };
+                MatchmakingQueue queue = new MatchmakingQueue(pool)
+                {
+                    SearchTimeout = TimeSpan.FromMinutes(5),
+                    RequeueOnDecline = false
+                };
+
                 MatchmakingQueueUser user = await createUserAsync(state, pool);
                 user.BanEndTime = DateTimeOffset.MinValue;
+
+                // The user is added to the queue before the queue is added to the dictionary
+                // so that the periodic update doesn't discard the queue due to a lack of users.
                 MatchmakingQueueUpdateBundle updateBundle = queue.Add(user);
 
                 Guid duelGuid = Guid.NewGuid();


### PR DESCRIPTION
If a player cancels an active duel it should no longer:
- Globally ban them from matchmaking.
- Return the other person to the queue (in which they'll be the permanent sole searching user).