### PR TITLE
Request frames not received from client on play end

### DIFF
--- a/SampleSpectatorClient/Program.cs
+++ b/SampleSpectatorClient/Program.cs
@@ -44,7 +44,8 @@ namespace SampleSpectatorClient
                         new[]
                         {
                             new LegacyReplayFrame(i, RNG.Next(0, 512), RNG.Next(0, 512), ReplayButtonState.None)
-                        }));
+                        },
+                        null));
                     Thread.Sleep(50);
                 }
 

--- a/SampleSpectatorClient/SpectatorClient.cs
+++ b/SampleSpectatorClient/SpectatorClient.cs
@@ -77,6 +77,8 @@ namespace SampleSpectatorClient
             return Task.CompletedTask;
         }
 
+        Task<CompleteReplayResponse> ISpectatorClient.CompleteReplay(CompleteReplayRequest request) => Task.FromResult(new CompleteReplayResponse([]));
+
         public Task BeginPlaying(long? scoreToken, SpectatorState state) => connection.SendAsync(nameof(ISpectatorServer.BeginPlaySession), scoreToken, state);
 
         public Task SendFrames(FrameDataBundle data) => connection.SendAsync(nameof(ISpectatorServer.SendFrameData), data);

--- a/osu.Server.Spectator.Tests/SpectatorHubTest.cs
+++ b/osu.Server.Spectator.Tests/SpectatorHubTest.cs
@@ -101,7 +101,8 @@ namespace osu.Server.Spectator.Tests
 
             var data = new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) });
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null);
 
             // check streaming data is propagating to watchers
             await hub.SendFrameData(data);
@@ -147,7 +148,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 1
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -197,7 +199,8 @@ namespace osu.Server.Spectator.Tests
 
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -247,7 +250,8 @@ namespace osu.Server.Spectator.Tests
                     Mods = [new OsuModTouchDevice()],
                     Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = 1 }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -299,7 +303,8 @@ namespace osu.Server.Spectator.Tests
                     TotalScore = 246_642,
                     Pauses = { 1000, 2000 },
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -353,7 +358,8 @@ namespace osu.Server.Spectator.Tests
                     TotalScoreWithoutMods = null,
                     Pauses = null,
                 },
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -538,7 +544,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 10
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -624,7 +631,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 10
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -675,7 +683,8 @@ namespace osu.Server.Spectator.Tests
 
             await hub.SendFrameData(new FrameDataBundle(
                 new FrameHeader(new ScoreInfo(), new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -729,7 +738,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Miss] = 1,
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -781,7 +791,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 1
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.OnDisconnectedAsync(null);
             await hub.OnConnectedAsync();
@@ -801,7 +812,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 2
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(5678, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(5678, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.EndPlaySession(new SpectatorState
             {
@@ -856,7 +868,8 @@ namespace osu.Server.Spectator.Tests
                         [HitResult.Great] = 1
                     }
                 }, new ScoreProcessorStatistics()),
-                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) }));
+                new[] { new LegacyReplayFrame(1234, 0, 0, ReplayButtonState.None) },
+                null));
 
             await hub.OnDisconnectedAsync(null);
 
@@ -864,6 +877,235 @@ namespace osu.Server.Spectator.Tests
 
             mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item => item.Score.ScoreInfo.OnlineID == 456)), Times.Never);
             Assert.Equal(0, scoreBuffer.RemainingUsages);
