### PR TITLE
Add accessibility mods to ranked play

### DIFF
--- a/SampleMultiplayerClient/MultiplayerClient.cs
+++ b/SampleMultiplayerClient/MultiplayerClient.cs
@@ -309,7 +309,8 @@ namespace SampleMultiplayerClient
 
         public Task MatchmakingLeaveLobby() => connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveLobby));
 
-        public Task MatchmakingJoinQueue(int poolId) => connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinQueue), poolId);
+        public Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request)
+            => connection.InvokeAsync<MatchmakingJoinQueueResponse>(nameof(IMatchmakingServer.MatchmakingJoinQueueWithParams), request);
 
         public Task MatchmakingLeaveQueue() => connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveQueue));
 

--- a/SampleMultiplayerClient/Program.cs
+++ b/SampleMultiplayerClient/Program.cs
@@ -142,7 +142,7 @@ namespace SampleMultiplayerClient
                             break;
 
                         case "mmjoinqueue":
-                            await targetClient.MatchmakingJoinQueue(int.Parse(args[0]));
+                            await targetClient.MatchmakingJoinQueueWithParams(new MatchmakingJoinQueueRequest { PoolId = int.Parse(args[0]) });
                             break;
 
                         case "mmleavequeue":

--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingQueueBackgroundServiceTests.cs
@@ -38,7 +38,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task AddToQueue()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingQueueJoined(), Times.Once);
@@ -48,7 +48,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task RemoveFromQueue()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
             await MatchmakingBackgroundService.RemoveFromQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
@@ -59,13 +59,13 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task MatchReady()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Never);
             User2Receiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Never);
 
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
@@ -75,8 +75,8 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task AcceptInvitation()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
@@ -98,8 +98,8 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task DeclineInvitation()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
@@ -121,8 +121,8 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task LeaveQueueAfterInvite()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);
@@ -146,8 +146,8 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         [Fact]
         public async Task QueueLeftOnDisconnect()
         {
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1);
-            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID)!, 1, []);
+            await MatchmakingBackgroundService.AddToQueueAsync(UserStates.GetEntityUnsafe(USER_ID_2)!, 1, []);
             await MatchmakingBackgroundService.ExecuteOnceAsync();
 
             UserReceiver.Verify(u => u.MatchmakingRoomInvitedWithParams(It.IsAny<MatchmakingRoomInvitationParams>()), Times.Once);

