### PR TITLE
Add/use per-pool DMR setting

### DIFF
--- a/osu.Server.Spectator/AppSettings.cs
+++ b/osu.Server.Spectator/AppSettings.cs
@@ -68,12 +68,6 @@ namespace osu.Server.Spectator
         /// </summary>
         public static bool MatchmakingDebugBeatmaps { get; }
 
-        /// <summary>
-        /// Enables/disables the use of dynamic beatmap ratings for matchmaking pools.
-        /// When disabled, ratings are still written to the database but not used for matches.
-        /// </summary>
-        public static bool MatchmakingUseDynamicBeatmapRatings { get; } = true;
-
         static AppSettings()
         {
             SaveReplays = bool.TryParse(Environment.GetEnvironmentVariable("SAVE_REPLAYS"), out bool saveReplays) ? saveReplays : SaveReplays;
@@ -147,10 +141,6 @@ namespace osu.Server.Spectator
             MatchmakingDebugBeatmaps = bool.TryParse(Environment.GetEnvironmentVariable("MATCHMAKING_DEBUG_BEATMAPS"), out bool mmDebugBeatmaps)
                 ? mmDebugBeatmaps
                 : MatchmakingDebugBeatmaps;
-
-            MatchmakingUseDynamicBeatmapRatings = bool.TryParse(Environment.GetEnvironmentVariable("MATCHMAKING_USE_DYNAMIC_BEATMAP_RATINGS"), out bool mmUseDynamicBeatmapRatings)
-                ? mmUseDynamicBeatmapRatings
-                : MatchmakingUseDynamicBeatmapRatings;
         }
     }
 }

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool.cs
@@ -39,6 +39,12 @@ namespace osu.Server.Spectator.Database.Models
         /// </summary>
         public int rating_search_radius_exp { get; set; } = 300;
 
+        /// <summary>
+        /// Enables/disables the use of dynamic beatmap ratings for this pool.
+        /// When disabled, ratings are still written to the database but not used for matches.
+        /// </summary>
+        public bool use_dmr { get; set; } = true;
+
         public MatchmakingPool ToMatchmakingPool() => new MatchmakingPool
         {
             Id = (int)id,

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingBeatmapSelector.cs
@@ -64,7 +64,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
 
                 Dictionary<BeatmapLookupKey, matchmaking_pool_beatmap> poolBeatmaps = [];
 
-                if (AppSettings.MatchmakingUseDynamicBeatmapRatings)
+                if (pool.use_dmr)
                     poolBeatmaps = (await db.GetMatchmakingPoolBeatmapsAsync(pool.id)).ToDictionary(b => new BeatmapLookupKey(b.beatmap_id, b.mods), b => b);
 
                 // The pool may not contain all ranked beatmaps, so back-fill it.
@@ -134,7 +134,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                 rating_sig = ratings[0].Sigma
             };
 
-            if (AppSettings.MatchmakingUseDynamicBeatmapRatings)
+            if (pool.use_dmr)
             {
                 // Store the beatmap back so that it can be used for subsequent lookups.
                 beatmaps[key] = beatmap;


### PR DESCRIPTION
- See also: https://github.com/ppy/osu-web/pull/13149
  - Can be deployed independently from the above - default value is `true` in the dapper model.

As brought up in https://discord.com/channels/188630481301012481/1440912440224120882/1526520144363524096, SR is still largely inaccurate for other rulesets.

This is now written to the database as `bool matchmaking_pools.use_dmr`. The value here is refreshed from the database every hour.