+        }
+
+        [Fact]
+        public async Task ReplayCompletionFlow_ClientSentAllFrames()
+        {
+            scoreUploader.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockSpectatorsReceiver = new Mock<ISpectatorClient>();
+            Mock<ISpectatorClient> mockStreamerReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.Caller).Returns(mockStreamerReceiver.Object);
+            mockClients.Setup(clients => clients.All).Returns(mockSpectatorsReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockSpectatorsReceiver.Object);
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            const long frame_bundle_count = 5;
+
+            for (int i = 1; i <= frame_bundle_count; ++i)
+            {
+                await hub.SendFrameData(new FrameDataBundle(
+                    new FrameHeader(new ScoreInfo
+                    {
+                        Statistics =
+                        {
+                            [HitResult.Great] = i
+                        }
+                    }, new ScoreProcessorStatistics()),
+                    new[] { new LegacyReplayFrame(1000 * i, 0, 0, ReplayButtonState.None) },
+                    i));
+            }
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Passed,
+                LastFrameBundleSequenceNumber = frame_bundle_count,
+            });
+
+            await uploadsCompleteAsync();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item =>
+                item.Score.ScoreInfo.OnlineID == 456 && item.Score.Replay.Frames.Count == frame_bundle_count)), Times.Once);
+
+            mockStreamerReceiver.Verify(streamer => streamer.CompleteReplay(It.Is<CompleteReplayRequest>(req => !req.FrameBundleSequenceNumbers.Any())), Times.Once());
+            mockSpectatorsReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
+        }
+
+        [Fact]
+        public async Task ReplayCompletionFlow_ClientResendsFramesFromTheMiddle()
+        {
+            scoreUploader.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockSpectatorsReceiver = new Mock<ISpectatorClient>();
+            Mock<ISpectatorClient> mockStreamerReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.Caller).Returns(mockStreamerReceiver.Object);
+            mockClients.Setup(clients => clients.All).Returns(mockSpectatorsReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockSpectatorsReceiver.Object);
+            mockStreamerReceiver.Setup(streamer => streamer.CompleteReplay(It.IsAny<CompleteReplayRequest>()))
+                                .Returns((CompleteReplayRequest req) =>
+                                {
+                                    var bundles = req.FrameBundleSequenceNumbers.Select(seq =>
+                                        new FrameDataBundle(
+                                            new FrameHeader(new ScoreInfo
+                                            {
+                                                Statistics =
+                                                {
+                                                    [HitResult.Great] = (int)seq
+                                                }
+                                            }, new ScoreProcessorStatistics()),
+                                            new[] { new LegacyReplayFrame(1000 * seq, 0, 0, ReplayButtonState.None) },
+                                            seq)
+                                    ).ToArray();
+                                    return Task.FromResult(new CompleteReplayResponse(bundles));
+                                });
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            const long frame_bundle_count = 10;
+
+            for (int i = 1; i <= frame_bundle_count; ++i)
+            {
+                if (i > 3 && i < 7)
+                    continue;
+
+                await hub.SendFrameData(new FrameDataBundle(
+                    new FrameHeader(new ScoreInfo
+                    {
+                        Statistics =
+                        {
+                            [HitResult.Great] = i
+                        }
+                    }, new ScoreProcessorStatistics()),
+                    new[] { new LegacyReplayFrame(1000 * i, 0, 0, ReplayButtonState.None) },
+                    i));
+            }
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Passed,
+                LastFrameBundleSequenceNumber = frame_bundle_count,
+            });
+
+            await uploadsCompleteAsync();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item =>
+                item.Score.ScoreInfo.OnlineID == 456 && item.Score.Replay.Frames.Count == frame_bundle_count)), Times.Once);
+
+            mockStreamerReceiver.Verify(streamer => streamer.CompleteReplay(It.Is<CompleteReplayRequest>(req => req.FrameBundleSequenceNumbers.Count() == 3)), Times.Once());
+            mockSpectatorsReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
+        }
+
+        [Fact]
+        public async Task ReplayCompletionFlow_ClientResendsFramesFromTheEnd()
+        {
+            scoreUploader.SaveReplays = true;
+
+            Mock<IHubCallerClients<ISpectatorClient>> mockClients = new Mock<IHubCallerClients<ISpectatorClient>>();
+            Mock<ISpectatorClient> mockSpectatorsReceiver = new Mock<ISpectatorClient>();
+            Mock<ISpectatorClient> mockStreamerReceiver = new Mock<ISpectatorClient>();
+            mockClients.Setup(clients => clients.Caller).Returns(mockStreamerReceiver.Object);
+            mockClients.Setup(clients => clients.All).Returns(mockSpectatorsReceiver.Object);
+            mockClients.Setup(clients => clients.Group(SpectatorHub.GetGroupId(streamer_id))).Returns(mockSpectatorsReceiver.Object);
+            mockStreamerReceiver.Setup(streamer => streamer.CompleteReplay(It.IsAny<CompleteReplayRequest>()))
+                                .Returns((CompleteReplayRequest req) =>
+                                {
+                                    var bundles = req.FrameBundleSequenceNumbers.Select(seq =>
+                                        new FrameDataBundle(
+                                            new FrameHeader(new ScoreInfo
+                                            {
+                                                Statistics =
+                                                {
+                                                    [HitResult.Great] = (int)seq
+                                                }
+                                            }, new ScoreProcessorStatistics()),
+                                            new[] { new LegacyReplayFrame(1000 * seq, 0, 0, ReplayButtonState.None) },
+                                            seq)
+                                    ).ToArray();
+                                    return Task.FromResult(new CompleteReplayResponse(bundles));
+                                });
+
+            Mock<HubCallerContext> mockContext = new Mock<HubCallerContext>();
+
+            mockContext.Setup(context => context.UserIdentifier).Returns(streamer_id.ToString());
+            hub.Context = mockContext.Object;
+            hub.Clients = mockClients.Object;
+
+            mockDatabase.Setup(db => db.GetScoreFromTokenAsync(1234)).Returns(Task.FromResult<SoloScore?>(new SoloScore
+            {
+                id = 456,
+                passed = true
+            }));
+
+            await hub.BeginPlaySession(1234, new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Playing,
+            });
+
+            const long frame_bundle_count = 10;
+
+            for (int i = 1; i <= frame_bundle_count - 3; ++i)
+            {
+                await hub.SendFrameData(new FrameDataBundle(
+                    new FrameHeader(new ScoreInfo
+                    {
+                        Statistics =
+                        {
+                            [HitResult.Great] = i
+                        }
+                    }, new ScoreProcessorStatistics()),
+                    new[] { new LegacyReplayFrame(1000 * i, 0, 0, ReplayButtonState.None) },
+                    i));
+            }
+
+            await hub.EndPlaySession(new SpectatorState
+            {
+                BeatmapID = beatmap_id,
+                RulesetID = 0,
+                State = SpectatedUserState.Passed,
+                LastFrameBundleSequenceNumber = frame_bundle_count,
+            });
+
+            await uploadsCompleteAsync();
+
+            mockScoreStorage.Verify(s => s.WriteAsync(It.Is<ScoreUploader.UploadItem>(item =>
+                item.Score.ScoreInfo.OnlineID == 456 && item.Score.Replay.Frames.Count == frame_bundle_count && item.Score.ScoreInfo.Statistics[HitResult.Great] == frame_bundle_count)), Times.Once);
+
+            mockStreamerReceiver.Verify(streamer => streamer.CompleteReplay(It.Is<CompleteReplayRequest>(req => req.FrameBundleSequenceNumbers.Count() == 3)), Times.Once());
+            mockSpectatorsReceiver.Verify(clients => clients.UserFinishedPlaying(streamer_id, It.Is<SpectatorState>(m => m.State == SpectatedUserState.Passed)), Times.Once());
         }
 
         private async Task uploadsCompleteAsync(int attempts = 5)