--- a/osu.Server.Spectator.Tests/RankedPlay/RankedPlayMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/RankedPlayMatchControllerTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Server.Spectator.Database;
+using osu.Server.Spectator.Database.Models;
+using osu.Server.Spectator.Hubs.Multiplayer;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue;
+using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay;
+using osu.Server.Spectator.Tests.Multiplayer;
+using Xunit;
+
+namespace osu.Server.Spectator.Tests.RankedPlay
+{
+    public class RankedPlayMatchControllerTests : MultiplayerTest
+    {
+        protected ServerMultiplayerRoom Room { get; private set; } = null!;
+        protected RankedPlayMatchController MatchController => (RankedPlayMatchController)Room.MatchController;
+
+        protected RankedPlayRoomState RoomState => (RankedPlayRoomState)Room.MatchState!;
+        protected RankedPlayUserInfo UserState => RoomState.Users[USER_ID];
+        protected RankedPlayUserInfo User2State => RoomState.Users[USER_ID_2];
+
+        public RankedPlayMatchControllerTests()
+        {
+            AppSettings.MatchmakingRoomRounds = 2;
+            AppSettings.MatchmakingRoomAllowSkip = true;
+
+            Database.Setup(db => db.GetRealtimeRoomAsync(ROOM_ID))
+                    .Callback<long>(roomId => InitialiseRoom(roomId, 20))
+                    .ReturnsAsync(() => new multiplayer_room
+                    {
+                        type = database_match_type.ranked_play,
+                        ends_at = DateTimeOffset.Now.AddMinutes(5),
+                        user_id = int.Parse(Hub.Context.UserIdentifier!),
+                    });
+
+            Database.Setup(db => db.GetMatchmakingUserStatsAsync(It.IsAny<int>(), It.IsAny<uint>()))
+                    .Returns<int, uint>((userId, poolId) => Task.FromResult<matchmaking_user_stats?>(new matchmaking_user_stats
+                    {
+                        user_id = (uint)userId,
+                        pool_id = poolId
+                    }));
+
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore { user_id = USER_ID, total_score = 1_000_000 },
+                        new SoloScore { user_id = USER_ID_2, total_score = 1_000_000 },
+                    ]));
+        }
+
+        [Fact]
+        public async Task UserModsAppliedOnEnter()
+        {
+            using (var room = await Rooms.GetForUse(ROOM_ID, true))
+            {
+                room.Item = await ServerMultiplayerRoom.InitialiseMatchmakingRoomAsync
+                (
+                    ROOM_ID,
+                    RoomController,
+                    DatabaseFactory.Object,
+                    EventDispatcher,
+                    LoggerFactory.Object,
+                    new matchmaking_pool(),
+                    new[]
+                    {
+                        new MatchmakingQueueUser(USER_ID.ToString(), new[] { new APIMod { Acronym = "HD" } }) { UserId = USER_ID },
+                        new MatchmakingQueueUser(USER_ID_2.ToString()) { UserId = USER_ID_2 }
+                    },
+                    new MatchmakingBeatmapSelector(new matchmaking_pool(), Enumerable.Range(1, 50).Select(i => new matchmaking_pool_beatmap
+                    {
+                        id = (uint)i,
+                        beatmap_id = i
+                    }).ToArray(), new Mock<IDatabaseFactory>().Object),
+                    new Mock<IMatchmakingQueueBackgroundService>().Object
+                );
+
+                Room = room.Item;
+            }
+
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser);
+
+            Assert.Equal("HD", Room.Users.Single(u => u.UserID == USER_ID).Mods.Single().Acronym);
+            Assert.Empty(Room.Users.Single(u => u.UserID == USER_ID_2).Mods);
+        }
+
+        [Fact]
+        public async Task UsersCanNotChangeOwnMods()
+        {
+            using (var room = await Rooms.GetForUse(ROOM_ID, true))
+            {
+                room.Item = await ServerMultiplayerRoom.InitialiseMatchmakingRoomAsync
+                (
+                    ROOM_ID,
+                    RoomController,
+                    DatabaseFactory.Object,
+                    EventDispatcher,
+                    LoggerFactory.Object,
+                    new matchmaking_pool(),
+                    new[]
+                    {
+                        new MatchmakingQueueUser(USER_ID.ToString(), new[] { new APIMod { Acronym = "HD" } }) { UserId = USER_ID },
+                        new MatchmakingQueueUser(USER_ID_2.ToString()) { UserId = USER_ID_2 }
+                    },
+                    new MatchmakingBeatmapSelector(new matchmaking_pool(), Enumerable.Range(1, 50).Select(i => new matchmaking_pool_beatmap
+                    {
+                        id = (uint)i,
+                        beatmap_id = i
+                    }).ToArray(), new Mock<IDatabaseFactory>().Object),
+                    new Mock<IMatchmakingQueueBackgroundService>().Object
+                );
+
+                Room = room.Item;
+            }
+
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser2);
+            await Hub.JoinRoom(ROOM_ID);
+            SetUserContext(ContextUser);
+
+            Assert.Equal("HD", Room.Users.Single(u => u.UserID == USER_ID).Mods.Single().Acronym);
+            Assert.Empty(Room.Users.Single(u => u.UserID == USER_ID_2).Mods);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Hub.ChangeUserMods([]));
+        }
+    }
+}

