### PR TITLE
Update packages

### DIFF
--- a/SampleMultiplayerClient/SampleMultiplayerClient.csproj
+++ b/SampleMultiplayerClient/SampleMultiplayerClient.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
     </ItemGroup>
 

--- a/SampleSpectatorClient/SampleSpectatorClient.csproj
+++ b/SampleSpectatorClient/SampleSpectatorClient.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
     </ItemGroup>
 

--- a/osu.Server.Spectator.PublicAPIDocs/osu.Server.Spectator.PublicAPIDocs.csproj
+++ b/osu.Server.Spectator.PublicAPIDocs/osu.Server.Spectator.PublicAPIDocs.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" PrivateAssets="analyzers;build" />
       <!-- end of pin block -->
-      <PackageReference Include="System.Text.Json" Version="10.0.5" />
+      <PackageReference Include="System.Text.Json" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
+++ b/osu.Server.Spectator.Tests/osu.Server.Spectator.Tests.csproj
@@ -10,13 +10,13 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/osu.Server.Spectator/osu.Server.Spectator.csproj
+++ b/osu.Server.Spectator/osu.Server.Spectator.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="4.0.19" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.24.3" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-        <PackageReference Include="Dapper" Version="2.1.72" />
-        <PackageReference Include="DogStatsD-CSharp-Client" Version="9.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
+        <PackageReference Include="Dapper" Version="2.1.79" />
+        <PackageReference Include="DogStatsD-CSharp-Client" Version="9.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="OpenSkillSharp" Version="1.1.0" />
         <PackageReference Include="ppy.osu.Game" Version="2026.527.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.527.0" />
@@ -22,7 +22,7 @@
         <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.527.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.527.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2026.317.0" />
-        <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
+        <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated
-------
| package | old version(s) | new version | downloads | released on | changelogs |
| :- | :-: | :-: | -: | :-: | :-: |
| AWSSDK.S3 | 4.0.19 | [4.0.24.3](https://www.nuget.org/packages/AWSSDK.S3/4.0.24.3) | >24.9k | 2026-06-10 | [link](https://github.com/aws/aws-sdk-net/releases/tag/4.0.267.0) |
| coverlet.collector | 8.0.0 | [10.0.1](https://www.nuget.org/packages/coverlet.collector/10.0.1) | >3.7M | 2026-05-18 | [link](https://github.com/coverlet-coverage/coverlet/releases/tag/v10.0.1) |
| Dapper | 2.1.72 | [2.1.79](https://www.nuget.org/packages/Dapper/2.1.79) | >1.4M | 2026-05-16 | [link](https://github.com/DapperLib/Dapper/releases/tag/2.1.79) |
| DogStatsD-CSharp-Client | 9.0.0 | [9.2.0](https://www.nuget.org/packages/DogStatsD-CSharp-Client/9.2.0) | >1.1k | 2026-06-10 | [link](https://github.com/DataDog/dogstatsd-csharp-client/releases/tag/9.2.0) |
| Microsoft.AspNetCore.SignalR.Client | 10.0.5 | [10.0.9](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/10.0.9) | >24k | 2026-06-09 | [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.301)[^1] |
| Microsoft.AspNetCore.SignalR.Protocols.MessagePack | 10.0.5 | [10.0.9](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Protocols.MessagePack/10.0.9) | >2.4k | 2026-06-09 | [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.301)[^1] |
| Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson | 10.0.5 | [10.0.9](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson/10.0.9) | >3.3k | 2026-06-09 | [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.301)[^1] |
| Microsoft.Extensions.Logging.Console | multiple | [10.0.9](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Console/10.0.9) | >299k | 2026-06-09 | [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.301)[^1] |
| Microsoft.NET.Test.Sdk | 18.3.0 | [18.6.0](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/18.6.0) | >3M | 2026-05-26 | [link](https://github.com/microsoft/vstest/releases/tag/v18.6.0) |
| Sentry.AspNetCore | 6.2.0 | [6.6.0](https://www.nuget.org/packages/Sentry.AspNetCore/6.6.0) | >111k | 2026-05-28 | [link](https://github.com/getsentry/sentry-dotnet/releases/tag/6.6.0) |
| System.Text.Json | 10.0.5 | [10.0.9](https://www.nuget.org/packages/System.Text.Json/10.0.9) | >103k | 2026-06-09 | [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.301)[^1] |

[^1]: Microsoft doesn't really do specific changelogs for these packages. Counterpoint: if one of these is pwned, it's just all over.

Held back
---------
- Microsoft.AspNetCore.Authentication.JwtBearer: Requires .NET 10.0.
- Microsoft.CodeAnalysis.CSharp.Workspaces: Used for docs, upgrading doesn't work.
- Microsoft.CodeAnalysis.Workspaces.MSBuild: Used for docs, upgrading doesn't work.
- ppy.osu.Game & rulesets: Probably could be bumped, but I'd rather not until the mod multiplier things are fully done client-side.

Testing done
-------------
- [x] Tests pass locally.
- [x] Tests pass on CI.
- [x] Brief multiplayer smoke test full-stack against lazer master (https://github.com/ppy/osu/pull/38053 *not* included, to check backwards compatibility).