### PR TITLE
Give ranked play rooms a default end date

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -496,8 +496,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 // Initialise the room and users
                 using (var roomUsage = await rooms.GetForUse(roomId, true))
                 {
-                    roomUsage.Item = await ServerMultiplayerRoom.InitialiseMatchmakingRoomAsync(roomId, roomController, databaseFactory, eventDispatcher, loggerFactory, bundle.Queue.Pool,
+                    ServerMultiplayerRoom room = await ServerMultiplayerRoom.InitialiseMatchmakingRoomAsync(roomId, roomController, databaseFactory, eventDispatcher, loggerFactory, bundle.Queue.Pool,
                         group.Users, beatmapSelector, this);
+
+                    await room.SetEndDateAsync(DateTimeOffset.Now + TimeSpan.FromMinutes(5));
+
+                    roomUsage.Item = room;
                 }
 
                 await hub.Clients.Group(group.Identifier).SendAsync(nameof(IMatchmakingClient.MatchmakingRoomReady), roomId, roomPassword);


### PR DESCRIPTION
Supplementary effort to attempt to fix ranked play rooms getting stuck in the database. In all cases I've checked, no users have joined the room, indicating some client-side issue occurred:

- https://osu.ppy.sh/multiplayer/rooms/3027897
- https://osu.ppy.sh/multiplayer/rooms/3027909
- https://osu.ppy.sh/multiplayer/rooms/3030791
- https://osu.ppy.sh/multiplayer/rooms/3033403

Etc...

They will still have their end date nulled when any user joins the room, via:

https://github.com/ppy/osu-server-spectator/blob/cef915ad5f2da08156b6dffb5eba0aa537132306/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerRoomController.cs#L99-L103