--- a/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
+++ b/osu.Server.Spectator.Tests/RankedPlay/Stages/ResultsStageTests.cs
@@ -459,6 +459,32 @@ namespace osu.Server.Spectator.Tests.RankedPlay.Stages
         }
 
         [Fact]
+        public async Task TotalScoreWithoutModsUsed()
+        {
+            Database.Setup(db => db.GetAllScoresForPlaylistItem(It.IsAny<long>()))
+                    .Returns<long>(_ => Task.FromResult<IEnumerable<SoloScore>>(
+                    [
+                        new SoloScore
+                        {
+                            user_id = USER_ID,
+                            total_score = 1_000_000,
+                            ScoreData = { TotalScoreWithoutMods = 500_000 }
+                        },
+                        new SoloScore
+                        {
+                            user_id = USER_ID_2,
+                            total_score = 0
+                        },
+                    ]));
+
+            await MatchController.Stage.Enter();
+            await FinishCountdown();
+
+            Assert.Equal(1_000_000, UserState.Life);
+            Assert.Equal(450_000, User2State.Life);
+        }
+
+        [Fact]
         public async Task UserNotKilledIfQuitInFinalRound()
         {
             User2State.Life = 1_000_000;

--- a/osu.Server.Spectator/Database/Models/SoloScore.cs
+++ b/osu.Server.Spectator/Database/Models/SoloScore.cs
@@ -69,6 +69,7 @@ namespace osu.Server.Spectator.Database.Models
             BuildID = build_id,
             Passed = passed,
             TotalScore = total_score,
+            TotalScoreWithoutMods = ScoreData.TotalScoreWithoutMods ?? 0,
             Accuracy = accuracy,
             UserID = (int)user_id,
             MaxCombo = (int)max_combo,
@@ -84,5 +85,7 @@ namespace osu.Server.Spectator.Database.Models
             PP = pp,
             HasReplay = has_replay
         };
+
+        public long TotalScoreWithoutMods => ScoreData.TotalScoreWithoutMods ?? total_score;
     }
 }

--- a/osu.Server.Spectator/Database/Models/SoloScoreData.cs
+++ b/osu.Server.Spectator/Database/Models/SoloScoreData.cs
@@ -20,5 +20,8 @@ namespace osu.Server.Spectator.Database.Models
 
         [JsonProperty("maximum_statistics")]
         public Dictionary<HitResult, int> MaximumStatistics { get; set; } = new Dictionary<HitResult, int>();
+
+        [JsonProperty("total_score_without_mods")]
+        public long? TotalScoreWithoutMods { get; set; }
     }
 }

--- a/osu.Server.Spectator/Hubs/Multiplayer/IMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/IMatchController.cs
@@ -10,6 +10,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
 {
     public interface IMatchController
     {
+        /// <summary>
+        /// Whether users should be able to change their own mods within the match.
+        /// </summary>
+        bool AllowUserModChanges { get; }
+
         MultiplayerPlaylistItem CurrentItem { get; }
 
         Task Initialise();

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs
@@ -96,6 +96,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
         /// </summary>
         private static readonly int[] placement_points = [15, 12, 10, 8, 6, 4, 2, 1];
 
+        public bool AllowUserModChanges => false;
+
         public MultiplayerPlaylistItem CurrentItem => room.Playlist.Single(item => item.ID == room.Settings.PlaylistItemId);
 
         private readonly ServerMultiplayerRoom room;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/IMatchmakingQueueBackgroundService.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// <summary>
         /// Adds a user to the matchmaking queue.
         /// </summary>
-        Task AddToQueueAsync(MultiplayerClientState state, int poolId);
+        Task AddToQueueAsync(MultiplayerClientState state, int poolId, APIMod[] mods);
 
         /// <summary>
         /// Removes a user from the matchmaking queue.

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs
@@ -18,6 +18,7 @@ using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Matchmaking.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Utils;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
@@ -152,7 +153,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 await lobby.Remove(state);
         }
 
-        public async Task AddToQueueAsync(MultiplayerClientState state, int poolId)
+        public async Task AddToQueueAsync(MultiplayerClientState state, int poolId, APIMod[] mods)
         {
             // Users should only ever be in one queue at a time.
             await RemoveFromQueueAsync(state);
@@ -164,8 +165,11 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 if (!pool.active)
                     throw new InvalidStateException("The selected matchmaking pool is no longer active.");
 
+                if (!ModUtils.InstantiateValidModsForRuleset(LegacyHelper.GetRulesetFromLegacyID(pool.ruleset_id), mods, out _))
+                    throw new InvalidStateException("Invalid mods selected for ruleset.");
+
                 MatchmakingQueue queue = poolQueues.GetOrAdd(poolId, _ => new MatchmakingQueue(pool));
-                await processBundle(queue.Add(await createUserAsync(state, pool)));
+                await processBundle(queue.Add(await createUserAsync(state, pool, mods)));
             }
         }
 