--- a/osu.Server.Spectator/Hubs/ScoreBuffer.cs
+++ b/osu.Server.Spectator/Hubs/ScoreBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -66,31 +67,38 @@ namespace osu.Server.Spectator.Hubs
                 var buffered = usage.Item;
                 Debug.Assert(buffered != null);
 
-                buffered.Score.ScoreInfo.Accuracy = data.Header.Accuracy;
-                buffered.Score.ScoreInfo.Statistics = data.Header.Statistics;
-                buffered.Score.ScoreInfo.MaxCombo = data.Header.MaxCombo;
-                buffered.Score.ScoreInfo.Combo = data.Header.Combo;
-                buffered.Score.ScoreInfo.TotalScore = data.Header.TotalScore;
-                buffered.Score.ScoreInfo.APIMods = data.Header.Mods;
-
-                // handle frame bundles from old clients that don't send both of these properties
-                // null checks can be elided when property is made non-nullable on `FrameDataBundle` 20261126
-                if (data.Header.TotalScoreWithoutMods != null)
-                    buffered.Score.ScoreInfo.TotalScoreWithoutMods = data.Header.TotalScoreWithoutMods.Value;
-
-                if (data.Header.Pauses != null)
-                {
-                    buffered.Score.ScoreInfo.Pauses.Clear();
-                    buffered.Score.ScoreInfo.Pauses.AddRange(data.Header.Pauses);
-                }
-
+                UpdateScoreInfoFromBundle(buffered.Score.ScoreInfo, data);
                 buffered.Score.Replay.Frames.AddRange(data.Frames);
 
                 buffered.LastUpdated = DateTimeOffset.Now;
+
+                if (data.SequenceNumber != null)
+                    buffered.FrameBundlesReceived.Add(data.SequenceNumber.Value);
             }
         }
 
-        public async Task<Score?> DequeueAsync(long scoreTokenId)
+        public static void UpdateScoreInfoFromBundle(ScoreInfo scoreInfo, FrameDataBundle data)
+        {
+            scoreInfo.Accuracy = data.Header.Accuracy;
+            scoreInfo.Statistics = data.Header.Statistics;
+            scoreInfo.MaxCombo = data.Header.MaxCombo;
+            scoreInfo.Combo = data.Header.Combo;
+            scoreInfo.TotalScore = data.Header.TotalScore;
+            scoreInfo.APIMods = data.Header.Mods;
+
+            // handle frame bundles from old clients that don't send both of these properties
+            // null checks can be elided when property is made non-nullable on `FrameDataBundle` 20261126
+            if (data.Header.TotalScoreWithoutMods != null)
+                scoreInfo.TotalScoreWithoutMods = data.Header.TotalScoreWithoutMods.Value;
+
+            if (data.Header.Pauses != null)
+            {
+                scoreInfo.Pauses.Clear();
+                scoreInfo.Pauses.AddRange(data.Header.Pauses);
+            }
+        }
+
+        public async Task<BufferedScore?> DequeueAsync(long scoreTokenId)
         {
             using (var usage = await store.TryGetForUse(scoreTokenId))
             {
@@ -102,7 +110,7 @@ namespace osu.Server.Spectator.Hubs
 
                 usage.Destroy();
                 DogStatsd.Increment($@"{statsd_prefix}.dequeued");
-                return buffered.Score;
+                return buffered;
             }
         }
 