@@ -211,7 +215,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     RequeueOnDecline = false
                 };
 
-                MatchmakingQueueUser user = await createUserAsync(state, pool);
+                MatchmakingQueueUser user = await createUserAsync(state, pool, []);
                 user.BanEndTime = DateTimeOffset.MinValue;
 
                 // The user is added to the queue before the queue is added to the dictionary
@@ -253,7 +257,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             }
 
             // Add the user to the duel queue.
-            MatchmakingQueueUser user = await createUserAsync(state, queue.Pool);
+            MatchmakingQueueUser user = await createUserAsync(state, queue.Pool, []);
             user.BanEndTime = DateTimeOffset.MinValue;
             await processBundle(queue.Add(user));
 
@@ -516,7 +520,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
             }
         }
 
-        private async Task<MatchmakingQueueUser> createUserAsync(MultiplayerClientState state, matchmaking_pool pool)
+        private async Task<MatchmakingQueueUser> createUserAsync(MultiplayerClientState state, matchmaking_pool pool, APIMod[] mods)
         {
             using (var db = databaseFactory.GetInstance())
             {
@@ -540,7 +544,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     });
                 }
 
-                return new MatchmakingQueueUser(state.ConnectionId)
+                return new MatchmakingQueueUser(state.ConnectionId, mods)
                 {
                     UserId = state.UserId,
                     Rating = stats.EloData.Rating,

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueUser.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueUser.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Online.API;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
 
 namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
@@ -51,9 +52,20 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
         /// </summary>
         public readonly string Identifier;
 
+        /// <summary>
+        /// The mods with which this user queued.
+        /// </summary>
+        public readonly APIMod[] Mods;
+
         public MatchmakingQueueUser(string identifier)
+            : this(identifier, [])
+        {
+        }
+
+        public MatchmakingQueueUser(string identifier, APIMod[] mods)
         {
             Identifier = identifier;
+            Mods = mods;
         }
 
         public bool Equals(MatchmakingQueueUser? other)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -30,6 +30,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         public const int PLAYER_HAND_SIZE = 5;
         public const int DECK_SIZE = 50;
 
+        public bool AllowUserModChanges => false;
+
         public MultiplayerPlaylistItem CurrentItem => Room.Playlist.Single(item => item.ID == Room.Settings.PlaylistItemId);
 
         public IMatchmakingQueueBackgroundService MatchmakingService { get; private set; } = null!;

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -462,13 +462,24 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             var item = beatmap?.ToPlaylistItem() ?? new MultiplayerPlaylistItem();
 
             Ruleset ruleset = LegacyHelper.GetRulesetFromLegacyID(Pool.ruleset_id);
-            item.AllowedMods = ruleset.AllMods.OfType<ModHidden>().Select(m => new APIMod(m)).ToArray();
+            item.AllowedMods = ruleset.AllMods.OfType<Mod>().Where(isUserModAllowed).Select(m => new APIMod(m)).ToArray();
 
             return item;
         }
 
-        private bool isUserModAllowed(Mod mod)
-            => mod is ModHidden;
+        private bool isUserModAllowed(IMod mod)
+        {
+            // Synchronise with client.
+            switch (mod)
+            {
+                case ModHidden:
+                case ModTraceable:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail
         {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -8,10 +8,14 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OpenSkillSharp.Models;
 using OpenSkillSharp.Rating;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 using osu.Server.Spectator.Database;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
@@ -57,7 +61,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// </summary>
         public int[] UserIdsByTurnOrder { get; private set; } = [];
 
-        public Dictionary<int, EloRating> RatingByUser { get; private set; } = [];
+        public readonly Dictionary<int, EloRating> RatingByUser = [];
+
+        private readonly Dictionary<int, APIMod[]> modsByUser = [];
 
         /// <summary>
         /// Mapping of cards to their associated effect.
@@ -107,7 +113,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             foreach (var beatmap in beatmaps)
             {
                 var card = new RankedPlayCardItem();
-                cardToEffectMap[card] = beatmap.ToPlaylistItem();
+                cardToEffectMap[card] = createPlaylistItem(beatmap);
                 deck.Add(card);
             }
 
@@ -116,7 +122,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             // Create an initial playlist item for the room. Clients require this to operate correctly.
             using (var db = DbFactory.GetInstance())
             {
-                MultiplayerPlaylistItem initialItem = new MultiplayerPlaylistItem();
+                MultiplayerPlaylistItem initialItem = createPlaylistItem(null);
                 initialItem.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, initialItem));
 
                 Room.Playlist.Add(initialItem);
@@ -127,6 +133,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             foreach (var user in users)
             {
                 RatingByUser[user.UserId] = user.Rating;
+                modsByUser[user.UserId] = user.Mods;
                 State.Users[user.UserId] = new RankedPlayUserInfo
                 {
                     Rating = (int)Math.Round(user.Rating.Mu),
@@ -191,6 +198,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         {
             await EventDispatcher.PostPlayerJoinedMatchmakingRoomAsync(Room.RoomID, user.UserID);
             await Stage.HandleUserJoined(user);
+
+            ModUtils.InstantiateValidModsForRuleset(LegacyHelper.GetRulesetFromLegacyID(Pool.ruleset_id), modsByUser[user.UserID], out List<Mod> validMods);
+            await Room.ChangeUserMods(user.UserID, validMods.Where(isUserModAllowed).Select(m => new APIMod(m)).ToArray());
         }
 
         async Task IMatchController.HandleUserLeft(MultiplayerRoomUser user)
@@ -446,6 +456,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
             await MatchmakingService.RecordMatch((int)Pool.id, State);
         }
+
+        private MultiplayerPlaylistItem createPlaylistItem(matchmaking_pool_beatmap? beatmap)
+        {
+            var item = beatmap?.ToPlaylistItem() ?? new MultiplayerPlaylistItem();
+
+            Ruleset ruleset = LegacyHelper.GetRulesetFromLegacyID(Pool.ruleset_id);
+            item.AllowedMods = ruleset.AllMods.OfType<ModHidden>().Select(m => new APIMod(m)).ToArray();
+
+            return item;
+        }
+
+        private bool isUserModAllowed(Mod mod)
+            => mod is ModHidden;
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail
         {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/ResultsStage.cs
@@ -70,8 +70,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 info.DamageInfo = Controller.Damage(userId);
             }
 
-            int winningTotalScore = (int)scores.Select(s => s.total_score).Max();
-            SoloScore[] winningScores = scores.Where(u => u.total_score == winningTotalScore).ToArray();
+            int winningTotalScore = (int)scores.Select(s => s.TotalScoreWithoutMods).Max();
+            SoloScore[] winningScores = scores.Where(u => u.TotalScoreWithoutMods == winningTotalScore).ToArray();
             winningUserId = winningScores.Length == 1 ? (int)winningScores.Single().user_id : null;
 
             if (winningUserId != null)
@@ -79,7 +79,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                 // Winner: losing player takes damage.
                 SoloScore losingScore = scores.Single(u => u.user_id != winningUserId);
 
-                int attackDamage = winningTotalScore - (int)losingScore.total_score;
+                int attackDamage = winningTotalScore - (int)losingScore.TotalScoreWithoutMods;
                 double attackMultiplier = State.DamageMultiplier + State.Users[winningUserId.Value].DamageMultiplier;
 
                 State.Users[(int)losingScore.user_id].DamageInfo = Controller.Damage((int)losingScore.user_id, attackDamage, attackMultiplier, BaseDamage);
@@ -92,7 +92,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
                     Controller.Pool.id,
                     Room.CurrentPlaylistItem.BeatmapID,
                     Room.CurrentPlaylistItem.RequiredMods.ToArray(),
-                    scores.Select(s => (int)s.total_score).ToArray(),
+                    scores.Select(s => (int)s.TotalScoreWithoutMods).ToArray(),
                     scores.Select(s => Controller.RatingByUser[(int)s.user_id]).ToArray());
             }
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs
@@ -288,6 +288,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                     if (room == null)
                         throw new InvalidOperationException("Attempted to operate on a null room");
 
+                    if (!room.MatchController.AllowUserModChanges)
+                        throw new InvalidOperationException("User mod changes are not allowed.");
+
                     await room.ChangeUserMods(Context.GetUserId(), newMods);
                 }
             }

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub_Matchmaking.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub_Matchmaking.cs
@@ -74,7 +74,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             }
 
             using (var userUsage = await GetOrCreateLocalUserState())