@@ -137,6 +145,7 @@ namespace osu.Server.Spectator.Hubs
         {
             public Score Score { get; }
             public DateTimeOffset LastUpdated { get; set; }
+            public HashSet<long> FrameBundlesReceived { get; } = [];
 
             public BufferedScore(Score score)
             {

--- a/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
+++ b/osu.Server.Spectator/Hubs/Spectator/SpectatorHub.cs
@@ -149,7 +149,9 @@ namespace osu.Server.Spectator.Hubs.Spectator
                     if (score == null)
                         return;
 
-                    await processScore(usage.Item!, score);
+                    if (usage.Item.State != null)
+                        usage.Item.State.LastFrameBundleSequenceNumber = state.LastFrameBundleSequenceNumber;
+                    await processScore(usage.Item, score);
                 }
                 finally
                 {
@@ -165,29 +167,67 @@ namespace osu.Server.Spectator.Hubs.Spectator
             await endPlaySession(Context.GetUserId(), state);
         }
 
-        private async Task processScore(SpectatorClientState item, Score score)
+        private async Task processScore(SpectatorClientState item, ScoreBuffer.BufferedScore score)
         {
             Debug.Assert(score != null && item.ScoreToken != null && item.Beatmap != null);
 
             long scoreToken = item.ScoreToken.Value;
 
             // Do nothing with scores on unranked beatmaps.
-            var status = score.ScoreInfo.BeatmapInfo!.Status;
+            var status = score.Score.ScoreInfo.BeatmapInfo!.Status;
             if (status < min_beatmap_status_for_replays || status > max_beatmap_status_for_replays)
                 return;
 
+            if (item.State?.LastFrameBundleSequenceNumber != null)
+                await attemptToEnsureReplayCompletion(scoreToken, item.State.LastFrameBundleSequenceNumber.Value, score);
+
             // if the user never hit anything, further processing that depends on the score existing can be waived because the client won't have submitted the score anyway.
             // see: https://github.com/ppy/osu/blob/a47ccb8edd2392258b6b7e176b222a9ecd511fc0/osu.Game/Screens/Play/SubmittingPlayer.cs#L281
-            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
+            if (!score.Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
                 return;
 
-            score.ScoreInfo.Date = DateTimeOffset.UtcNow;
+            score.Score.ScoreInfo.Date = DateTimeOffset.UtcNow;
             // this call is a little expensive due to reflection usage, so only run it at the end of score processing
             // even though in theory the rank could be recomputed after every replay frame.
-            score.ScoreInfo.Rank = StandardisedScoreMigrationTools.ComputeRank(score.ScoreInfo);
+            score.Score.ScoreInfo.Rank = StandardisedScoreMigrationTools.ComputeRank(score.Score.ScoreInfo);
 
-            await scoreUploader.EnqueueAsync(scoreToken, score, item.Beatmap);
+            await scoreUploader.EnqueueAsync(scoreToken, score.Score, item.Beatmap);
             await scoreProcessedSubscriber.RegisterForSingleScoreAsync(Context.ConnectionId, Context.GetUserId(), scoreToken);
+        }
+
+        private async Task attemptToEnsureReplayCompletion(long scoreToken, long lastFrameBundleSequenceNumber, ScoreBuffer.BufferedScore score)
+        {
+            try
+            {
+                HashSet<long> missingBundleIds = [];
+
+                if (lastFrameBundleSequenceNumber != score.FrameBundlesReceived.Count)
+                {
+                    for (long i = 1; i <= lastFrameBundleSequenceNumber; ++i)
+                    {
+                        if (!score.FrameBundlesReceived.Contains(i))
+                            missingBundleIds.Add(i);
+                    }
+                }
+
+                var response = await Clients.Caller.CompleteReplay(new CompleteReplayRequest(scoreToken, missingBundleIds));
+
+                if (!response.FrameBundles.Any())
+                    return;
+
+                foreach (var bundle in response.FrameBundles)
+                {
+                    score.Score.Replay.Frames.AddRange(bundle.Frames);
+                    if (bundle.SequenceNumber == lastFrameBundleSequenceNumber)
+                        ScoreBuffer.UpdateScoreInfoFromBundle(score.Score.ScoreInfo, bundle);
+                }
+
+                score.Score.Replay.Frames = score.Score.Replay.Frames.OrderBy(f => f.Time).ToList();
+            }
+            catch (Exception ex)
+            {
+                Error($"Attempt to ensure replay completion for score token {scoreToken} failed", ex);
+            }
         }
 
         public async Task StartWatchingUser(int userId)


### PR DESCRIPTION
- [ ] Depends on / server-side counterpart to https://github.com/ppy/osu/pull/38163

Refer to above for the general gist of what this is.

For the server-side part specifically, it may be desired to have some sort of metric on how often this reconciliation flow actually results in needing to re-send frames. Listening to suggestions.