-                await matchmakingQueueService.AddToQueueAsync(userUsage.Item!, request.PoolId);
+                await matchmakingQueueService.AddToQueueAsync(userUsage.Item!, request.PoolId, request.Mods);
 
             return new MatchmakingJoinQueueResponse();
         }

--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub_Matchmaking.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub_Matchmaking.cs
@@ -34,6 +34,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             }
         }
 
+        // Provided for backwards compatibility. Can be removed 20261001.
+        public async Task MatchmakingJoinQueue(int poolId)
+        {
+            await MatchmakingJoinQueueWithParams(new MatchmakingJoinQueueRequest { PoolId = poolId });
+        }
+
         public async Task<MatchmakingPool[]> GetMatchmakingPoolsOfType(MatchmakingPoolType type)
         {
             using (var db = databaseFactory.GetInstance())
@@ -59,7 +65,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 await matchmakingQueueService.RemoveFromLobbyAsync(userUsage.Item!);
         }
 
-        public async Task MatchmakingJoinQueue(int poolId)
+        public async Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request)
         {
             using (var db = databaseFactory.GetInstance())
             {
@@ -68,7 +74,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
             }
 
             using (var userUsage = await GetOrCreateLocalUserState())
-                await matchmakingQueueService.AddToQueueAsync(userUsage.Item!, poolId);
+                await matchmakingQueueService.AddToQueueAsync(userUsage.Item!, request.PoolId);
+
+            return new MatchmakingJoinQueueResponse();
         }
 
         public async Task MatchmakingLeaveQueue()

--- a/osu.Server.Spectator/Hubs/Multiplayer/Standard/StandardMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Standard/StandardMatchController.cs
@@ -25,6 +25,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Standard
         public const int HOST_PLAYLIST_LIMIT = 50;
         public const int GUEST_PLAYLIST_LIMIT = 3;
 
+        public bool AllowUserModChanges => true;
+
         public MultiplayerPlaylistItem CurrentItem => room.Playlist[currentPlaylistItemIndex];
 
         protected StandardMatchRoomState State { get; }


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu/pull/38209 for `IMultiplayerClient` model change.

This change has two purposes:
1. Applying mods to users in the room (as expected).
2. Changing the results stage to only care about `TotalScoreWithoutMods`.